### PR TITLE
i#1734 tagged addrs: Add new OFFLINE_TYPE_PC_TOP_BIT

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -986,61 +986,79 @@ typedef struct _trace_entry_t trace_entry_t;
 // reconstructing the trace_entry_t format that the readers expect via a
 // post-processing step before feeding it to analysis tools.
 
+// We use a single 64-bit record entry defined as a union to cover all record types.
+// The offline_type_t enum stored in the type field, along with other logic to handle
+// non-canonical top bits (described right below), identifies the union alternative.
 // We target 64-bit addresses and do not bother to shrink the module or timestamp
 // entries for 32-bit apps.
 // We assume that a 64-bit address has far fewer real bits, typically
-// 48 bits, and that the bits 48..55 are always identical.
+// 48 bits, and that certain bits must be identical to be "canonical" and avoid
+// a fault.
 // Often all 48..63 are identical, including 61..63 where we store our type field.
-// For the most common record type, a memref, we have both all 0's and all 1's be its
-// type to reduce instrumentation overhead.
-// The offline_type_t, along with other logic for Top Byte Ignore described below,
-// identifies the union alternative.
+// For the most common record type, a memref (load or store address), we have both
+// all 0's and all 1's be its type to reduce instrumentation overhead.
 //
-// For Top Byte Ignore where the top byte 56..63 can be anything, making
-// OFFLINE_TYPE_MEMREF{,_HIGH} look like any of the other record types.
-// We distinguish it by adding restrictions on the other types to avoid
-// having all 0's or all 1's in bits 48..55 (we assume OFFLINE_TYPE_MEMREF{,HIGH}
-// always has all 0's or all 1's there as previously mentioned) as follows:
+// We support top address bits being non-canonical in the following manner:
+// + Top Byte Ignore (AArch64) or Upper Address Ignore (AMD): we support the full
+//   top byte 56..63 being anything.
+// + Linear Address Masking (Intel x86_64): we support both LAM_U48 with bits
+//   48..62 (looks like Top Byte Ignore to us) and LAM_U57 with bits 57..62 as
+//   any value.
+// We need to distinguish a memref (OFFLINE_TYPE_MEMREF{,_HIGH}) whose top bits make
+// it look like another type.
+// We do not worry about the following types as they never appear where we expect
+// a memref (they should always be separated by at least a timestamp):
+// (XXX i#1734: If this were to change: we would ensure we can identify block
+// boundaries by knowing the memref count or adding a record in order to separate these.)
+// + OFFLINE_TYPE_THREAD
+// + OFFLINE_TYPE_PID
+// + OFFLINE_EXT_TYPE_HEADER_DEPRECATED, OFFLINE_EXT_TYPE_FOOTER,
+//   OFFLINE_EXT_TYPE_HEADER
+// We also do not worry about these:
+// + OFFLINE_TYPE_IFLUSH: Only used for AArch32 where addresses are only 32 bits.
+// + OFFLINE_EXT_TYPE_MEMINFO: a read (==0) would have canonical 48..55: but this
+//   is used for filtering and always precedes addresses, so it should never be
+//   confused with an address.
+// For the remaining types: for the top byte being non-canonical where bits 48..55
+// still must be all 0's or 1's, we avoid other types from ever being legitimate values
+// when 48..55 are all 0's or '1s as follows:
 // + OFFLINE_TYPE_PC: A PC record: instr_count is 12 bits: 5 in top byte; 7 as top
 //   bits of 48..55. Bit 48 is top bit of modidx: which can be set as that's part of
 //   PC_MODIDX_INVALID. So for 48..55 to be all 0's: count is multiple of 128, or
 //   count is 0. 0 is only used for filtered, where a PC entry with count 0 precedes
 //   each memref, so we can distinguish by record order. To be all 1's: count must be
 //   at least 127. We avoid this by ensuring -max_bb_instrs is 126.
