### PR TITLE
i#7906 Handle more AArch64 cache operations in drmemtrace

### DIFF
--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -179,7 +179,9 @@ instru_t::is_aarch64_dcache_flush_op(instr_t *instr)
     case OP_dc_ivac:
     case OP_dc_cvau:
     case OP_dc_civac:
-    case OP_dc_cvac: return true;
+    case OP_dc_cvac:
+    case OP_dc_cvap:
+    case OP_dc_cvadp: return true;
     }
     return false;
 }


### PR DESCRIPTION
Add two cache maintenance operations that were missing from the switch in the tracer's is_aarch64_dcache_flush_op() function:

dc cvap: Data or unified cache line clean by VA to Point of Persistence

dc cvadp: Data or unified cache line clean by VA to Point of Deep Persistence

Fixes #7906