### PR TITLE
i#7695: Fix 32-bit test failures on certain runners

### DIFF
--- a/clients/drcachesim/tests/offline-burst_syscall_inject.template
+++ b/clients/drcachesim/tests/offline-burst_syscall_inject.template
@@ -12,7 +12,11 @@ Output format:
 ------------------------------------------------------------
            1           0:       W0.T1 <marker: version 7>
 #ifdef X86
+# ifdef X64
            2           0:       W0.T1 <marker: filetype 0x4240>
+# else
+           2           0:       W0.T1 <marker: filetype 0x4220>
+# endif
 #else
            2           0:       W0.T1 <marker: filetype 0x4208>
 #endif
@@ -20,6 +24,7 @@ Output format:
            4           0:       W0.T1 <marker: page size 4096>
            5           0:       W0.T1 <marker: timestamp 1>
 #ifdef X86
+# ifdef X64
            6           0:       W0.T1 <marker: trace start for system call number 324>
            7           1:       W0.T1 ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
            8           2:       W0.T1 ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target 0xf00d\)
@@ -32,6 +37,20 @@ Output format:
           15           4:       W0.T1 <marker: trace start for system call number 268435455>
           16           5:       W0.T1 ifetch       2 byte\(s\) @ 0x00000000f00d8b00 0f 07                sysret \(target 0xf00d\)
           17           5:       W0.T1 <marker: trace end for system call number 268435455>
+# else
+           6           0:       W0.T1 <marker: trace start for system call number 375>
+           7           1:       W0.T1 ifetch       1 byte\(s\) @ 0xdeadbe00 90                   nop
+           8           2:       W0.T1 ifetch       2 byte\(s\) @ 0xdeadbe01 0f 07                sysret \(target 0xf00d\)
+           9           2:       W0.T1 <marker: trace end for system call number 375>
+          10           2:       W0.T1 <marker: trace start for system call number 224>
+          11           3:       W0.T1 ifetch       2 byte\(s\) @ 0x8badf000 8b 12                mov    \(%edx\), %edx
+          12           3:       W0.T1 read         4 byte\(s\) @ 0xdecafbad by PC 0x8badf000
+          13           4:       W0.T1 ifetch       2 byte\(s\) @ 0x8badf002 0f 07                sysret \(target 0xf00d\)
+          14           4:       W0.T1 <marker: trace end for system call number 224>
+          15           4:       W0.T1 <marker: trace start for system call number 268435455>
+          16           5:       W0.T1 ifetch       2 byte\(s\) @ 0xf00d8b00 0f 07                sysret \(target 0xf00d\)
+          17           5:       W0.T1 <marker: trace end for system call number 268435455>
+# endif
 #else
            6           0:       W0.T1 <marker: trace start for system call number 283>
            7           1:       W0.T1 ifetch       4 byte\(s\) @ 0x00000000deadbe00 d503201f   nop

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1814,10 +1814,13 @@ invariant_checker_t::check_for_pc_discontinuity(
     if (shard->prev_kernel_end_branch_target_ != 0) {
         const addr_t kernel_end_branch_target = shard->prev_kernel_end_branch_target_;
         shard->prev_kernel_end_branch_target_ = 0;
-        if (kernel_end_branch_target != cur_pc)
+        if (kernel_end_branch_target != cur_pc &&
+            // We always see a discontinuity for sysenter.
+            prev_instr.instr.type != TRACE_TYPE_INSTR_SYSENTER) {
             // We want the check for PC continuity of cur_pc to take precedence
             // over this, so later code may overwrite error_msg.
             error_msg = "Kernel trace-end branch marker does not match next pc";
+        }
     }
     if (prev_instr_trace_pc == 0 /*first*/) {
         return error_msg;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4444,7 +4444,8 @@ if (BUILD_CLIENTS)
     endif ()
 
     # Test reading a legacy pre-interleaved file in thread-sharded mode.
-    if (ZLIB_FOUND)
+    # The checked-in file is for x86_64 so we have to limit the test to that.
+    if (ZLIB_FOUND AND X64)
       torunonly_api(tool.drcacheoff.legacy "${drcachesim_path}" "offline-legacy.c" ""
         "-infile;${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/offline-legacy-trace.gz;-no_core_sharded"
         OFF OFF)
@@ -4810,7 +4811,8 @@ if (BUILD_CLIENTS)
         "-use_physical" "@${test_mode_flag}@-tool@view" "")
     endif ()
 
-    if (UNIX AND ZLIB_FOUND)
+    # The checked-in file is for x86_64 so we have to limit the test to that.
+    if (UNIX AND ZLIB_FOUND AND X64)
       add_exe(tool.fib_plus
         ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/fib_plus.c)
       link_with_pthread(tool.fib_plus)
@@ -4922,10 +4924,15 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.burst_replace_nodr ON)
       torunonly_drcacheoff(burst_replace tool.drcacheoff.burst_replace "" "" "")
 
