### PR TITLE
i#1734 top bits: Handle top-byte-ignore addresses in drmemtrace

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -787,9 +787,11 @@ typedef enum {
     TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN,
 
     /**
-     * Appears only in raw records. This is turned into #TRACE_MARKER_TYPE_KERNEL_EVENT
-     * in post-processing. Its purpose is to have a non-canonical value in bits 48..55
-     * so we can distinguish it from an address with the top byte set and ignored.
+     * Appears only in offline raw records. This is turned into
+     * #TRACE_MARKER_TYPE_KERNEL_EVENT in post-processing.  Its purpose is to have a
+     * non-canonical value in bits 48..55 of offline_entry_t (unlike
+     * #TRACE_MARKER_TYPE_KERNEL_EVENT which has 0 in 48..55) so we can distinguish it
+     * from an address with the top byte set and ignored.
      */
     TRACE_MARKER_TYPE_KERNEL_EVENT_RAW,
 
@@ -987,24 +989,29 @@ typedef struct _trace_entry_t trace_entry_t;
 // We target 64-bit addresses and do not bother to shrink the module or timestamp
 // entries for 32-bit apps.
 // We assume that a 64-bit address has far fewer real bits, typically
-// 48 bits, and that the top bits 48..55 are always identical.
-// Often 56..63 must also be identical: that's where we store our type field.
-// For the most common, a memref, we have both all 0's and all 1's be its
+// 48 bits, and that the bits 48..55 are always identical.
+// Often all 48..63 are identical, including 61..63 where we store our type field.
+// For the most common record type, a memref, we have both all 0's and all 1's be its
 // type to reduce instrumentation overhead.
-// The offline_type_t identifies which union alternative.
+// The offline_type_t, along with other logic for Top Byte Ignore described below,
+// identifies the union alternative.
 //
-// For Top Byte Ignore where the top byte 56..63 can be anything, we need to
-// distinguish OFFLINE_TYPE_MEMREF{,_HIGH} from the others.
-// We do this as follows:
+// For Top Byte Ignore where the top byte 56..63 can be anything, making
+// OFFLINE_TYPE_MEMREF{,_HIGH} look like any of the other record types.
+// We distinguish it by adding restrictions on the other types to avoid
+// having all 0's or all 1's in bits 48..55 (we assume OFFLINE_TYPE_MEMREF{,HIGH}
+// always has all 0's or all 1's there as previously mentioned) as follows:
 // + OFFLINE_TYPE_PC: A PC record: instr_count is 12 bits: 5 in top byte; 7 as top
-//   bits of 48.55. Bit 48 is top bit of modidx: which can be set as that's part of
-//   PC_MODIDX_INVALID. So for 48.55 to be all 0's: count is multiple of 128, or
-//   count is 0. 0 is only used for filtered, where it precedes any memref, so it
-//   should never be confused. To be all 1's: count is at least 127. We solve this by
-//   ensuring -max_bb_instrs is 126.
-// + OFFLINE_TYPE_THREAD and OFFLINE_TYPE_PID: We assume these will never
-//   appear where we expect a memref; there will always be a timestamp or
-//   some other marker in between.
+//   bits of 48..55. Bit 48 is top bit of modidx: which can be set as that's part of
+//   PC_MODIDX_INVALID. So for 48..55 to be all 0's: count is multiple of 128, or
+//   count is 0. 0 is only used for filtered, where a PC entry with count 0 precedes
+//   each memref, so we can distinguish by record order. To be all 1's: count must be
+//   at least 127. We avoid this by ensuring -max_bb_instrs is 126.
+// + OFFLINE_TYPE_THREAD and OFFLINE_TYPE_PID: We assume these will never appear where
+//   we expect a memref; there will always be a timestamp or some other marker in
+//   between.
+//   XXX i#1734: If this were to change: we would ensure we can identify block
+//   boundaries by knowing the memref count or adding a record in order to avoid these.
 // + OFFLINE_TYPE_TIMESTAMP: A timestamp with 0's in 48..55 and 0's in top bits would
 //   be older than 0x8001000000000000 which is 12/2/1609; with 0's in 48..55 and at
 //   least one 1 in top bits would be at least 0x8100000000000000 which is 5/31/3884;
@@ -1015,17 +1022,17 @@ typedef struct _trace_entry_t trace_entry_t;
 // + OFFLINE_TYPE_EXTENDED:
 //   + OFFLINE_EXT_TYPE_MARKER: offline_entry_t.extended.valueB is bits 48..55 so
 //     we need to distinguish marker types 0 and all 1's. There is no all 1's; 0 is
-//     TRACE_MARKER_TYPE_KERNEL_EVENT which we no longer use in raw recores: we use
+//     TRACE_MARKER_TYPE_KERNEL_EVENT which we no longer use in raw records: we use
 //     TRACE_MARKER_TYPE_KERNEL_EVENT_RAW and convert it in raw2trace.
 //   + OFFLINE_EXT_TYPE_HEADER_DEPRECATED, OFFLINE_EXT_TYPE_FOOTER,
-//     OFFLINE_EXT_TYPE_FOOTER: We assume these will never appear where we expect a
+//     OFFLINE_EXT_TYPE_HEADER: We assume these will never appear where we expect a
 //     memref; there will always be a timestamp or some other marker in between.
-//   + OFFLINE_EXT_TYPE_MEMINFO: a read (==0) would have canonical 48.55: but this
+//   + OFFLINE_EXT_TYPE_MEMINFO: a read (==0) would have canonical 48..55: but this
 //     is used for filtering and always precedes addresses, so it should never be
 //     confused with an address.
-// TODO i#1734: Add support to reader_t to optionally (default true) canonicalize
-// all non-canonical addresses (and PC values: and make sure non-canonical PC
-// values are preserved, which they should be without extra work).
+// TODO i#1734: Add support to reader_t to optionally (default true) canonicalize all
+// non-canonical addresses (including PC values, along with adding tests to ensure
+// non-canonical PC values are preserved, which they should be without extra work).
 typedef enum {
     OFFLINE_TYPE_MEMREF, // We rely on this being 0.
     OFFLINE_TYPE_PC,

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -786,6 +786,13 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN,
 
+    /**
+     * Appears only in raw records. This is turned into #TRACE_MARKER_TYPE_KERNEL_EVENT
+     * in post-processing. Its purpose is to have a non-canonical value in bits 48..55
+     * so we can distinguish it from an address with the top byte set and ignored.
+     */
+    TRACE_MARKER_TYPE_KERNEL_EVENT_RAW,
+
     // ...
     // These values are reserved for future built-in marker types.
     // ...
@@ -980,11 +987,45 @@ typedef struct _trace_entry_t trace_entry_t;
 // We target 64-bit addresses and do not bother to shrink the module or timestamp
 // entries for 32-bit apps.
 // We assume that a 64-bit address has far fewer real bits, typically
-// 48 bits, and that the top bits 48..63 are always identical.  Thus we can store
-// a type field in those top bits.
+// 48 bits, and that the top bits 48..55 are always identical.
+// Often 56..63 must also be identical: that's where we store our type field.
 // For the most common, a memref, we have both all 0's and all 1's be its
 // type to reduce instrumentation overhead.
-// The type simply identifies which union alternative:
+// The offline_type_t identifies which union alternative.
+//
+// For Top Byte Ignore where the top byte 56..63 can be anything, we need to
+// distinguish OFFLINE_TYPE_MEMREF{,_HIGH} from the others.
+// We do this as follows:
+// + OFFLINE_TYPE_PC: A PC record: instr_count is 12 bits: 5 in top byte; 7 as top
+//   bits of 48.55. Bit 48 is top bit of modidx: which can be set as that's part of
+//   PC_MODIDX_INVALID. So for 48.55 to be all 0's: count is multiple of 128, or
+//   count is 0. 0 is only used for filtered, where it precedes any memref, so it
+//   should never be confused. To be all 1's: count is at least 127. We solve this by
+//   ensuring -max_bb_instrs is 126.
+// + OFFLINE_TYPE_THREAD and OFFLINE_TYPE_PID: We assume these will never
+//   appear where we expect a memref; there will always be a timestamp or
+//   some other marker in between.
+// + OFFLINE_TYPE_TIMESTAMP: A timestamp with 0's in 48..55 and 0's in top bits would
+//   be older than 0x8001000000000000 which is 12/2/1609; with 0's in 48..55 and at
+//   least one 1 in top bits would be at least 0x8100000000000000 which is 5/31/3884;
+//   with 1's in 48..55 would be at least 0x00ff000000000000 which is 7/1/3875. So it
+//   seems reasonable to exclude any seeming timestamp with a canonical 48..55:
+//   assume it's an address.
+// + OFFLINE_TYPE_IFLUSH: AArch32-only where addresses are only 32 bits.
+// + OFFLINE_TYPE_EXTENDED:
+//   + OFFLINE_EXT_TYPE_MARKER: offline_entry_t.extended.valueB is bits 48..55 so
+//     we need to distinguish marker types 0 and all 1's. There is no all 1's; 0 is
+//     TRACE_MARKER_TYPE_KERNEL_EVENT which we no longer use in raw recores: we use
+//     TRACE_MARKER_TYPE_KERNEL_EVENT_RAW and convert it in raw2trace.
+//   + OFFLINE_EXT_TYPE_HEADER_DEPRECATED, OFFLINE_EXT_TYPE_FOOTER,
+//     OFFLINE_EXT_TYPE_FOOTER: We assume these will never appear where we expect a
+//     memref; there will always be a timestamp or some other marker in between.
+//   + OFFLINE_EXT_TYPE_MEMINFO: a read (==0) would have canonical 48.55: but this
+//     is used for filtering and always precedes addresses, so it should never be
+//     confused with an address.
+// TODO i#1734: Add support to reader_t to optionally (default true) canonicalize
+// all non-canonical addresses (and PC values: and make sure non-canonical PC
+// values are preserved, which they should be without extra work).
 typedef enum {
     OFFLINE_TYPE_MEMREF, // We rely on this being 0.
     OFFLINE_TYPE_PC,

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -142,8 +142,8 @@ namespace drmemtrace {
 #    define IF_UNIX(x) x
 #endif
 
-// This value is selected so that offline_entry_t.pc never has
-// canonical (all 0 or all 1) bits 48..55.
+// This value is selected so that offline_entry_t.pc never has canonical
+// (all 0 or all 1) bits 48..55.  See the offline_type_t comment.
 #define MAX_BB_INSTRS_NAME "max_bb_instrs"
 #define MAX_BB_INSTRS 126
 

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -141,6 +141,11 @@ namespace drmemtrace {
 #    define IF_WINDOWS(x)
 #    define IF_UNIX(x) x
 #endif
+
+// This value is selected so that offline_entry_t.pc never has
+// canonical (all 0 or all 1) bits 48..55.
+#define MAX_BB_INSTRS_NAME "max_bb_instrs"
+#define MAX_BB_INSTRS 126
 
 static inline int
 compute_log2(int64_t value)

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -168,12 +168,18 @@ configure_application(char *app_name, char **app_argv, std::string tracer_ops,
     pid = dr_inject_get_process_id(*inject_data);
 
     process = dr_inject_get_image_name(*inject_data);
+
+    // Default option so we can distinguish raw PC records from top-byte-set
+    // addresses.
+    std::string default_dr_ops =
+        std::string("-") + MAX_BB_INSTRS_NAME + " " + std::to_string(MAX_BB_INSTRS);
+    std::string dr_ops = default_dr_ops + op_dr_ops.get_value();
+
     NOTIFY(1, "INFO", "configuring %s pid=" PIDFMT " dr_ops=\"%s\"", process, pid,
-           op_dr_ops.get_value().c_str());
+           dr_ops.c_str());
     if (dr_register_process(process, pid, false /*local*/, op_dr_root.get_value().c_str(),
                             DR_MODE_CODE_MANIPULATION, op_dr_debug.get_value(),
-                            DR_PLATFORM_DEFAULT,
-                            op_dr_ops.get_value().c_str()) != DR_SUCCESS) {
+                            DR_PLATFORM_DEFAULT, dr_ops.c_str()) != DR_SUCCESS) {
         FATAL_ERROR("failed to register DynamoRIO configuration");
     }
     NOTIFY(1, "INFO", "configuring client \"%s\" ops=\"%s\"",

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -169,11 +169,12 @@ configure_application(char *app_name, char **app_argv, std::string tracer_ops,
 
     process = dr_inject_get_image_name(*inject_data);
 
-    // Default option so we can distinguish raw PC records from top-byte-set
-    // addresses.
+    // Change the max instrs per bb from DR's default 256 down to 126 so we can
+    // distinguish raw PC records from top-byte-set addresses (see offline_type_t
+    // comments in trace_entry.h).
     std::string default_dr_ops =
         std::string("-") + MAX_BB_INSTRS_NAME + " " + std::to_string(MAX_BB_INSTRS);
-    std::string dr_ops = default_dr_ops + op_dr_ops.get_value();
+    std::string dr_ops = default_dr_ops + " " + op_dr_ops.get_value();
 
     NOTIFY(1, "INFO", "configuring %s pid=" PIDFMT " dr_ops=\"%s\"", process, pid,
            dr_ops.c_str());

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -987,6 +987,24 @@ check_kernel_xfer()
             return false;
     }
 #endif
+    // Contains raw-only marker.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT_RAW, 2),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, true,
+                         { "TRACE_MARKER_TYPE_KERNEL_EVENT_RAW should not appear in the "
+                           "final trace",
+                           TID_A,
+                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/1 },
+                         "Failed to catch raw-only marker"))
+            return false;
+    }
     return true;
 }
 

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -258,8 +258,7 @@ offline_entry_t
 make_memref(uint64_t addr)
 {
     offline_entry_t entry;
-    entry.addr.type = OFFLINE_TYPE_MEMREF;
-    entry.addr.addr = addr;
+    entry.combined_value = addr;
     return entry;
 }
 
@@ -2997,6 +2996,7 @@ test_branch_decoration(void *drcontext)
         // Now repeat that branch to test encodings.
         raw.push_back(make_block(offs_mov, 2));
         raw.push_back(make_block(offs_store, 1));
+        raw.push_back(make_memref(42));
         raw.push_back(make_exit());
 
         std::vector<trace_entry_t> entries;
@@ -3026,6 +3026,7 @@ test_branch_decoration(void *drcontext)
             check_entry(entries, idx, TRACE_TYPE_INSTR_TAKEN_JUMP, -1, offs_jcc) &&
             check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
             check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+            check_entry(entries, idx, TRACE_TYPE_WRITE, -1) &&
             check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
             check_entry(entries, idx, TRACE_TYPE_FOOTER, -1);
     }
