### PR TITLE
i#1734 top bits: Auto-canonicalize addresses in scheduler

### DIFF
--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -120,6 +120,14 @@ public:
          * Counts the instances when the kernel syscall sequences were injected.
          */
         SCHED_STAT_KERNEL_SYSCALL_SEQUENCE_INJECTIONS,
+        /**
+         * Counts the instances of top address bits being modified for auto-
+         * canonicalization (when #dynamorio::drmemtrace::scheduler_tmpl_t::
+         * scheduler_options_t.canonicalize_addresses is enabled).
+         * This counts at the #memref_t level and so will double-count an instruction
+         * PC that is present in both an instruction fetch and data load/store record.
+         */
+        SCHED_STAT_CANONICALIZED_ADDRESSES,
         /** Count of statistic types. */
         SCHED_STAT_TYPE_COUNT,
     };

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -795,6 +795,10 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_KERNEL_EVENT_RAW,
 
+    // XXX: When adding a new type, if its value is an address, add it to
+    // scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_canonicalize_addresses()
+    // for auto-canonicalization support.
+
     // ...
     // These values are reserved for future built-in marker types.
     // ...

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2023-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -357,6 +357,25 @@ scheduler_tmpl_t<RecordType, ReaderType>::stream_t::get_schedule_statistic(
     schedule_statistic_t stat) const
 {
     return scheduler_->get_statistic(ordinal_, stat);
+}
+
+template <>
+bool
+scheduler_tmpl_t<memref_t, reader_t>::record_type_canonicalization_supported()
+{
+#ifdef X64
+    return true;
+#else
+    return false;
+#endif
+}
+
+template <>
+bool
+scheduler_tmpl_t<trace_entry_t, record_reader_t>::record_type_canonicalization_supported()
+{
+    // Canonicalization is only supported for memref_t.
+    return false;
 }
 
 template class scheduler_tmpl_t<memref_t, reader_t>;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -947,7 +947,9 @@ public:
          * Auto-canonicalization is only supported for #memref_t instantiation (not
          * for #trace_entry_t).
          */
-        bool canonicalize_addresses = true;
+        bool canonicalize_addresses =
+            scheduler_tmpl_t<RecordType,
+                             ReaderType>::record_type_canonicalization_supported();
         // When adding new options, also add to print_configuration().
     };
 
@@ -1413,6 +1415,15 @@ public:
      */
     scheduler_status_t
     write_recorded_schedule();
+
+    /**
+     * Returns whether auto-canonicalization of addresses is supported by this
+     * scheduler_tmpl_t template instantiation's RecordType.
+     * If supported, it can be enabled via #dynamorio::drmemtrace::scheduler_tmpl_t::
+     * scheduler_options_t.canonicalize_addresses.
+     */
+    static bool
+    record_type_canonicalization_supported();
 
 protected:
     typedef scheduler_tmpl_t<RecordType, ReaderType> sched_type_t;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -937,6 +937,17 @@ public:
          * this value (including at 0).  Setting this field to 0 disables stealing.
          */
         uint64_t steal_attempt_period = 10000;
+        /**
+         * Sets whether to canonicalize (set to all 0's or all 1's) the top bytes
+         * of each address in each record.  This is relevant for platforms
+         * with a Top Byte Ignore feature where the top byte(s) of a 64-bit address
+         * can contain any value which is ignored by the hardware.
+         * Marker values whose type is unknown are not canonicalized (these include
+         * TRACE_MARKER_TYPE_FUNC_ARG and TRACE_MARKER_TYPE_FUNC_RETVAL).
+         * Auto-canonicalization is only supported for #memref_t instantiation (not
+         * for #trace_entry_t).
+         */
+        bool canonicalize_addresses = true;
         // When adding new options, also add to print_configuration().
     };
 

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -390,6 +390,10 @@ scheduler_impl_tmpl_t<memref_t, reader_t>::print_record(const memref_t &record)
     else if (record.marker.type == TRACE_TYPE_MARKER) {
         fprintf(stderr, " marker=%d val=%zu", record.marker.marker_type,
                 record.marker.marker_value);
+    } else if (type_is_prefetch(record.data.type) ||
+               record.data.type == TRACE_TYPE_READ ||
+               record.data.type == TRACE_TYPE_WRITE) {
+        fprintf(stderr, " addr=0x%zx", record.data.addr);
     }
     fprintf(stderr, "\n");
 }