-      set(tool.drcacheoff.burst_replaceall_nodr ON)
-      torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall ""
-        "@-tool@basic_counts" "")
-      unset(tool.drcacheoff.burst_replaceall_rawtemp) # use preprocessor
+      # This test has not been updated to write out encodings.bin and so it has
+      # trouble with some vdso code in 32-bit. 32-bit is a low priority target
+      # so we do not plan to address this and simply disable for 32-bit.
+      if (X64)
+        set(tool.drcacheoff.burst_replaceall_nodr ON)
+        torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall ""
+          "@-tool@basic_counts" "")
+        unset(tool.drcacheoff.burst_replaceall_rawtemp) # use preprocessor
+      endif ()
 
       if (X64 AND UNIX)
         set(tool.drcacheoff.burst_noreach_nodr ON)
@@ -5471,7 +5478,8 @@ if (BUILD_CLIENTS)
   # Limited to UNIX because the checked-in modules.log is in UNIX format
   # (Windows needs extra fields per library).
   # Limited to ZLIB_FOUND because we test gzipped .raw files here as well.
-  if (UNIX AND ZLIB_FOUND)
+  # The checked-in file is for x86_64 so we have to limit the test to that.
+  if (UNIX AND ZLIB_FOUND AND X64)
     # We make a writable copy so we can both write the final trace there and run our
     # analyzer in a single command line  Since we're testing postprocessing we
     # need to dynamically clobber the directory.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5478,30 +5478,33 @@ if (BUILD_CLIENTS)
   # Limited to UNIX because the checked-in modules.log is in UNIX format
   # (Windows needs extra fields per library).
   # Limited to ZLIB_FOUND because we test gzipped .raw files here as well.
-  # The checked-in file is for x86_64 so we have to limit the test to that.
-  if (UNIX AND ZLIB_FOUND AND X64)
-    # We make a writable copy so we can both write the final trace there and run our
-    # analyzer in a single command line  Since we're testing postprocessing we
-    # need to dynamically clobber the directory.
-    set(srcdir
-      ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.aarch64.raw)
-    set(locdir ${CMAKE_CURRENT_BINARY_DIR}/drmemtrace.altbindir.aarch64)
-    file(MAKE_DIRECTORY ${locdir})
-    file(COPY ${srcdir}/raw DESTINATION ${locdir}/)
-    torunonly_api(tool.drcacheoff.altbindir "${drcachesim_path}"
-      "offline-altbindir.c" ""
-      "-indir;${locdir};-tool;opcode_mix;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
-      OFF OFF)
-    set(tool.drcacheoff.altbindir_basedir
-      "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
-    set(tool.drcacheoff.altbindir_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
-    set(tool.drcacheoff.altbindir_precmd
+  if (UNIX AND ZLIB_FOUND)
+    # The checked-in file is for x86_64 so we have to limit the test to that.
+    if (X64)
+      # We make a writable copy so we can both write the final trace there and run our
+      # analyzer in a single command line  Since we're testing postprocessing we
+      # need to dynamically clobber the directory.
+      set(srcdir
+        ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.aarch64.raw)
+      set(locdir ${CMAKE_CURRENT_BINARY_DIR}/drmemtrace.altbindir.aarch64)
+      file(MAKE_DIRECTORY ${locdir})
+      file(COPY ${srcdir}/raw DESTINATION ${locdir}/)
+      torunonly_api(tool.drcacheoff.altbindir "${drcachesim_path}"
+        "offline-altbindir.c" ""
+        "-indir;${locdir};-tool;opcode_mix;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
+        OFF OFF)
+      set(tool.drcacheoff.altbindir_basedir
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      set(tool.drcacheoff.altbindir_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+      set(tool.drcacheoff.altbindir_precmd
         "${CMAKE_COMMAND}@-E@remove_directory@${locdir}/trace")
-    set(tool.drcacheoff.altbindir_failok ON)
+      set(tool.drcacheoff.altbindir_failok ON)
+    endif ()
 
     # Test the legacy trace versions OFFLINE_FILE_VERSION_KERNEL_INT_PC-1 and
     # TRACE_ENTRY_VERSION_NO_KERNEL_PC.  This requires a checked-in trace and thus
     # -alt_module_dir; it has gzipped .raw files; hence here next to the altbindir test.
+    # This does support 32-bit by expecting an error message there.
     set(srcdir
       ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.legacy-int-offs.raw)
     set(locdir ${PROJECT_BINARY_DIR}/drmemtrace.legacy-int-offs)


### PR DESCRIPTION
Fixes 32-bit test failures that occur in a group on certain Github runners.

First we have tests that use a checked-in trace file and are only run if zlib is available. The failing runners must have zlib, while all the passing runners do not have zlib:
+ code_api|tool.drcacheoff.legacy
+ code_api|tool.drcacheoff.func_view_noret
+ code_api|tool.drcacheoff.altbindir

The checked-in file used for all 3 of these is a 64-bit file! So naturally they fail, with file reader errors.  So the solution is to disable for 32-bit (32-bit is low priority; not worth adding an input file).

Next we have:
+ code_api|tool.drcacheoff.burst_replaceall

This fails because it doesn't write out the encodings.bin file and we see sysenter wrapper code: we end up with a modidx -1 and raw2trace fails because there's no encoding info (we got rid of vdso contents in modules.log).  We should just disable for 32-bit; again, not worth spending time improving the test just for 32-bit.

Finally:
+ code_api|tool.drcacheoff.burst_syscall_inject

This has an invariant failure on sysenter: that we can just relax.

Tested locally where these failures all reproduce.

Fixes #7695