-// + OFFLINE_TYPE_THREAD and OFFLINE_TYPE_PID: We assume these will never appear where
-//   we expect a memref; there will always be a timestamp or some other marker in
-//   between.
-//   XXX i#1734: If this were to change: we would ensure we can identify block
-//   boundaries by knowing the memref count or adding a record in order to avoid these.
 // + OFFLINE_TYPE_TIMESTAMP: A timestamp with 0's in 48..55 and 0's in top bits would
 //   be older than 0x8001000000000000 which is 12/2/1609; with 0's in 48..55 and at
 //   least one 1 in top bits would be at least 0x8100000000000000 which is 5/31/3884;
 //   with 1's in 48..55 would be at least 0x00ff000000000000 which is 7/1/3875. So it
 //   seems reasonable to exclude any seeming timestamp with a canonical 48..55:
 //   assume it's an address.
-// + OFFLINE_TYPE_IFLUSH: AArch32-only where addresses are only 32 bits.
-// + OFFLINE_TYPE_EXTENDED:
-//   + OFFLINE_EXT_TYPE_MARKER: offline_entry_t.extended.valueB is bits 48..55 so
-//     we need to distinguish marker types 0 and all 1's. There is no all 1's; 0 is
-//     TRACE_MARKER_TYPE_KERNEL_EVENT which we no longer use in raw records: we use
-//     TRACE_MARKER_TYPE_KERNEL_EVENT_RAW and convert it in raw2trace.
-//   + OFFLINE_EXT_TYPE_HEADER_DEPRECATED, OFFLINE_EXT_TYPE_FOOTER,
-//     OFFLINE_EXT_TYPE_HEADER: We assume these will never appear where we expect a
-//     memref; there will always be a timestamp or some other marker in between.
-//   + OFFLINE_EXT_TYPE_MEMINFO: a read (==0) would have canonical 48..55: but this
-//     is used for filtering and always precedes addresses, so it should never be
-//     confused with an address.
-// TODO i#1734: Add support to reader_t to optionally (default true) canonicalize all
-// non-canonical addresses (including PC values, along with adding tests to ensure
-// non-canonical PC values are preserved, which they should be without extra work).
+// + OFFLINE_EXT_TYPE_MARKER: offline_entry_t.extended.valueB is bits 48..55 so
+//   we need to distinguish marker types 0 and all 1's. There is no all 1's; 0 is
+//   TRACE_MARKER_TYPE_KERNEL_EVENT which we no longer use in raw records: we use
+//   TRACE_MARKER_TYPE_KERNEL_EVENT_RAW and convert it in raw2trace.
+// The final piece is distinguishing LAM_U48 where bits 48..55 do not need to all
+// be the same.  However, here the top bit 63 must match bit 47, with both being 0
+// for user-mode addresses.  We assume kernel code never uses these top bits for
+// metadata, and so if all our types have 1 for the top bit we should be all set.
+// We add OFFLINE_TYPE_PC_TOP_BIT for the PC; TIMESTAMP and MARKER already have
+// the top bit set.
 typedef enum {
     OFFLINE_TYPE_MEMREF, // We rely on this being 0.
     OFFLINE_TYPE_PC,
     OFFLINE_TYPE_THREAD,
     OFFLINE_TYPE_PID,
     OFFLINE_TYPE_TIMESTAMP,
+#ifdef X64
+    // Identical to OFFLINE_TYPE_PC but the top bit is set, which allows distinguishing
+    // from an address with non-canonical bits 48..62 (Intel's Linear Address Masking
+    // in LAM_U48 mode).
+    OFFLINE_TYPE_PC_TOP_BIT,
+#else
     // An ARM SYS_cacheflush: always has two addr entries for [start, end).
     OFFLINE_TYPE_IFLUSH,
+#endif
     // The ext field identifies this further.
     OFFLINE_TYPE_EXTENDED,
     OFFLINE_TYPE_MEMREF_HIGH = 7,

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1016,13 +1016,13 @@ typedef struct _trace_entry_t trace_entry_t;
 // boundaries by knowing the memref count or adding a record in order to separate these.)
 // + OFFLINE_TYPE_THREAD
 // + OFFLINE_TYPE_PID
-// + OFFLINE_EXT_TYPE_HEADER_DEPRECATED, OFFLINE_EXT_TYPE_FOOTER,
-//   OFFLINE_EXT_TYPE_HEADER
+// + OFFLINE_TYPE_EXTENDED subtypes OFFLINE_EXT_TYPE_HEADER_DEPRECATED,
+//   OFFLINE_EXT_TYPE_FOOTER, and OFFLINE_EXT_TYPE_HEADER
 // We also do not worry about these:
 // + OFFLINE_TYPE_IFLUSH: Only used for AArch32 where addresses are only 32 bits.
-// + OFFLINE_EXT_TYPE_MEMINFO: a read (==0) would have canonical 48..55: but this
-//   is used for filtering and always precedes addresses, so it should never be
-//   confused with an address.
+// + OFFLINE_TYPE_EXTENDED subtype OFFLINE_EXT_TYPE_MEMINFO: a read (==0) would have
+//   canonical 48..55: but this is used for filtering and always precedes addresses,
+//   so it should never be confused with an address.
 // For the remaining types: for the top byte being non-canonical where bits 48..55
 // still must be all 0's or 1's, we avoid other types from ever being legitimate values
 // when 48..55 are all 0's or '1s as follows:
@@ -1038,16 +1038,17 @@ typedef struct _trace_entry_t trace_entry_t;
 //   with 1's in 48..55 would be at least 0x00ff000000000000 which is 7/1/3875. So it
 //   seems reasonable to exclude any seeming timestamp with a canonical 48..55:
 //   assume it's an address.
-// + OFFLINE_EXT_TYPE_MARKER: offline_entry_t.extended.valueB is bits 48..55 so
-//   we need to distinguish marker types 0 and all 1's. There is no all 1's; 0 is
-//   TRACE_MARKER_TYPE_KERNEL_EVENT which we no longer use in raw records: we use
-//   TRACE_MARKER_TYPE_KERNEL_EVENT_RAW and convert it in raw2trace.
+// + OFFLINE_TYPE_EXTENDED subtype OFFLINE_EXT_TYPE_MARKER:
+//   offline_entry_t.extended.valueB is bits 48..55 so we need to distinguish marker
+//   types 0 and all 1's. There is no all 1's; 0 is TRACE_MARKER_TYPE_KERNEL_EVENT
+//   which we no longer use in raw records: we use TRACE_MARKER_TYPE_KERNEL_EVENT_RAW
+//   and convert it in raw2trace.
 // The final piece is distinguishing LAM_U48 where bits 48..55 do not need to all
 // be the same.  However, here the top bit 63 must match bit 47, with both being 0
 // for user-mode addresses.  We assume kernel code never uses these top bits for
 // metadata, and so if all our types have 1 for the top bit we should be all set.
-// We add OFFLINE_TYPE_PC_TOP_BIT for the PC; TIMESTAMP and MARKER already have
-// the top bit set.
+// We add OFFLINE_TYPE_PC_TOP_BIT for the PC; OFFLINE_TYPE_TIMESTAMP and
+// OFFLINE_TYPE_EXTENDED already have the top bit set.
 typedef enum {
     OFFLINE_TYPE_MEMREF, // We rely on this being 0.
     OFFLINE_TYPE_PC,
@@ -1069,7 +1070,7 @@ typedef enum {
 } offline_type_t;
 
 // Sub-type when the primary type is OFFLINE_TYPE_EXTENDED.
-// These differ in what they store in offline_entry_t.extended.value.
+// These differ in what they store in offline_entry_t.extended.value{A,B}.
 typedef enum {
     // The initial entry in trace files with version older than
     // OFFLINE_FILE_VERSION_HEADER_FIELDS_SWAP.  The valueA field holds the

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -4263,7 +4263,7 @@ test_top_byte_ignore(void *drcontext)
     check_type.combined_value = ADDR_LIKE_PC_TOP_BIT;
     ASSERT(check_type.pc.type == OFFLINE_TYPE_PC_TOP_BIT, "invalid top-bit constant");
     raw.push_back(make_memref(ADDR_LIKE_PC_TOP_BIT));
-#    ifdef X86
+#    ifdef X86_64
     // Test bits 48..55 not being canonical.
     constexpr uint64_t ADDR_LIKE_PC_LAM_U57 = 0x2abc123400005678;
     check_type.combined_value = ADDR_LIKE_PC_LAM_U57;

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -247,7 +247,7 @@ offline_entry_t
 make_block(uint64_t offs, uint64_t instr_count)
 {
     offline_entry_t entry;
-    entry.pc.type = OFFLINE_TYPE_PC;
+    entry.pc.type = IF_X64_ELSE(OFFLINE_TYPE_PC_TOP_BIT, OFFLINE_TYPE_PC);
     entry.pc.modidx = 0; // Just one "module" in this test.
     entry.pc.modoffs = offs;
     entry.pc.instr_count = instr_count;
@@ -4204,6 +4204,12 @@ test_top_byte_ignore(void *drcontext)
     instr_t *load4 =
         XINST_CREATE_load(drcontext, opnd_create_reg(REG1), OPND_CREATE_MEMPTR(REG1, 0));
     // No elision (because REG1 has changed).
+    instr_t *load5 =
+        XINST_CREATE_load(drcontext, opnd_create_reg(REG1), OPND_CREATE_MEMPTR(REG1, 0));
+    // No elision (because REG1 has changed).
+    instr_t *load6 =
+        XINST_CREATE_load(drcontext, opnd_create_reg(REG1), OPND_CREATE_MEMPTR(REG1, 0));
+    // No elision (because REG1 has changed).
     instr_t *store1 =
         XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG1, 0), opnd_create_reg(REG2));
     instr_t *move =
@@ -4216,6 +4222,8 @@ test_top_byte_ignore(void *drcontext)
     instrlist_append(ilist, load2);
     instrlist_append(ilist, load3);
     instrlist_append(ilist, load4);
+    instrlist_append(ilist, load5);
+    instrlist_append(ilist, load6);
     instrlist_append(ilist, store1);
     instrlist_append(ilist, move);
     instrlist_append(ilist, store2);
@@ -4224,7 +4232,9 @@ test_top_byte_ignore(void *drcontext)
     size_t offs_load2 = offs_load1 + instr_length(drcontext, load1);
     size_t offs_load3 = offs_load2 + instr_length(drcontext, load2);
     size_t offs_load4 = offs_load3 + instr_length(drcontext, load3);
-    size_t offs_store1 = offs_load4 + instr_length(drcontext, load4);
+    size_t offs_load5 = offs_load4 + instr_length(drcontext, load4);
+    size_t offs_load6 = offs_load5 + instr_length(drcontext, load5);
+    size_t offs_store1 = offs_load6 + instr_length(drcontext, load6);
     size_t offs_move = offs_store1 + instr_length(drcontext, store1);
     size_t offs_store2 = offs_move + instr_length(drcontext, move);
 
@@ -4236,7 +4246,7 @@ test_top_byte_ignore(void *drcontext)
     constexpr uint64_t TIME_VALUE = 101;
     raw.push_back(make_timestamp(TIME_VALUE));
     raw.push_back(make_core());
-    raw.push_back(make_block(offs_load1, 7));
+    raw.push_back(make_block(offs_load1, 9));
     // Select addresses with top bits set such that they look like
     // other record types, to ensure we treat them as addresses.
     offline_entry_t check_type;
@@ -4245,10 +4255,23 @@ test_top_byte_ignore(void *drcontext)
     ASSERT(check_type.timestamp.type == OFFLINE_TYPE_TIMESTAMP,
            "invalid top-bit constant");
     raw.push_back(make_memref(ADDR_LIKE_TIMESTAMP));
-    constexpr uint64_t ADDR_LIKE_PC = 0x20ff123400005678;
+    constexpr uint64_t ADDR_LIKE_PC = 0x2000123400005678;
     check_type.combined_value = ADDR_LIKE_PC;
     ASSERT(check_type.pc.type == OFFLINE_TYPE_PC, "invalid top-bit constant");
     raw.push_back(make_memref(ADDR_LIKE_PC));
+    constexpr uint64_t ADDR_LIKE_PC_TOP_BIT = 0xab00123400005678;
+    check_type.combined_value = ADDR_LIKE_PC_TOP_BIT;
+    ASSERT(check_type.pc.type == OFFLINE_TYPE_PC_TOP_BIT, "invalid top-bit constant");
+    raw.push_back(make_memref(ADDR_LIKE_PC_TOP_BIT));
+#    ifdef X86
+    // Test bits 48..55 not being canonical.
+    constexpr uint64_t ADDR_LIKE_PC_LAM_U57 = 0x2abc123400005678;
+    check_type.combined_value = ADDR_LIKE_PC_LAM_U57;
+    ASSERT(check_type.pc.type == OFFLINE_TYPE_PC, "invalid top-bit constant");
+    raw.push_back(make_memref(ADDR_LIKE_PC_LAM_U57));
+#    else
+    raw.push_back(make_memref(ADDR_LIKE_PC));
+#    endif
     constexpr uint64_t ADDR_LIKE_KERNEL_EVENT = 0xc200000000000000;
     check_type.combined_value = ADDR_LIKE_KERNEL_EVENT;
     ASSERT(check_type.extended.type == OFFLINE_TYPE_EXTENDED &&
@@ -4276,7 +4299,7 @@ test_top_byte_ignore(void *drcontext)
         return false;
     int idx = 0;
     return (
-        stats[RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE] == 5 &&
+        stats[RAW2TRACE_STAT_NON_CANONICAL_TOP_BITS] == 7 &&
         check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
@@ -4300,6 +4323,13 @@ test_top_byte_ignore(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_READ, -1, ADDR_LIKE_PC) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load4) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, ADDR_LIKE_PC_TOP_BIT) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load5) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1,
+                    IF_X86_ELSE(ADDR_LIKE_PC_LAM_U57, ADDR_LIKE_PC)) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load6) &&
         check_entry(entries, idx, TRACE_TYPE_READ, -1, ADDR_LIKE_KERNEL_EVENT) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store1) &&

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -240,9 +240,13 @@ offline_instru_t::get_entry_type(byte *buf_ptr) const
     case OFFLINE_TYPE_PC: return TRACE_TYPE_INSTR;
     case OFFLINE_TYPE_THREAD: return TRACE_TYPE_THREAD;
     case OFFLINE_TYPE_PID: return TRACE_TYPE_PID;