@@ -416,6 +420,79 @@ scheduler_impl_tmpl_t<memref_t, reader_t>::invalid_kernel_sequence_key()
 {
     // System numbers are small non-negative integers.
     return -1;
+}
+
+template <>
+bool
+scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_canonicalization_supported()
+{
+    return true;
+}
+
+template <>
+int
+scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_canonicalize_addresses(
+    memref_t &record)
+{
+    int count = 0;
+    if (type_is_instr(record.instr.type)) {
+        addr_t canon_pc = canonicalize_address(record.instr.addr);
+        if (canon_pc != record.instr.addr) {
+            ++count;
+            record.instr.addr = canon_pc;
+        }
+        if (record.instr.indirect_branch_target != 0) {
+            canon_pc = canonicalize_address(record.instr.indirect_branch_target);
+            if (canon_pc != record.instr.indirect_branch_target) {
+                ++count;
+                record.instr.indirect_branch_target = canon_pc;
+            }
+        }
+    } else if (type_is_prefetch(record.data.type) ||
+               record.data.type == TRACE_TYPE_READ ||
+               record.data.type == TRACE_TYPE_WRITE) {
+        addr_t canon_addr = canonicalize_address(record.data.addr);
+        if (canon_addr != record.data.addr) {
+            ++count;
+            record.data.addr = canon_addr;
+        }
+        addr_t canon_pc = canonicalize_address(record.data.pc);
+        if (canon_pc != record.data.pc) {
+            ++count;
+            record.data.pc = canon_pc;
+        }
+    } else if (record.flush.type == TRACE_TYPE_INSTR_FLUSH ||
+               record.flush.type == TRACE_TYPE_INSTR_FLUSH_END ||
+               record.flush.type == TRACE_TYPE_DATA_FLUSH ||
+               record.flush.type == TRACE_TYPE_DATA_FLUSH_END) {
+        addr_t canon_addr = canonicalize_address(record.flush.addr);
+        if (canon_addr != record.flush.addr) {
+            ++count;
+            record.flush.addr = canon_addr;
+        }
+        addr_t canon_pc = canonicalize_address(record.flush.pc);
+        if (canon_pc != record.flush.pc) {
+            ++count;
+            record.flush.pc = canon_pc;
+        }
+    } else if (record.marker.type == TRACE_TYPE_MARKER &&
+               (record.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_FUNC_RETADDR ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_PHYSICAL_ADDRESS ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_VIRTUAL_ADDRESS ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ENTRY ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_BRANCH_TARGET ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT ||
+                record.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN)) {
+        addr_t canon_value = canonicalize_address(record.marker.marker_value);
+        if (canon_value != record.marker.marker_value) {
+            ++count;
+            record.marker.marker_value = canon_value;
+        }
+    }
+    return count;
 }
 
 /******************************************************************************
@@ -707,6 +784,25 @@ scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::invalid_kernel_sequence_k
     return -1;
 }
 
+template <>
+bool
+scheduler_impl_tmpl_t<trace_entry_t,
+                      record_reader_t>::record_type_canonicalization_supported()
+{
+    // Canonicalization is only supported for memref_t.
+    return false;
+}
+
+template <>
+int
+scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::record_type_canonicalize_addresses(
+    trace_entry_t &record)
+{
+    // Canonicalization is only supported for memref_t.
+    assert(false);
+    return 0;
+}
+
 /***************************************************************************
  * Scheduler.
  */
@@ -780,6 +876,10 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::print_configuration()
            options_.ignore_low_latency_unsched);
     VPRINT(this, 1, "  %-25s : %d\n", "direct_switch_fallbacks",
            options_.direct_switch_fallbacks);
+    VPRINT(this, 1, "  %-25s : %" PRIu64 "\n", "steal_attempt_period",
+           options_.steal_attempt_period);
+    VPRINT(this, 1, "  %-25s : %d\n", "canonicalize_addresses",
+           options_.canonicalize_addresses);
 }
 
 template <typename RecordType, typename ReaderType>
@@ -815,6 +915,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::~scheduler_impl_tmpl_t()
         VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Runqueue lock contended",
                outputs_[i].ready_queue.lock->get_count_contended());
 #endif
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Addresses auto-canonicalized",
+               outputs_[i].stats[memtrace_stream_t::SCHED_STAT_CANONICALIZED_ADDRESSES]);
     }
 }
 