@@ -3068,6 +3069,7 @@ test_branch_decoration(void *drcontext)
         raw.push_back(make_block(offs_mov, 2));
         raw.push_back(make_block(offs_jcc_move, 1));
         raw.push_back(make_block(offs_store, 1));
+        raw.push_back(make_memref(42));
         raw.push_back(make_exit());
 
         std::vector<trace_entry_t> entries;
@@ -3108,6 +3110,7 @@ test_branch_decoration(void *drcontext)
             check_entry(entries, idx, TRACE_TYPE_INSTR_UNTAKEN_JUMP, -1, offs_jcc_move) &&
             check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
             check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+            check_entry(entries, idx, TRACE_TYPE_WRITE, -1) &&
             check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
             check_entry(entries, idx, TRACE_TYPE_FOOTER, -1);
     }
@@ -4119,6 +4122,115 @@ test_negative_timestamps(void *drcontext)
     }
 }
 
+bool
+test_top_byte_ignore(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting non-canonical top bytes in addresses\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *load1 =
+        XINST_CREATE_load(drcontext, opnd_create_reg(REG1), OPND_CREATE_MEMPTR(REG2, 0));
+    // Re-use the base so this will be elided, to test base sharing.
+    constexpr int SHARE_DISP = 10;
+    instr_t *load2 = XINST_CREATE_load(drcontext, opnd_create_reg(REG1),
+                                       OPND_CREATE_MEMPTR(REG2, SHARE_DISP));
+    // No elision (because REG1 has changed).
+    instr_t *load3 =
+        XINST_CREATE_load(drcontext, opnd_create_reg(REG1), OPND_CREATE_MEMPTR(REG1, 0));
+    // No elision (because REG1 has changed).
+    instr_t *load4 =
+        XINST_CREATE_load(drcontext, opnd_create_reg(REG1), OPND_CREATE_MEMPTR(REG1, 0));
+    // No elision (because REG1 has changed).
+    instr_t *store1 =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG1, 0), opnd_create_reg(REG2));
+    instr_t *move =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    // No elision (b/c prior move changed REG2).
+    instr_t *store2 =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, load1);
+    instrlist_append(ilist, load2);
+    instrlist_append(ilist, load3);
+    instrlist_append(ilist, load4);
+    instrlist_append(ilist, store1);
+    instrlist_append(ilist, move);
+    instrlist_append(ilist, store2);
+    size_t offs_nop = 0;
+    size_t offs_load1 = offs_nop + instr_length(drcontext, nop);
+    size_t offs_load2 = offs_load1 + instr_length(drcontext, load1);
+    size_t offs_load3 = offs_load2 + instr_length(drcontext, load2);
+    size_t offs_load4 = offs_load3 + instr_length(drcontext, load3);
+    size_t offs_store1 = offs_load4 + instr_length(drcontext, load4);
+    size_t offs_move = offs_store1 + instr_length(drcontext, store1);
+    size_t offs_store2 = offs_move + instr_length(drcontext, move);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    constexpr uint64_t TIME_VALUE = 101;
+    raw.push_back(make_timestamp(TIME_VALUE));
+    raw.push_back(make_core());
+    raw.push_back(make_block(offs_load1, 7));
+    // Select addresses with top bits set such that they look like
+    // other record types, to ensure we treat them as addresses.
+    constexpr uint64_t ADDR_LIKE_TIMESTAMP = 0x8000123400005678;
+    raw.push_back(make_memref(ADDR_LIKE_TIMESTAMP));
+    constexpr uint64_t ADDR_LIKE_PC = 0x20ff123400005678;
+    raw.push_back(make_memref(ADDR_LIKE_PC));
+    constexpr uint64_t ADDR_LIKE_KERNEL_EVENT = 0xc200000000000000;
+    raw.push_back(make_memref(ADDR_LIKE_KERNEL_EVENT));
+    constexpr uint64_t ADDR_LIKE_HEADER = 0xc400200000000c40;
+    raw.push_back(make_memref(ADDR_LIKE_HEADER));
+    constexpr uint64_t ADDR_LIKE_FOOTER = 0xc100000000000000;
+    raw.push_back(make_memref(ADDR_LIKE_FOOTER));
+    raw.push_back(make_exit());
+
+    std::vector<uint64_t> stats;
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries, &stats))
+        return false;
+    int idx = 0;
+    return (
+        stats[RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE] == 5 &&
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,
+                    TIME_VALUE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load1) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, ADDR_LIKE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load2) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1,
+                    ADDR_LIKE_TIMESTAMP + SHARE_DISP) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load3) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, ADDR_LIKE_PC) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load4) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, ADDR_LIKE_KERNEL_EVENT) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store1) &&
+        check_entry(entries, idx, TRACE_TYPE_WRITE, -1, ADDR_LIKE_HEADER) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store2) &&
+        check_entry(entries, idx, TRACE_TYPE_WRITE, -1, ADDR_LIKE_FOOTER) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -4144,7 +4256,7 @@ test_main(int argc, const char *argv[])
         !test_stats_timestamp_instr_count(drcontext) ||
         !test_is_maybe_blocking_syscall(drcontext) || !test_ifiltered(drcontext) ||
         !test_asynchronous_signal(drcontext) || !test_syscall_injection(drcontext) ||