-    case OFFLINE_TYPE_TIMESTAMP: return TRACE_TYPE_THREAD; // Closest.
+#ifdef X64
+    case OFFLINE_TYPE_PC_TOP_BIT: return TRACE_TYPE_INSTR;
+#else
     case OFFLINE_TYPE_IFLUSH: return TRACE_TYPE_INSTR_FLUSH;
-    case OFFLINE_TYPE_EXTENDED: return TRACE_TYPE_MARKER; // Closest.
+#endif
+    case OFFLINE_TYPE_TIMESTAMP: return TRACE_TYPE_THREAD; // Closest.
+    case OFFLINE_TYPE_EXTENDED: return TRACE_TYPE_MARKER;  // Closest.
     }
     DR_ASSERT(false);
     return TRACE_TYPE_THREAD_EXIT; // Unknown: returning rarest entry.
@@ -259,7 +263,8 @@ int
 offline_instru_t::get_instr_count(byte *buf_ptr) const
 {
     offline_entry_t *entry = (offline_entry_t *)buf_ptr;
-    if (entry->addr.type != OFFLINE_TYPE_PC)
+    if (entry->addr.type !=
+        OFFLINE_TYPE_PC IF_X64(&&entry->addr.type != OFFLINE_TYPE_PC_TOP_BIT))
         return 0;
     // TODO i#3995: We should *not* count "non-fetched" instrs so we'll match
     // hardware performance counters.
@@ -271,7 +276,8 @@ addr_t
 offline_instru_t::get_entry_addr(void *drcontext, byte *buf_ptr) const
 {
     offline_entry_t *entry = (offline_entry_t *)buf_ptr;
-    if (entry->addr.type == OFFLINE_TYPE_PC) {
+    if (entry->addr.type ==
+        OFFLINE_TYPE_PC IF_X64(|| entry->addr.type == OFFLINE_TYPE_PC_TOP_BIT)) {
         // XXX i#4014: Use caching to avoid lookup for last queried modbase.
         app_pc modbase;
         if (drmodtrack_lookup_pc_from_index(drcontext, entry->pc.modidx, &modbase) !=
@@ -353,6 +359,10 @@ offline_instru_t::append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr
 int
 offline_instru_t::append_iflush(byte *buf_ptr, addr_t start, size_t size)
 {
+#ifdef X64
+    DR_ASSERT(false);
+    return 0;
+#else
     offline_entry_t *entry = (offline_entry_t *)buf_ptr;
     entry->addr.type = OFFLINE_TYPE_IFLUSH;
     entry->addr.addr = start;
@@ -360,6 +370,7 @@ offline_instru_t::append_iflush(byte *buf_ptr, addr_t start, size_t size)
     entry->addr.type = OFFLINE_TYPE_IFLUSH;
     entry->addr.addr = start + size;
     return 2 * sizeof(offline_entry_t);
+#endif
 }
 
 int
@@ -563,7 +574,7 @@ offline_instru_t::insert_save_pc(void *drcontext, instrlist_t *ilist, instr_t *w
                                  app_pc pc, uint instr_count, per_block_t *per_block)
 {
     offline_entry_t entry;
-    entry.pc.type = OFFLINE_TYPE_PC;
+    entry.pc.type = IF_X64_ELSE(OFFLINE_TYPE_PC_TOP_BIT, OFFLINE_TYPE_PC);
     app_pc modbase;
     uint modidx;
     uint64_t modoffs;

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * ******************************************************************************/
 
@@ -1005,7 +1005,8 @@ find_unfiltered_record(byte *start, byte *end)
     int num_memrefs = 0;
 
     for (offline_entry_t *entry = last; entry >= (offline_entry_t *)start; entry--) {
-        if (entry->pc.type == OFFLINE_TYPE_PC) {
+        if (entry->pc.type ==
+            OFFLINE_TYPE_PC IF_X64(|| entry->addr.type == OFFLINE_TYPE_PC_TOP_BIT)) {
             NOTIFY(4, "PC: instr count = %d, num_memrefs = %d\n", entry->pc.instr_count,
                    num_memrefs);
             if ((entry->pc.instr_count == 1 && num_memrefs > 0) ||

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2304,10 +2304,9 @@ raw2trace_t::could_entry_be_address(offline_entry_t entry)
     // We further handle Linear Address Masking LAM_48 by ensuring the top
     // bit matches bit 47 and either both are zero or bits 48..55 are canonical.
     char bits48_55 = (entry.combined_value >> 48) & 0xff;
-#ifdef X86
-    return TESTALL(0x80ff800000000000, entry.combined_value) ||
-        (bits48_55 == 0 || bits48_55 == static_cast<char>(0xff) ||
-         !TESTANY(0x8000800000000000, entry.combined_value));
+#ifdef X86_64
+    return !TESTANY(0x8000800000000000, entry.combined_value) || bits48_55 == 0 ||
+        bits48_55 == static_cast<char>(0xff);
 #else
     return bits48_55 == 0 || bits48_55 == static_cast<char>(0xff);
 #endif

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -457,7 +457,8 @@ raw2trace_t::process_offline_entry(raw2trace_thread_data_t *tdata,
             tdata->error = "memref entry found outside of bb";
             return false;
         }
-    } else if (in_entry->pc.type == OFFLINE_TYPE_PC) {
+    } else if (in_entry->pc.type ==
+               OFFLINE_TYPE_PC IF_X64(|| in_entry->pc.type == OFFLINE_TYPE_PC_TOP_BIT)) {
         if (reinterpret_cast<trace_entry_t *>(buf) != buf_base) {
             tdata->error = "We shouldn't have buffered anything before calling "
                            "append_bb_entries";
@@ -465,6 +466,7 @@ raw2trace_t::process_offline_entry(raw2trace_thread_data_t *tdata,
         }
         if (!append_bb_entries(tdata, in_entry, last_bb_handled))
             return false;
+#ifndef X64
     } else if (in_entry->addr.type == OFFLINE_TYPE_IFLUSH) {
         const offline_entry_t *entry = get_next_entry(tdata);
         if (entry == nullptr || entry->addr.type != OFFLINE_TYPE_IFLUSH) {
@@ -475,6 +477,7 @@ raw2trace_t::process_offline_entry(raw2trace_thread_data_t *tdata,
             (ptr_uint_t)entry->addr.addr);
         buf += trace_metadata_writer_t::write_iflush(
             buf, in_entry->addr.addr, (size_t)(entry->addr.addr - in_entry->addr.addr));
+#endif
     } else {
         std::stringstream ss;
         ss << "Unknown trace type " << (int)in_entry->timestamp.type;
@@ -1335,7 +1338,7 @@ raw2trace_t::do_conversion()
                 thread_data_[i]->syscall_traces_conversion_empty;
             syscall_traces_injected_ += thread_data_[i]->syscall_traces_injected;
             negative_times_corrected_ += thread_data_[i]->negative_times_corrected;
-            non_canonical_top_bytes_ += thread_data_[i]->non_canonical_top_bytes;
+            non_canonical_top_bits_ += thread_data_[i]->non_canonical_top_bits;
         }
     } else {
         // The files can be converted concurrently.
@@ -1369,7 +1372,7 @@ raw2trace_t::do_conversion()
             syscall_traces_conversion_empty_ += tdata->syscall_traces_conversion_empty;
             syscall_traces_injected_ += tdata->syscall_traces_injected;
             negative_times_corrected_ += tdata->negative_times_corrected;
-            non_canonical_top_bytes_ += tdata->non_canonical_top_bytes;
+            non_canonical_top_bits_ += tdata->non_canonical_top_bits;
         }
     }
     error = aggregate_and_write_schedule_files();
@@ -2298,8 +2301,16 @@ raw2trace_t::could_entry_be_address(offline_entry_t entry)
     // look for addresses by having those other types containn non-canonical
     // values in 48..55 (and all other records cannot appear where we look
     // for addresses).
+    // We further handle Linear Address Masking LAM_48 by ensuring the top
+    // bit matches bit 47 and either both are zero or bits 48..55 are canonical.
     char bits48_55 = (entry.combined_value >> 48) & 0xff;
+#ifdef X86
+    return TESTALL(0x80ff800000000000, entry.combined_value) ||
+        (bits48_55 == 0 || bits48_55 == static_cast<char>(0xff) ||
+         !TESTANY(0x8000800000000000, entry.combined_value));
+#else
     return bits48_55 == 0 || bits48_55 == static_cast<char>(0xff);
+#endif
 }
 
 bool
@@ -2368,13 +2379,13 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
         if (in_entry != nullptr && could_entry_be_address(*in_entry)) {
             // We've distinguished other types as documented under the
             // offline_type_t type, so we assume this is in fact an address
-            // and Top Byte Ignore is enabled in the hardware.
+            // and Top Byte Ignore or Linear Address Masking is enabled in the hardware.
             // We do not clear the top bits for remember_base or recording in
             // the trace: that's left to higher abstraction levels, and we need
             // the precise value for remember_base.
             log(2, "Found non-canonical-top-byte address 0x" ZHEX64_FORMAT_STRING "\n",
                 in_entry->combined_value);
-            accumulate_to_statistic(tdata, RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE, 1);
+            accumulate_to_statistic(tdata, RAW2TRACE_STAT_NON_CANONICAL_TOP_BITS, 1);
         } else if (expect_all_memrefs) {
             tdata->error = "Missing memref in block without predicated accesses";
             log(1,
@@ -3824,8 +3835,8 @@ raw2trace_t::accumulate_to_statistic(raw2trace_thread_data_t *tdata,
     case RAW2TRACE_STAT_NEGATIVE_TIMES_CORRECTED:
         tdata->negative_times_corrected += value;
         break;
-    case RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE:
-        tdata->non_canonical_top_bytes += value;
+    case RAW2TRACE_STAT_NON_CANONICAL_TOP_BITS:
+        tdata->non_canonical_top_bits += value;
         break;
     case RAW2TRACE_STAT_MAX:
     default: DR_ASSERT(false);
@@ -3854,7 +3865,7 @@ raw2trace_t::get_statistic(raw2trace_statistic_t stat)
         return syscall_traces_conversion_empty_;
     case RAW2TRACE_STAT_SYSCALL_TRACES_INJECTED: return syscall_traces_injected_;
     case RAW2TRACE_STAT_NEGATIVE_TIMES_CORRECTED: return negative_times_corrected_;
-    case RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE: return non_canonical_top_bytes_;
+    case RAW2TRACE_STAT_NON_CANONICAL_TOP_BITS: return non_canonical_top_bits_;
     case RAW2TRACE_STAT_MAX:
     default: DR_ASSERT(false); return 0;
     }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -126,8 +126,8 @@ typedef enum {
     RAW2TRACE_STAT_SYSCALL_TRACES_INJECTED,
     // Count of negative times that were corrected.
     RAW2TRACE_STAT_NEGATIVE_TIMES_CORRECTED,
-    // Count of addresses found with a non-canonical top byte.
-    RAW2TRACE_STAT_NON_CANONICAL_TOP_BYTE,
+    // Count of addresses found with non-canonical top bits.
+    RAW2TRACE_STAT_NON_CANONICAL_TOP_BITS,
     // We add a MAX member so that we can iterate over all stats in unit tests.
     RAW2TRACE_STAT_MAX,
 } raw2trace_statistic_t;
@@ -738,7 +738,7 @@ protected:
         uint64 syscall_traces_conversion_empty = 0;
         uint64 syscall_traces_injected = 0;
         uint64 negative_times_corrected = 0;
-        uint64 non_canonical_top_bytes = 0;
+        uint64 non_canonical_top_bits = 0;
 
         uint64 cur_chunk_instr_count = 0;
         uint64 cur_chunk_ref_count = 0;
@@ -1017,7 +1017,7 @@ protected:
     uint64 syscall_traces_conversion_empty_ = 0;
     uint64 syscall_traces_injected_ = 0;
     uint64 negative_times_corrected_ = 0;
-    uint64 non_canonical_top_bytes_ = 0;
+    uint64 non_canonical_top_bits_ = 0;
 
     std::unique_ptr<module_mapper_t> module_mapper_;
 


### PR DESCRIPTION
Switches to using a new block PC type OFFLINE_TYPE_PC_TOP_BIT for raw drmemtrace offline records in 64-bit mode.  This allows distinguishing addresses from PC records under Intel Linear Address Masking with bits 48..62 ignored.

Adds a test case to the unit tests.

Issue: #1734