@@ -857,6 +959,12 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
 {
     options_ = std::move(options);
     verbosity_ = options_.verbosity;
+
+    if (options_.canonicalize_addresses && !record_type_canonicalization_supported()) {
+        error_string_ = "canonicalize_addresses is only supported for memref_t";
+        return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
+    }
+
     // workload_inputs is not const so we can std::move readers out of it.
     for (int workload_idx = 0; workload_idx < static_cast<int>(workload_inputs.size());
          ++workload_idx) {
@@ -3314,6 +3422,10 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::update_next_record(output_ordinal
     if (is_marker && marker_type == TRACE_MARKER_TYPE_FILETYPE) {
         record_type_set_marker_value(
             record, adjust_filetype(static_cast<offline_file_type_t>(marker_value)));
+    }
+    if (options_.canonicalize_addresses) {
+        outputs_[output].stats[memtrace_stream_t::SCHED_STAT_CANONICALIZED_ADDRESSES] +=
+            record_type_canonicalize_addresses(record);
     }
     if (options_.mapping != sched_type_t::MAP_TO_ANY_OUTPUT &&
         options_.mapping != sched_type_t::MAP_AS_PREVIOUSLY)

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -423,13 +423,6 @@ scheduler_impl_tmpl_t<memref_t, reader_t>::invalid_kernel_sequence_key()
 }
 
 template <>
-bool
-scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_canonicalization_supported()
-{
-    return true;
-}
-
-template <>
 int
 scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_canonicalize_addresses(
     memref_t &record)
@@ -785,15 +778,6 @@ scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::invalid_kernel_sequence_k
 }
 
 template <>
-bool
-scheduler_impl_tmpl_t<trace_entry_t,
-                      record_reader_t>::record_type_canonicalization_supported()
-{
-    // Canonicalization is only supported for memref_t.
-    return false;
-}
-
-template <>
 int
 scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::record_type_canonicalize_addresses(
     trace_entry_t &record)
@@ -960,7 +944,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
     options_ = std::move(options);
     verbosity_ = options_.verbosity;
 
-    if (options_.canonicalize_addresses && !record_type_canonicalization_supported()) {
+    if (options_.canonicalize_addresses &&
+        !sched_type_t::record_type_canonicalization_supported()) {
         error_string_ = "canonicalize_addresses is only supported for memref_t";
         return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
     }

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -963,7 +963,18 @@ protected:
     static inline addr_t
     canonicalize_address(addr_t address)
     {
-#ifdef X64
+#ifdef ARM_64
+        // For AArch64 the top address bit does *not* have to match the ignored
+        // bits, so we go with the 2nd-most-significant byte (since top-byte-ignore
+        // is only the very top byte; the 2nd must be all 1's or all 0's and is
+        // what we want the top byte to match to make canonical).
+        if (TESTANY(1ULL << 55, address))
+            return address | 0xffff000000000000;
+        return address & 0x0000ffffffffffff;
+#elif defined(X64)
+        // The Intel manual defines canonical as the top bits matching the highest
+        // actual address bit. RISC-V seems to match, based on how the Linux kernel
+        // "untags" addresses.
         if (TESTANY(1ULL << 47, address))
             return address | 0xffff000000000000;
         return address & 0x0000ffffffffffff;
@@ -971,9 +982,6 @@ protected:
         return address;
 #endif
     }
-
-    bool
-    record_type_canonicalization_supported();
 
     // Returns the number of fields that were modified.
     int

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -960,6 +960,25 @@ protected:
     void
     insert_switch_tid_pid(input_info_t &input);
 
+    static inline addr_t
+    canonicalize_address(addr_t address)
+    {
+#ifdef X64
+        if (TESTANY(1ULL << 47, address))
+            return address | 0xffff000000000000;
+        return address & 0x0000ffffffffffff;
+#else
+        return address;
+#endif
+    }
+
+    bool
+    record_type_canonicalization_supported();
+
+    // Returns the number of fields that were modified.
+    int
+    record_type_canonicalize_addresses(RecordType &record);
+
     void
     update_next_record(output_ordinal_t output, RecordType &record);
 

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -9957,6 +9957,184 @@ test_random_layout()
     assert(random_match_count <= NUM_OUTPUTS);
 }
 
+void
+test_canonicalize()
+{
+    std::cerr << "\n----------------\nTesting address canonicalization\n";
+    static constexpr memref_tid_t TID_A = 42;
+    static constexpr addr_t TOP_PC_A = 0xab00123400560078;
+    static constexpr addr_t TOP_PC_A_CANON = 0x0000123400560078;
+    static constexpr addr_t TOP_PC_B = 0xeeffa23400560078;
+    static constexpr addr_t TOP_PC_B_CANON = 0xffffa23400560078;
+    static constexpr addr_t TOP_ADDR_A = 0x5700432100560078;
+    static constexpr addr_t TOP_ADDR_A_CANON = 0x0000432100560078;
+    static constexpr addr_t TOP_ADDR_B = 0xcdff832100780056;
+    static constexpr addr_t TOP_ADDR_B_CANON = 0xffff832100780056;
+    std::vector<trace_entry_t> refs_A = {
+        /* clang-format off */
+        test_util::make_thread(TID_A),
+        test_util::make_pid(1),
+        test_util::make_version(4),
+        test_util::make_timestamp(10),
+        test_util::make_instr(TOP_PC_A),
+        test_util::make_memref(TOP_ADDR_A, TRACE_TYPE_WRITE),
+        test_util::make_marker(TRACE_MARKER_TYPE_BRANCH_TARGET, TOP_PC_A),
+        test_util::make_instr(TOP_PC_B, TRACE_TYPE_INSTR_INDIRECT_JUMP),
+        test_util::make_memref(TOP_ADDR_B),
+        test_util::make_instr(TOP_PC_A),
+        test_util::make_memref(TOP_ADDR_A, TRACE_TYPE_PREFETCH_READ_L1),
+        test_util::make_instr(TOP_PC_B),
+        test_util::make_memref(TOP_ADDR_A, TRACE_TYPE_INSTR_FLUSH),
+        test_util::make_memref(TOP_ADDR_A, TRACE_TYPE_INSTR_FLUSH_END),
+        test_util::make_instr(TOP_PC_A),
+        test_util::make_memref(TOP_ADDR_B, TRACE_TYPE_DATA_FLUSH),
+        test_util::make_memref(TOP_ADDR_B, TRACE_TYPE_DATA_FLUSH_END),
+        test_util::make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, TOP_PC_A),
+        test_util::make_marker(TRACE_MARKER_TYPE_KERNEL_XFER, TOP_PC_A),
+        test_util::make_marker(TRACE_MARKER_TYPE_FUNC_RETADDR, TOP_PC_A),
+        test_util::make_marker(TRACE_MARKER_TYPE_RSEQ_ABORT, TOP_PC_A),
+        test_util::make_marker(TRACE_MARKER_TYPE_PHYSICAL_ADDRESS, TOP_ADDR_A),
+        test_util::make_marker(TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, TOP_ADDR_A),
+        test_util::make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, TOP_PC_A),
+        test_util::make_marker(TRACE_MARKER_TYPE_HARDWARE_EVENT, TOP_PC_B),
+        test_util::make_marker(TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, TOP_PC_B),
+        test_util::make_exit(TID_A),
+        /* clang-format on */
+    };
+    {
+        // Test with canonicalization.
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(
+            std::unique_ptr<test_util::mock_reader_t>(
+                new test_util::mock_reader_t(refs_A)),
+            std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()),
+            TID_A);
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/3);
+        sched_ops.canonicalize_addresses = true;
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, /*outputs=*/1, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        auto *stream = scheduler.get_stream(0);
+        memref_t memref;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+            assert(status == scheduler_t::STATUS_OK);
+            if (type_is_instr(memref.instr.type)) {
+                assert(memref.instr.addr == TOP_PC_A_CANON ||
+                       memref.instr.addr == TOP_PC_B_CANON);
+                assert(memref.instr.indirect_branch_target == 0 ||
+                       memref.instr.indirect_branch_target == TOP_PC_A_CANON ||
+                       memref.instr.indirect_branch_target == TOP_PC_B_CANON);
+            } else if (type_is_prefetch(memref.data.type) ||
+                       memref.data.type == TRACE_TYPE_READ ||
+                       memref.data.type == TRACE_TYPE_WRITE) {
+                assert(memref.data.addr == TOP_ADDR_A_CANON ||
+                       memref.data.addr == TOP_ADDR_B_CANON);
+                assert(memref.data.pc == TOP_PC_A_CANON ||
+                       memref.data.pc == TOP_PC_B_CANON);
+            } else if (memref.flush.type == TRACE_TYPE_INSTR_FLUSH ||
+                       memref.flush.type == TRACE_TYPE_INSTR_FLUSH_END ||
+                       memref.flush.type == TRACE_TYPE_DATA_FLUSH ||
+                       memref.flush.type == TRACE_TYPE_DATA_FLUSH_END) {
+                assert(memref.flush.addr == TOP_ADDR_A_CANON ||
+                       memref.flush.addr == TOP_ADDR_B_CANON);
+                assert(memref.flush.pc == TOP_PC_A_CANON ||
+                       memref.flush.pc == TOP_PC_B_CANON);
+            } else if (memref.marker.type == TRACE_TYPE_MARKER &&
+                       (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_RETADDR ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_PHYSICAL_ADDRESS ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_VIRTUAL_ADDRESS ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ENTRY ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_BRANCH_TARGET ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT ||
+                        memref.marker.marker_type ==
+                            TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN)) {
+                assert(memref.marker.marker_value == TOP_ADDR_A_CANON ||
+                       memref.marker.marker_value == TOP_ADDR_B_CANON ||
+                       memref.marker.marker_value == TOP_PC_A_CANON ||
+                       memref.marker.marker_value == TOP_PC_B_CANON);
+            }
+        }
+        std::cerr << "Auto-canonicalized "
+                  << scheduler.get_stream(0)->get_schedule_statistic(
+                         memtrace_stream_t::SCHED_STAT_CANONICALIZED_ADDRESSES)
+                  << " addresses\n";
+        assert(stream->get_schedule_statistic(
+                   memtrace_stream_t::SCHED_STAT_CANONICALIZED_ADDRESSES) == 29);
+    }
+    {
+        // Test without canonicalization.
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(
+            std::unique_ptr<test_util::mock_reader_t>(
+                new test_util::mock_reader_t(refs_A)),
+            std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()),
+            TID_A);
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/3);
+        sched_ops.canonicalize_addresses = false;
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, /*outputs=*/1, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        auto *stream = scheduler.get_stream(0);
+        memref_t memref;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+            assert(status == scheduler_t::STATUS_OK);
+            if (type_is_instr(memref.instr.type)) {
+                assert(memref.instr.addr == TOP_PC_A || memref.instr.addr == TOP_PC_B);
+                assert(memref.instr.indirect_branch_target == 0 ||
+                       memref.instr.indirect_branch_target == TOP_PC_A ||
+                       memref.instr.indirect_branch_target == TOP_PC_B);
+            } else if (type_is_prefetch(memref.data.type) ||
+                       memref.data.type == TRACE_TYPE_READ ||
+                       memref.data.type == TRACE_TYPE_WRITE) {
+                assert(memref.data.addr == TOP_ADDR_A || memref.data.addr == TOP_ADDR_B);
+                assert(memref.data.pc == TOP_PC_A || memref.data.pc == TOP_PC_B);
+            } else if (memref.flush.type == TRACE_TYPE_INSTR_FLUSH ||
+                       memref.flush.type == TRACE_TYPE_INSTR_FLUSH_END ||
+                       memref.flush.type == TRACE_TYPE_DATA_FLUSH ||
+                       memref.flush.type == TRACE_TYPE_DATA_FLUSH_END) {
+                assert(memref.flush.addr == TOP_ADDR_A ||
+                       memref.flush.addr == TOP_ADDR_B);
+                assert(memref.flush.pc == TOP_PC_A || memref.flush.pc == TOP_PC_B);
+            } else if (memref.marker.type == TRACE_TYPE_MARKER &&
+                       (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_RETADDR ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_PHYSICAL_ADDRESS ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_VIRTUAL_ADDRESS ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ENTRY ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_BRANCH_TARGET ||
+                        memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT ||
+                        memref.marker.marker_type ==
+                            TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN)) {
+                assert(memref.marker.marker_value == TOP_ADDR_A ||
+                       memref.marker.marker_value == TOP_ADDR_B ||
+                       memref.marker.marker_value == TOP_PC_A ||
+                       memref.marker.marker_value == TOP_PC_B);
+            }
+        }
+        assert(stream->get_schedule_statistic(
+                   memtrace_stream_t::SCHED_STAT_CANONICALIZED_ADDRESSES) == 0);
+    }
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -10012,6 +10190,7 @@ test_main(int argc, const char *argv[])
     test_options_match();
     test_noise_generator();
     test_random_layout();
+    test_canonicalize();
 
     dr_standalone_exit();
     return 0;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -9960,6 +9960,9 @@ test_random_layout()
 void
 test_canonicalize()
 {
+#ifndef X64
+    return;
+#else
     std::cerr << "\n----------------\nTesting address canonicalization\n";
     static constexpr memref_tid_t TID_A = 42;
     static constexpr addr_t TOP_PC_A = 0xab00123400560078;
@@ -10133,6 +10136,7 @@ test_canonicalize()
         assert(stream->get_schedule_statistic(
                    memtrace_stream_t::SCHED_STAT_CANONICALIZED_ADDRESSES) == 0);
     }
+#endif
 }
 
 int


### PR DESCRIPTION
Adds a new on-by-default drmemtrace scheduler option "canonicalize_addresses" which auto-canonicalizes PC and address values in all record types. This avoids requiring all tools to handle top bits being set.

Auto-canonicalization is only supported for memref_t usage: not for trace_entry_t.

Adds a new scheduler statistic SCHED_STAT_CANONICALIZED_ADDRESSES which counts memref_t fields modified for canonicalization, which should be very useful for seeing which traces have top bits set and how many.

Adds a scheduler unit test.

Issue: #1734