-        !test_negative_timestamps(drcontext))
+        !test_negative_timestamps(drcontext) || !test_top_byte_ignore(drcontext))
         return 1;
     return 0;
 }

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -258,6 +258,10 @@ offline_entry_t
 make_memref(uint64_t addr)
 {
     offline_entry_t entry;
+    // The type field is included in the address, just like occurs in
+    // instrumentation, even with non-canonical addresses which won't
+    // have the right type field (which we distinguish using the logic
+    // outlined in the offline_type_t comment).
     entry.combined_value = addr;
     return entry;
 }
@@ -4179,15 +4183,34 @@ test_top_byte_ignore(void *drcontext)
     raw.push_back(make_block(offs_load1, 7));
     // Select addresses with top bits set such that they look like
     // other record types, to ensure we treat them as addresses.
+    offline_entry_t check_type;
     constexpr uint64_t ADDR_LIKE_TIMESTAMP = 0x8000123400005678;
+    check_type.combined_value = ADDR_LIKE_TIMESTAMP;
+    ASSERT(check_type.timestamp.type == OFFLINE_TYPE_TIMESTAMP,
+           "invalid top-bit constant");
     raw.push_back(make_memref(ADDR_LIKE_TIMESTAMP));
     constexpr uint64_t ADDR_LIKE_PC = 0x20ff123400005678;
