### PR TITLE
i#4103 clang-tidy: Remove unused drmemtrace.h include from output.cpp

### DIFF
--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -45,7 +45,6 @@
 #include <string>
 
 #include "dr_api.h"
-#include "drmemtrace.h"
 #include "drmgr.h"
 #include "droption.h"
 #include "drx.h"


### PR DESCRIPTION
Removes an unused `drmemtrace.h` include from
`clients/drcachesim/tracer/output.cpp`.

`clang-tidy` with `misc-include-cleaner` no longer reports the unused include warning after this change. The project rebuilds successfully after removing the include.

Part of #4103.