+    check_type.combined_value = ADDR_LIKE_PC;
+    ASSERT(check_type.pc.type == OFFLINE_TYPE_PC, "invalid top-bit constant");
     raw.push_back(make_memref(ADDR_LIKE_PC));
     constexpr uint64_t ADDR_LIKE_KERNEL_EVENT = 0xc200000000000000;
+    check_type.combined_value = ADDR_LIKE_KERNEL_EVENT;
+    ASSERT(check_type.extended.type == OFFLINE_TYPE_EXTENDED &&
+               check_type.extended.ext == OFFLINE_EXT_TYPE_MARKER &&
+               check_type.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT,
+           "invalid top-bit constant");
     raw.push_back(make_memref(ADDR_LIKE_KERNEL_EVENT));
     constexpr uint64_t ADDR_LIKE_HEADER = 0xc400200000000c40;
+    check_type.combined_value = ADDR_LIKE_HEADER;
+    ASSERT(check_type.extended.type == OFFLINE_TYPE_EXTENDED &&
+               check_type.extended.ext == OFFLINE_EXT_TYPE_HEADER,
+           "invalid top-bit constant");
     raw.push_back(make_memref(ADDR_LIKE_HEADER));
     constexpr uint64_t ADDR_LIKE_FOOTER = 0xc100000000000000;
+    check_type.combined_value = ADDR_LIKE_FOOTER;
+    ASSERT(check_type.extended.type == OFFLINE_TYPE_EXTENDED &&
+               check_type.extended.ext == OFFLINE_EXT_TYPE_FOOTER,
+           "invalid top-bit constant");
     raw.push_back(make_memref(ADDR_LIKE_FOOTER));
     raw.push_back(make_exit());
 

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -4125,6 +4125,9 @@ test_negative_timestamps(void *drcontext)
 bool
 test_top_byte_ignore(void *drcontext)
 {
+#ifndef X64
+    return true;
+#else
     std::cerr << "\n===============\nTesting non-canonical top bytes in addresses\n";
     instrlist_t *ilist = instrlist_create(drcontext);
     instr_t *nop = XINST_CREATE_nop(drcontext);
@@ -4229,6 +4232,7 @@ test_top_byte_ignore(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_WRITE, -1, ADDR_LIKE_FOOTER) &&
         check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
         check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+#endif
 }
 
 int

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -684,6 +684,12 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         }
         shard->last_chunk_ordinal_ = memref.marker.marker_value;
     }
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW) {
+        report_if_false(
+            shard, false,
+            "TRACE_MARKER_TYPE_KERNEL_EVENT_RAW should not appear in the final trace");
+    }
     // Ensure each syscall instruction has a marker immediately afterward.  An
     // asynchronous signal could be delivered after the tracer recorded the syscall
     // instruction but before DR executed the syscall itself (xref i#5790) but raw2trace

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -104,8 +104,8 @@ offline_instru_t::offline_instru_t(
     DR_ASSERT(elide_memref_note_ != DRMGR_NOTE_NONE);
 
     uint64 max_bb_instrs;
-    if (!dr_get_integer_option("max_bb_instrs", &max_bb_instrs))
-        max_bb_instrs = 256; /* current default */
+    if (!dr_get_integer_option(MAX_BB_INSTRS_NAME, &max_bb_instrs))
+        max_bb_instrs = MAX_BB_INSTRS;
     max_block_encoding_size_ = static_cast<int>(max_bb_instrs) * MAX_INSTR_LENGTH;
     encoding_lock_ = dr_mutex_create();
     encoding_buf_sz_ = ALIGN_FORWARD(max_block_encoding_size_ * 10, dr_page_size());

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -106,6 +106,11 @@ offline_instru_t::offline_instru_t(
     uint64 max_bb_instrs;
     if (!dr_get_integer_option(MAX_BB_INSTRS_NAME, &max_bb_instrs))
         max_bb_instrs = MAX_BB_INSTRS;
+    else if (max_bb_instrs > MAX_BB_INSTRS) {
+        log_(1,
+             "Warning: -%s is too large (max is %d) to safely support Top Byte Ignore\n",
+             MAX_BB_INSTRS_NAME, MAX_BB_INSTRS);
+    }
     max_block_encoding_size_ = static_cast<int>(max_bb_instrs) * MAX_INSTR_LENGTH;
     encoding_lock_ = dr_mutex_create();
     encoding_buf_sz_ = ALIGN_FORWARD(max_block_encoding_size_ * 10, dr_page_size());

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2247,7 +2247,7 @@ raw2trace_t::could_entry_be_address(offline_entry_t entry)
     // architectures the 2nd-highest byte (bits 48..55) must be canonical:
     // all 0's or all 1's.
     char bits48_55 = (entry.combined_value >> 48) & 0xff;
-    return bits48_55 == 0 || bits48_55 == 0xff;
+    return bits48_55 == 0 || bits48_55 == static_cast<char>(0xff);
 }
 
 bool

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -994,8 +994,9 @@ raw2trace_t::maybe_inject_pending_syscall_sequence(raw2trace_thread_data_t *tdat
         // For syscalls interrupted by a signal and did not have a post-syscall
         // event.
         (is_marker &&
-         (entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-          entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW))) {
+         trace_metadata_writer_t::canonicalize_marker_type(
+             static_cast<trace_marker_type_t>(entry.extended.valueB)) ==
+             TRACE_MARKER_TYPE_KERNEL_EVENT)) {
         is_injection_point = true;
     } else if (is_marker && entry.extended.valueB == TRACE_MARKER_TYPE_FUNC_ID) {
         if (!tdata->saw_first_func_id_marker_after_syscall_) {
@@ -1091,8 +1092,9 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
         if (entry.extended.type == OFFLINE_TYPE_EXTENDED &&
             (entry.extended.ext == OFFLINE_EXT_TYPE_FOOTER ||
              (entry.extended.ext == OFFLINE_EXT_TYPE_MARKER &&
-              (entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-               entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW ||
+              (trace_metadata_writer_t::canonicalize_marker_type(
+                   static_cast<trace_marker_type_t>(entry.extended.valueB)) ==
+                   TRACE_MARKER_TYPE_KERNEL_EVENT ||
                entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_XFER ||
                (entry.extended.valueB == TRACE_MARKER_TYPE_WINDOW_ID &&
                 entry.extended.valueA != tdata->last_window))))) {
@@ -1100,8 +1102,7 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
             // Get the next instr's pc from the interruption value in the marker
             // (a record for the next instr itself won't appear until the signal
             // returns, if that happens).
-            if (is_marker_type(&entry, TRACE_MARKER_TYPE_KERNEL_EVENT) ||
-                is_marker_type(&entry, TRACE_MARKER_TYPE_KERNEL_EVENT_RAW)) {
+            if (is_marker_type(&entry, TRACE_MARKER_TYPE_KERNEL_EVENT)) {
                 uintptr_t marker_val = 0;
                 if (!get_marker_value(tdata, &in_entry, &marker_val))
                     return false;
@@ -1597,12 +1598,14 @@ raw2trace_t::interrupted_by_kernel_event(raw2trace_thread_data_t *tdata, uint64_
             // Check for interruption of the basic block in the middle by either
             // a kernel event (e.g., a signal) or DR not finishing the block
             // (e.g., on detach or some thread relocation like a synchronous flush).
-            if (next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW ||
+            if (trace_metadata_writer_t::canonicalize_marker_type(
+                    static_cast<trace_marker_type_t>(next_entry->extended.valueB)) ==
+                    TRACE_MARKER_TYPE_KERNEL_EVENT ||
                 next_entry->extended.valueB == TRACE_MARKER_TYPE_MIDBLOCK_END_PC) {
                 bool is_kernel =
-                    next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                    next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW;
+                    trace_metadata_writer_t::canonicalize_marker_type(
+                        static_cast<trace_marker_type_t>(next_entry->extended.valueB)) ==
+                    TRACE_MARKER_TYPE_KERNEL_EVENT;
                 uintptr_t marker_val = 0;
                 if (!get_marker_value(tdata, &next_entry, &marker_val)) {
                     return false;
@@ -1918,9 +1921,9 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                         return false;
                 }
             } else if (instrs_are_separate) {
-                // There is only one memref entry, after a count=0 PC entry.
-                // Full info (type and size) is provided via OFFLINE_EXT_TYPE_MEMINFO
-                // records, so we don't need to iterate operands.
+                // There is only one memref entry (each memref is after a count=0 PC
+                // entry). Full info (type and size) is provided via
+                // OFFLINE_EXT_TYPE_MEMINFO records, so we don't need to iterate operands.
                 if (instr->num_mem_srcs() + instr->num_mem_dests() > 0) {
                     if (!append_memref(tdata, &buf, instr, instr->mem_src_at(0), false,
                                        reg_vals, nullptr))
@@ -2189,7 +2192,9 @@ raw2trace_t::is_marker_type(const offline_entry_t *entry, trace_marker_type_t ma
 {
     return entry->extended.type == OFFLINE_TYPE_EXTENDED &&
         entry->extended.ext == OFFLINE_EXT_TYPE_MARKER &&
-        entry->extended.valueB == marker_type;
+        (entry->extended.valueB == marker_type ||
+         trace_metadata_writer_t::canonicalize_marker_type(
+             static_cast<trace_marker_type_t>(entry->extended.valueB)) == marker_type);
 }
 
 bool
@@ -2213,8 +2218,9 @@ raw2trace_t::get_marker_value(raw2trace_thread_data_t *tdata,
 #endif
     }
 #ifdef X64 // 32-bit always had the absolute pc as the raw marker value.
-    if ((*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-        (*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW ||
+    if (trace_metadata_writer_t::canonicalize_marker_type(
+            static_cast<trace_marker_type_t>((*entry)->extended.valueB)) ==
+            TRACE_MARKER_TYPE_KERNEL_EVENT ||
         (*entry)->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT ||
         (*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_XFER) {
         if (get_version(tdata) >= OFFLINE_FILE_VERSION_KERNEL_INT_PC &&
@@ -2245,7 +2251,11 @@ raw2trace_t::could_entry_be_address(offline_entry_t entry)
 {
     // With Top Byte Ignore the top byte might be anything, but on our current
     // architectures the 2nd-highest byte (bits 48..55) must be canonical:
-    // all 0's or all 1's.
+    // all 0's or all 1's.  We use the logic outlined in the comment for
+    // offline_type_t to rule out other records that can appear where we
+    // look for addresses by having those other types containn non-canonical
+    // values in 48..55 (and all other records cannot appear where we look
+    // for addresses).
     char bits48_55 = (entry.combined_value >> 48) & 0xff;
     return bits48_55 == 0 || bits48_55 == static_cast<char>(0xff);
 }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -108,6 +108,8 @@ int
 trace_metadata_writer_t::write_marker(byte *buffer, trace_marker_type_t type,
                                       uintptr_t val)
 {
+    if (val == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW)
+        val = TRACE_MARKER_TYPE_KERNEL_EVENT;
     return instru.append_marker(buffer, type, val);
 }
 int
@@ -523,7 +525,8 @@ raw2trace_t::process_marker(raw2trace_thread_data_t *tdata,
         return true;
     }
     buf += trace_metadata_writer_t::write_marker(buf, marker_type, marker_val);
-    if (marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+    if (marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+        marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW) {
         log(4, "Signal/exception between bbs\n");
         // An rseq side exit may next hit a signal which is then the
         // boundary of the rseq region.
@@ -983,7 +986,9 @@ raw2trace_t::maybe_inject_pending_syscall_sequence(raw2trace_thread_data_t *tdat
         (is_marker && entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_XFER) ||
         // For syscalls interrupted by a signal and did not have a post-syscall
         // event.
-        (is_marker && entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT)) {
+        (is_marker &&
+         (entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+          entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW))) {
         is_injection_point = true;
     } else if (is_marker && entry.extended.valueB == TRACE_MARKER_TYPE_FUNC_ID) {
         if (!tdata->saw_first_func_id_marker_after_syscall_) {
@@ -1080,6 +1085,7 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
             (entry.extended.ext == OFFLINE_EXT_TYPE_FOOTER ||
              (entry.extended.ext == OFFLINE_EXT_TYPE_MARKER &&
               (entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+               entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW ||
                entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_XFER ||
                (entry.extended.valueB == TRACE_MARKER_TYPE_WINDOW_ID &&
                 entry.extended.valueA != tdata->last_window))))) {
@@ -1087,7 +1093,8 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
             // Get the next instr's pc from the interruption value in the marker
             // (a record for the next instr itself won't appear until the signal
             // returns, if that happens).
-            if (is_marker_type(&entry, TRACE_MARKER_TYPE_KERNEL_EVENT)) {
+            if (is_marker_type(&entry, TRACE_MARKER_TYPE_KERNEL_EVENT) ||
+                is_marker_type(&entry, TRACE_MARKER_TYPE_KERNEL_EVENT_RAW)) {
                 uintptr_t marker_val = 0;
                 if (!get_marker_value(tdata, &in_entry, &marker_val))
                     return false;
@@ -1318,6 +1325,7 @@ raw2trace_t::do_conversion()
                 thread_data_[i]->syscall_traces_conversion_empty;
             syscall_traces_injected_ += thread_data_[i]->syscall_traces_injected;
             negative_times_corrected_ += thread_data_[i]->negative_times_corrected;
+            non_canonical_top_bytes_ += thread_data_[i]->non_canonical_top_bytes;
         }
     } else {
         // The files can be converted concurrently.
@@ -1351,6 +1359,7 @@ raw2trace_t::do_conversion()
             syscall_traces_conversion_empty_ += tdata->syscall_traces_conversion_empty;
             syscall_traces_injected_ += tdata->syscall_traces_injected;
             negative_times_corrected_ += tdata->negative_times_corrected;
+            non_canonical_top_bytes_ += tdata->non_canonical_top_bytes;
         }
     }
     error = aggregate_and_write_schedule_files();
@@ -1582,9 +1591,11 @@ raw2trace_t::interrupted_by_kernel_event(raw2trace_thread_data_t *tdata, uint64_
             // a kernel event (e.g., a signal) or DR not finishing the block
             // (e.g., on detach or some thread relocation like a synchronous flush).
             if (next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW ||
                 next_entry->extended.valueB == TRACE_MARKER_TYPE_MIDBLOCK_END_PC) {
                 bool is_kernel =
-                    next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT;
+                    next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                    next_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW;
                 uintptr_t marker_val = 0;
                 if (!get_marker_value(tdata, &next_entry, &marker_val)) {
                     return false;
@@ -2187,6 +2198,7 @@ raw2trace_t::get_marker_value(raw2trace_thread_data_t *tdata,
     }
 #ifdef X64 // 32-bit always had the absolute pc as the raw marker value.
     if ((*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+        (*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW ||
         (*entry)->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT ||
         (*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_XFER) {
         if (get_version(tdata) >= OFFLINE_FILE_VERSION_KERNEL_INT_PC &&
@@ -2210,6 +2222,16 @@ raw2trace_t::get_marker_value(raw2trace_thread_data_t *tdata,
 #endif
     *value = marker_val;
     return true;
+}
+
+bool
+raw2trace_t::could_entry_be_address(offline_entry_t entry)
+{
+    // With Top Byte Ignore the top byte might be anything, but on our current
+    // architectures the 2nd-highest byte (bits 48..55) must be canonical:
+    // all 0's or all 1's.
+    char bits48_55 = (entry.combined_value >> 48) & 0xff;
+    return bits48_55 == 0 || bits48_55 == 0xff;
 }
 
 bool
@@ -2273,24 +2295,36 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
         (in_entry == nullptr ||
          (in_entry->addr.type != OFFLINE_TYPE_MEMREF &&
           in_entry->addr.type != OFFLINE_TYPE_MEMREF_HIGH))) {
-        // This happens when there are predicated memrefs in the bb, or for a
-        // zero-iter rep string loop, or for a multi-memref instr with -L0_filter.
-        // For predicated memrefs, they could be earlier, so "instr"
-        // may not itself be predicated.
-        // XXX i#2015: if there are multiple predicated memrefs, our instr vs
-        // data stream may not be in the correct order here.
-        log(4,
-            "Missing memref from predication, 0-iter repstr, filter, "
-            "or reached end of memrefs output by scatter/gather seq "
-            "(next type is 0x" ZHEX64_FORMAT_STRING ")\n",
-            in_entry == nullptr ? 0 : in_entry->combined_value);
-        if (in_entry != nullptr) {
-            unread_last_entry(tdata);
+        if (in_entry != nullptr && could_entry_be_address(*in_entry)) {
+            // We've distinguished other types as documented under the
+            // offline_type_t type, so we assume this is in fact an address
+            // and Top Byte Ignore is enabled in the hardware.
+            // We do not clear the top bits for remember_base or recording in
+            // the trace: that's left to higher abstraction levels, and we need
+            // the precise value for remember_base.
+            log(2, "Found non-canonical-top-byte address 0x" ZHEX64_FORMAT_STRING "\n",
+                in_entry->combined_value);
+            accumulate_to_statistic(tdata, RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE, 1);
+        } else {
+            // This happens when there are predicated memrefs in the bb, or for a
+            // zero-iter rep string loop, or for a multi-memref instr with -L0_filter.
+            // For predicated memrefs, they could be earlier, so "instr"
+            // may not itself be predicated.
+            // XXX i#2015: if there are multiple predicated memrefs, our instr vs
+            // data stream may not be in the correct order here.
+            log(4,
+                "Missing memref from predication, 0-iter repstr, filter, "
+                "or reached end of memrefs output by scatter/gather seq "
+                "(next type is 0x" ZHEX64_FORMAT_STRING ")\n",
+                in_entry == nullptr ? 0 : in_entry->combined_value);
+            if (in_entry != nullptr) {
+                unread_last_entry(tdata);
+            }
+            if (reached_end_of_memrefs != nullptr) {
+                *reached_end_of_memrefs = true;
+            }
+            return true;
         }
-        if (reached_end_of_memrefs != nullptr) {
-            *reached_end_of_memrefs = true;
-        }
-        return true;
     }
     if (!have_type) {
         if (instr->is_prefetch()) {
@@ -3680,6 +3714,9 @@ raw2trace_t::accumulate_to_statistic(raw2trace_thread_data_t *tdata,
     case RAW2TRACE_STAT_NEGATIVE_TIMES_CORRECTED:
         tdata->negative_times_corrected += value;
         break;
+    case RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE:
+        tdata->non_canonical_top_bytes += value;
+        break;
     case RAW2TRACE_STAT_MAX:
     default: DR_ASSERT(false);
     }
@@ -3707,6 +3744,7 @@ raw2trace_t::get_statistic(raw2trace_statistic_t stat)
         return syscall_traces_conversion_empty_;
     case RAW2TRACE_STAT_SYSCALL_TRACES_INJECTED: return syscall_traces_injected_;
     case RAW2TRACE_STAT_NEGATIVE_TIMES_CORRECTED: return negative_times_corrected_;
+    case RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE: return non_canonical_top_bytes_;
     case RAW2TRACE_STAT_MAX:
     default: DR_ASSERT(false); return 0;
     }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1917,6 +1917,15 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                             is_scatter, reg_vals, &reached_end_of_memrefs))
                         return false;
                 }
+            } else if (instrs_are_separate) {
+                // There is only one memref entry, after a count=0 PC entry.
+                // Full info (type and size) is provided via OFFLINE_EXT_TYPE_MEMINFO
+                // records, so we don't need to iterate operands.
+                if (instr->num_mem_srcs() + instr->num_mem_dests() > 0) {
+                    if (!append_memref(tdata, &buf, instr, instr->mem_src_at(0), false,
+                                       reg_vals, nullptr))
+                        return false;
+                }
             } else {
                 for (uint j = 0; j < instr->num_mem_srcs(); j++) {
                     if (!append_memref(tdata, &buf, instr, instr->mem_src_at(j), false,

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -104,13 +104,18 @@ trace_metadata_writer_t::write_thread_exit(byte *buffer, thread_id_t tid)
 {
     return instru.append_thread_exit(buffer, tid);
 }
+trace_marker_type_t
+trace_metadata_writer_t::canonicalize_marker_type(trace_marker_type_t marker_type)
+{
+    if (marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW)
+        return TRACE_MARKER_TYPE_KERNEL_EVENT;
+    return marker_type;
+}
 int
 trace_metadata_writer_t::write_marker(byte *buffer, trace_marker_type_t type,
                                       uintptr_t val)
 {
-    if (val == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW)
-        val = TRACE_MARKER_TYPE_KERNEL_EVENT;
-    return instru.append_marker(buffer, type, val);
+    return instru.append_marker(buffer, canonicalize_marker_type(type), val);
 }
 int
 trace_metadata_writer_t::write_iflush(byte *buffer, addr_t start, size_t size)
@@ -399,6 +404,7 @@ raw2trace_t::process_offline_entry(raw2trace_thread_data_t *tdata,
                 return false;
             trace_marker_type_t marker_type =
                 static_cast<trace_marker_type_t>(in_entry->extended.valueB);
+            marker_type = trace_metadata_writer_t::canonicalize_marker_type(marker_type);
             if (!process_marker(tdata, marker_type, marker_val, buf, flush_decode_cache))
                 return false;
             // If there is currently a delayed branch that has not been emitted yet,
@@ -491,6 +497,8 @@ raw2trace_t::process_marker(raw2trace_thread_data_t *tdata,
                             trace_marker_type_t marker_type, uintptr_t marker_val,
                             byte *&buf, DR_PARAM_OUT bool *flush_decode_cache)
 {
+    // The type should have been canonicalized.
+    DR_ASSERT(marker_type != TRACE_MARKER_TYPE_KERNEL_EVENT_RAW);
     if (marker_type == TRACE_MARKER_TYPE_MIDBLOCK_END_PC) {
         // Consumed by raw2trace and not made visible in final trace.
         return true;
@@ -525,8 +533,7 @@ raw2trace_t::process_marker(raw2trace_thread_data_t *tdata,
         return true;
     }
     buf += trace_metadata_writer_t::write_marker(buf, marker_type, marker_val);
-    if (marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-        marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT_RAW) {
+    if (marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) {
         log(4, "Signal/exception between bbs\n");
         // An rseq side exit may next hit a signal which is then the
         // boundary of the rseq region.

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -363,6 +363,8 @@ private:
 struct trace_metadata_writer_t {
     static int
     write_thread_exit(byte *buffer, thread_id_t tid);
+    static trace_marker_type_t
+    canonicalize_marker_type(trace_marker_type_t marker_type);
     static int
     write_marker(byte *buffer, trace_marker_type_t type, uintptr_t val);
     static int

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -126,6 +126,8 @@ typedef enum {
     RAW2TRACE_STAT_SYSCALL_TRACES_INJECTED,
     // Count of negative times that were corrected.
     RAW2TRACE_STAT_NEGATIVE_TIMES_CORRECTED,
+    // Count of addresses found with a non-canonical top byte.
+    RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE,
     // We add a MAX member so that we can iterate over all stats in unit tests.
     RAW2TRACE_STAT_MAX,
 } raw2trace_statistic_t;
@@ -732,6 +734,7 @@ protected:
         uint64 syscall_traces_conversion_empty = 0;
         uint64 syscall_traces_injected = 0;
         uint64 negative_times_corrected = 0;
+        uint64 non_canonical_top_bytes = 0;
 
         uint64 cur_chunk_instr_count = 0;
         uint64 cur_chunk_ref_count = 0;
@@ -1010,6 +1013,7 @@ protected:
     uint64 syscall_traces_conversion_empty_ = 0;
     uint64 syscall_traces_injected_ = 0;
     uint64 negative_times_corrected_ = 0;
+    uint64 non_canonical_top_bytes_ = 0;
 
     std::unique_ptr<module_mapper_t> module_mapper_;
 
@@ -1214,6 +1218,9 @@ private:
     get_marker_value(raw2trace_thread_data_t *tdata,
                      DR_PARAM_INOUT const offline_entry_t **entry,
                      DR_PARAM_OUT uintptr_t *value);
+
+    bool
+    could_entry_be_address(offline_entry_t entry);
 
     bool
     append_memref(raw2trace_thread_data_t *tdata, DR_PARAM_INOUT trace_entry_t **buf_in,

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2608,6 +2608,12 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
     uint64 max_bb_instrs;
     if (!dr_get_integer_option(MAX_BB_INSTRS_NAME, &max_bb_instrs))
         max_bb_instrs = MAX_BB_INSTRS;
+    else if (max_bb_instrs > MAX_BB_INSTRS) {
+        NOTIFY(
+            1,
+            "Warning: -%s is too large (max is %d) to safely support Top Byte Ignore\n",
+            MAX_BB_INSTRS_NAME, MAX_BB_INSTRS);
+    }
     DR_ASSERT(max_bb_instrs < uint64(1) << PC_INSTR_COUNT_BITS);
     redzone_size = instru->sizeof_entry() * (size_t)max_bb_instrs * 2;
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1832,7 +1832,7 @@ event_kernel_xfer(void *drcontext, const dr_kernel_xfer_info_t *info)
     case DR_XFER_EXCEPTION_DISPATCHER:
     case DR_XFER_RAISE_DISPATCHER:
     case DR_XFER_CALLBACK_DISPATCHER:
-    case DR_XFER_RSEQ_ABORT: marker_type = TRACE_MARKER_TYPE_KERNEL_EVENT; break;
+    case DR_XFER_RSEQ_ABORT: marker_type = TRACE_MARKER_TYPE_KERNEL_EVENT_RAW; break;
     case DR_XFER_SIGNAL_RETURN:
     case DR_XFER_CALLBACK_RETURN:
     case DR_XFER_CONTINUE:
@@ -2603,8 +2603,8 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
      * max_bb_instrs can fit in the instr_count bitfield in offline_entry_t.
      */
     uint64 max_bb_instrs;
-    if (!dr_get_integer_option("max_bb_instrs", &max_bb_instrs))
-        max_bb_instrs = 256; /* current default */
+    if (!dr_get_integer_option(MAX_BB_INSTRS_NAME, &max_bb_instrs))
+        max_bb_instrs = MAX_BB_INSTRS;
     DR_ASSERT(max_bb_instrs < uint64(1) << PC_INSTR_COUNT_BITS);
     redzone_size = instru->sizeof_entry() * (size_t)max_bb_instrs * 2;
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1832,7 +1832,10 @@ event_kernel_xfer(void *drcontext, const dr_kernel_xfer_info_t *info)
     case DR_XFER_EXCEPTION_DISPATCHER:
     case DR_XFER_RAISE_DISPATCHER:
     case DR_XFER_CALLBACK_DISPATCHER:
-    case DR_XFER_RSEQ_ABORT: marker_type = TRACE_MARKER_TYPE_KERNEL_EVENT_RAW; break;
+    case DR_XFER_RSEQ_ABORT:
+        marker_type = op_offline.get_value() ? TRACE_MARKER_TYPE_KERNEL_EVENT_RAW
+                                             : TRACE_MARKER_TYPE_KERNEL_EVENT;
+        break;
     case DR_XFER_SIGNAL_RETURN:
     case DR_XFER_CALLBACK_RETURN:
     case DR_XFER_CONTINUE:


### PR DESCRIPTION
Adds handling of top-byte-ignore load and store addresses in drmemtrace. This is done by taking advantage of bits 48...55 still being required to be in canonical form (all 0's or all 1's) on all supported machines, which severely limits which other records a top-bits-set address can impersonate.

+ Timestamps can be distinguished by expecting reasonable values.
+ PC records are made distinct by lowering -max_bb_instrs to 126.
+ Markers are made distinct by using a new TRACE_MARKER_TYPE_KERNEL_EVENT_RAW which is turned into TRACE_MARKER_TYPE_KERNEL_EVENT in raw2trace. A new invariant check ensures this _RAW type is not present in final traces; a new unit test validates the check.
+ Other types either cannot appear where an address can or always precede an address.

Adds a unit test.

Also tested on an internal app with real top-byte-ignore addresses that previously broke drmemtrace.

Issue: #1734