### PR TITLE
i#7914 skipped memrefs: Record contiguous scatter/gather skipped memrefs

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -795,6 +795,19 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_KERNEL_EVENT_RAW,
 
+    /**
+     * Appears after an instruction fetch entry for an instruction with predicated,
+     * conditional, or masked memory references.  For each memory reference that did
+     * not actually occur as it was masked out or predicated false, this marker will
+     * be included.  The marker value is the memory address that would have been
+     * referenced.  Neither the memory reference size nor type (read or write) is
+     * included: it is assumed that they can be inferred from the instruction fetch
+     * entry.  This marker is meant for use by simulators for prefetching or other
+     * purposes performed by hardware before the mask or predication is resolved.
+     * Online traces do not contain these markers; only offline.
+     */
+    TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+
     // XXX: When adding a new type, if its value is an address, add it to
     // scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_canonicalize_addresses()
     // for auto-canonicalization support.
@@ -1071,6 +1084,10 @@ typedef enum {
     // field holds the type (OFFLINE_FILE_TYPE*), while valueB holds the
     // version (OFFLINE_FILE_VERSION*).
     OFFLINE_EXT_TYPE_HEADER,
+    // valueB holds the address of the base of a contiguous scatter/gather operation.
+    // This is used to produce TRACE_MARKER_TYPE_SKIPPED_MEMREF records.
+    // valueA is set to 1 to avoid this being confused with an address.
+    OFFLINE_EXT_TYPE_GATHER_BASE,
 } offline_ext_type_t;
 
 #define EXT_VALUE_A_BITS 48

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1086,7 +1086,7 @@ typedef enum {
     OFFLINE_EXT_TYPE_HEADER,
     // valueB holds the address of the base of a contiguous scatter/gather operation.
     // This is used to produce TRACE_MARKER_TYPE_SKIPPED_MEMREF records.
-    // valueA is set to 1 to avoid this being confused with an address.
+    // valueB is set to 1 to avoid this being confused with an address.
     OFFLINE_EXT_TYPE_GATHER_BASE,
 } offline_ext_type_t;
 

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -795,16 +795,23 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_KERNEL_EVENT_RAW,
 
+    // TODO i#7914: Once we've implemented support for all masked/predicated memrefs,
+    // increment the trace version.
     /**
      * Appears after an instruction fetch entry for an instruction with predicated,
      * conditional, or masked memory references.  For each memory reference that did
      * not actually occur as it was masked out or predicated false, this marker will
      * be included.  The marker value is the memory address that would have been
-     * referenced.  Neither the memory reference size nor type (read or write) is
-     * included: it is assumed that they can be inferred from the instruction fetch
-     * entry.  This marker is meant for use by simulators for prefetching or other
-     * purposes performed by hardware before the mask or predication is resolved.
-     * Online traces do not contain these markers; only offline.
+     * referenced.  For instructions with multiple memory references, these markers
+     * will appear at the same position a record for a real reference would appear:
+     * so for a contiguous scatter/gather these markers may be interleaved with
+     * regular records with the full set of markers and regular records fully
+     * covering all possible references.  Neither the memory reference size nor type
+     * (read or write) is included: it is assumed that they can be inferred from the
+     * instruction fetch entry.  This marker is meant for use by simulators for
+     * prefetching or other purposes performed by hardware before the mask or
+     * predication is resolved.  Online traces do not contain these markers; only
+     * offline.
      */
     TRACE_MARKER_TYPE_SKIPPED_MEMREF,
 
@@ -1086,8 +1093,12 @@ typedef enum {
     OFFLINE_EXT_TYPE_HEADER,
     // valueB holds the address of the base of a contiguous scatter/gather operation.
     // This is used to produce TRACE_MARKER_TYPE_SKIPPED_MEMREF records.
-    // valueB is set to 1 to avoid this being confused with an address.
-    OFFLINE_EXT_TYPE_GATHER_BASE,
+    // valueB is set to 1 to avoid this being confused with an address (see
+    // Top Byte Ignore comments).
+    // Since valueB only holds 48 bits this does not preserve the top bits.
+    // TODO i#7914: Store a different sentinel in valueB when the top bits
+    // in canonical form should be 1's.
+    OFFLINE_EXT_TYPE_SCATTER_GATHER_BASE,
 } offline_ext_type_t;
 
 #define EXT_VALUE_A_BITS 48

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -566,6 +566,7 @@ Total counts:
            0 total physical address unavailable markers
           75 total system call number markers
            0 total blocking system call markers
+           0 total skipped memref markers
           12 total other markers
            0 total encodings
 Thread 64951 counts:
@@ -589,6 +590,7 @@ Thread 64951 counts:
            0 physical address unavailable markers
           56 system call number markers
            0 blocking system call markers
+           0 skipped memref markers
            4 other markers
            0 encodings
 Thread 64958 counts:
@@ -612,6 +614,7 @@ Thread 64958 counts:
            0 physical address unavailable markers
            9 system call number markers
            0 blocking system call markers
+           0 skipped memref markers
            4 other markers
            0 encodings
 Thread 64959 counts:
@@ -635,6 +638,7 @@ Thread 64959 counts:
            0 physical address unavailable markers
           10 system call number markers
            0 blocking system call markers
+           0 skipped memref markers
            4 other markers
            0 encodings
 \endcode

--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -32,6 +32,7 @@ Total counts:
            0 total physical address unavailable markers
           14 total system call number markers
            0 total blocking system call markers
+           0 total skipped memref markers
            4 total other markers
          114 total encodings
 Thread [0-9]* counts:
@@ -55,5 +56,6 @@ Thread [0-9]* counts:
            0 physical address unavailable markers
           14 system call number markers
            0 blocking system call markers
+           0 skipped memref markers
            4 other markers
          114 encodings

--- a/clients/drcachesim/tests/allasm_scattergather_aarch64.asm
+++ b/clients/drcachesim/tests/allasm_scattergather_aarch64.asm
@@ -80,7 +80,6 @@
  */
 
 test_scalar_plus_vector:
-#if 0 //NOCHECK
         // ld1b scalar+vector
         ld1b    DEST_REG1.s, S_MASK_REG/z, [BUFFER_REG, S_INDEX_REG.s, uxtw] // 4
         ld1b    DEST_REG1.s, S_MASK_REG/z, [BUFFER_REG, S_INDEX_REG.s, sxtw] // 4
@@ -256,14 +255,13 @@ test_scalar_plus_vector:
         st1d    SRC_REG1.d, D_MASK_REG, [BUFFER_REG, D_INDEX_REG.d, lsl #3]  // 2
         st1d    SRC_REG1.d, D_MASK_REG, [BUFFER_REG, D_INDEX_REG.d]          // 2
                                                                              // Total: 12
-#endif
+
         // Total stores: 14 + 28 + 28 + 12 = 82
 
         ret
 
 
 test_vector_plus_immediate:
-#if 0 //NOCHECK
         ld1b    DEST_REG1.d, D_MASK_REG/z, [Z_BASE_REG.d, #0] // 2
         ldff1b  DEST_REG1.d, D_MASK_REG/z, [Z_BASE_REG.d, #0] // 2
         ld1sb   DEST_REG1.d, D_MASK_REG/z, [Z_BASE_REG.d, #0] // 2
@@ -287,11 +285,10 @@ test_vector_plus_immediate:
         st1d    SRC_REG1.d, D_MASK_REG, [Z_BASE_REG.d, #0] // 2
 
         // Total stores: 8
-#endif
+
         ret
 
 test_scalar_plus_scalar:
-#if 0 //NOCHECK
         ld1b     DEST_REG1.b, B_MASK_REG/z, [BUFFER_REG, X_INDEX_REG]         // 16
         ld1b     DEST_REG1.h, H_MASK_REG/z, [BUFFER_REG, X_INDEX_REG]         // 8
         ld1b     DEST_REG1.s, S_MASK_REG/z, [BUFFER_REG, X_INDEX_REG]         // 4
@@ -381,7 +378,7 @@ test_scalar_plus_scalar:
                                                                                                                     // Total: 120
 
         // Total stores: 52 + 60 + 90 + 120 = 322
-#endif
+
         ret
 
 

--- a/clients/drcachesim/tests/allasm_scattergather_aarch64.asm
+++ b/clients/drcachesim/tests/allasm_scattergather_aarch64.asm
@@ -80,6 +80,7 @@
  */
 
 test_scalar_plus_vector:
+#if 0 //NOCHECK
         // ld1b scalar+vector
         ld1b    DEST_REG1.s, S_MASK_REG/z, [BUFFER_REG, S_INDEX_REG.s, uxtw] // 4
         ld1b    DEST_REG1.s, S_MASK_REG/z, [BUFFER_REG, S_INDEX_REG.s, sxtw] // 4
@@ -255,13 +256,14 @@ test_scalar_plus_vector:
         st1d    SRC_REG1.d, D_MASK_REG, [BUFFER_REG, D_INDEX_REG.d, lsl #3]  // 2
         st1d    SRC_REG1.d, D_MASK_REG, [BUFFER_REG, D_INDEX_REG.d]          // 2
                                                                              // Total: 12
-
+#endif
         // Total stores: 14 + 28 + 28 + 12 = 82
 
         ret
 
 
 test_vector_plus_immediate:
+#if 0 //NOCHECK
         ld1b    DEST_REG1.d, D_MASK_REG/z, [Z_BASE_REG.d, #0] // 2
         ldff1b  DEST_REG1.d, D_MASK_REG/z, [Z_BASE_REG.d, #0] // 2
         ld1sb   DEST_REG1.d, D_MASK_REG/z, [Z_BASE_REG.d, #0] // 2
@@ -285,10 +287,11 @@ test_vector_plus_immediate:
         st1d    SRC_REG1.d, D_MASK_REG, [Z_BASE_REG.d, #0] // 2
 
         // Total stores: 8
-
+#endif
         ret
 
 test_scalar_plus_scalar:
+#if 0 //NOCHECK
         ld1b     DEST_REG1.b, B_MASK_REG/z, [BUFFER_REG, X_INDEX_REG]         // 16
         ld1b     DEST_REG1.h, H_MASK_REG/z, [BUFFER_REG, X_INDEX_REG]         // 8
         ld1b     DEST_REG1.s, S_MASK_REG/z, [BUFFER_REG, X_INDEX_REG]         // 4
@@ -378,7 +381,7 @@ test_scalar_plus_scalar:
                                                                                                                     // Total: 120
 
         // Total stores: 52 + 60 + 90 + 120 = 322
-
+#endif
         ret
 
 

--- a/clients/drcachesim/tests/basic_counts.templatex
+++ b/clients/drcachesim/tests/basic_counts.templatex
@@ -45,6 +45,7 @@ Total counts:
      .* total physical address unavailable markers
      .* total system call number markers
      .* total blocking system call markers
+     .* total skipped memref markers
      .* total other markers
      .* total encodings
 Thread .* counts:
@@ -72,5 +73,6 @@ Thread .* counts:
      .* physical address unavailable markers
      .* system call number markers
      .* blocking system call markers
+     .* skipped memref markers
      .* other markers
      .* encodings

--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -91,6 +91,7 @@ Total counts:
            0 total physical address unavailable markers
          480 total system call number markers
          183 total blocking system call markers
+           0 total skipped memref markers
          316 total other markers
        21842 total encodings
 Core [0-9] counts:

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -31,6 +31,7 @@ Total counts:
            0 total physical address unavailable markers
           14 total system call number markers
           12 total blocking system call markers
+           0 total skipped memref markers
            5 total other markers
           38 total encodings
 Thread [0-9]* counts:
@@ -54,5 +55,6 @@ Thread [0-9]* counts:
            0 physical address unavailable markers
           14 system call number markers
           12 blocking system call markers
+           0 skipped memref markers
            5 other markers
           38 encodings

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-aarch64.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-aarch64.templatex
@@ -38,6 +38,24 @@ Total counts:
            1 total threads
      .* total timestamp \+ cpuid markers
 .*
+#ifdef __ARM_FEATURE_SVE2
+#if (__ARM_FEATURE_SVE_BITS == 128)
+        2956 total skipped memref markers
+#elif (__ARM_FEATURE_SVE_BITS == 256)
+// TODO i#7914: Fill in expected value.
+#elif (__ARM_FEATURE_SVE_BITS == 512)
+// TODO i#7914: Fill in expected value.
+#endif /* __ARM_FEATURE_SVE_BITS */
+#else
+#if (__ARM_FEATURE_SVE_BITS == 128)
+// TODO i#7914: Fill in expected value.
+#elif (__ARM_FEATURE_SVE_BITS == 256)
+// TODO i#7914: Fill in expected value.
+#elif (__ARM_FEATURE_SVE_BITS == 512)
+// TODO i#7914: Fill in expected value.
+#endif /* __ARM_FEATURE_SVE_BITS */
+#endif /* __ARM_FEATURE_SVE2 */
+.*
 Thread .* counts:
 #ifdef __ARM_FEATURE_SVE2
          997 \(fetched\) instructions

--- a/clients/drcachesim/tests/offline-basic_counts.templatex
+++ b/clients/drcachesim/tests/offline-basic_counts.templatex
@@ -43,8 +43,8 @@ Total counts:
      .* total physical address \+ virtual address marker pairs
      .* total physical address unavailable markers
      .* total system call number markers
-     .* total skipped memref markers
      .* total blocking system call markers
+     .* total skipped memref markers
      .* total other markers
      .* total encodings
 Thread .* counts:

--- a/clients/drcachesim/tests/offline-basic_counts.templatex
+++ b/clients/drcachesim/tests/offline-basic_counts.templatex
@@ -43,6 +43,7 @@ Total counts:
      .* total physical address \+ virtual address marker pairs
      .* total physical address unavailable markers
      .* total system call number markers
+     .* total skipped memref markers
      .* total blocking system call markers
      .* total other markers
      .* total encodings
@@ -71,5 +72,6 @@ Thread .* counts:
      .* physical address unavailable markers
      .* system call number markers
      .* blocking system call markers
+     .* skipped memref markers
      .* other markers
      .* encodings

--- a/clients/drcachesim/tests/offline-legacy-int-offs.templatex
+++ b/clients/drcachesim/tests/offline-legacy-int-offs.templatex
@@ -26,6 +26,7 @@ Total counts:
            0 total physical address unavailable markers
            0 total system call number markers
            0 total blocking system call markers
+           0 total skipped memref markers
           16 total other markers
         8426 total encodings
 Thread 552306 counts:
@@ -49,6 +50,7 @@ Thread 552306 counts:
            0 physical address unavailable markers
            0 system call number markers
            0 blocking system call markers
+           0 skipped memref markers
            8 other markers
         6390 encodings
 Thread 552323 counts:
@@ -72,6 +74,7 @@ Thread 552323 counts:
            0 physical address unavailable markers
            0 system call number markers
            0 blocking system call markers
+           0 skipped memref markers
            4 other markers
         1028 encodings
 Thread 552324 counts:
@@ -95,6 +98,7 @@ Thread 552324 counts:
            0 physical address unavailable markers
            0 system call number markers
            0 blocking system call markers
+           0 skipped memref markers
            4 other markers
         1008 encodings
 #else

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -70,7 +70,7 @@ Window #0:
            0 window physical address unavailable markers
            1 window system call number markers
            0 window blocking system call markers
-           0 skipped memref markers
+           0 window skipped memref markers
            6 window other markers
            8 window encodings
 Window #1:

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -45,6 +45,7 @@ Total counts:
            0 total physical address unavailable markers
            7 total system call number markers
            6 total blocking system call markers
+           0 total skipped memref markers
           13 total other markers
           25 total encodings
 Total windows: 8
@@ -69,6 +70,7 @@ Window #0:
            0 window physical address unavailable markers
            1 window system call number markers
            0 window blocking system call markers
+           0 skipped memref markers
            6 window other markers
            8 window encodings
 Window #1:
@@ -92,6 +94,7 @@ Window #1:
            0 window physical address unavailable markers
            1 window system call number markers
            1 window blocking system call markers
+           0 window skipped memref markers
            1 window other markers
            9 window encodings
 Window #2:
@@ -115,6 +118,7 @@ Window #2:
            0 window physical address unavailable markers
            1 window system call number markers
            1 window blocking system call markers
+           0 window skipped memref markers
            1 window other markers
            3 window encodings
 Window #3:
@@ -138,6 +142,7 @@ Window #3:
            0 window physical address unavailable markers
            1 window system call number markers
            1 window blocking system call markers
+           0 window skipped memref markers
            1 window other markers
            0 window encodings
 Window #4:
@@ -161,6 +166,7 @@ Window #4:
            0 window physical address unavailable markers
            1 window system call number markers
            1 window blocking system call markers
+           0 window skipped memref markers
            1 window other markers
            0 window encodings
 Window #5:
@@ -184,6 +190,7 @@ Window #5:
            0 window physical address unavailable markers
            1 window system call number markers
            1 window blocking system call markers
+           0 window skipped memref markers
            1 window other markers
            0 window encodings
 Window #6:
@@ -207,6 +214,7 @@ Window #6:
            0 window physical address unavailable markers
            1 window system call number markers
            1 window blocking system call markers
+           0 window skipped memref markers
            1 window other markers
            5 window encodings
 Window #7:
@@ -230,6 +238,7 @@ Window #7:
            0 window physical address unavailable markers
            0 window system call number markers
            0 window blocking system call markers
+           0 window skipped memref markers
            1 window other markers
            0 window encodings
 Thread [0-9]* counts:
@@ -253,5 +262,6 @@ Thread [0-9]* counts:
            0 physical address unavailable markers
            1 system call number markers
            0 blocking system call markers
+           0 window skipped memref markers
            6 other markers
            8 encodings

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -262,6 +262,6 @@ Thread [0-9]* counts:
            0 physical address unavailable markers
            1 system call number markers
            0 blocking system call markers
-           0 window skipped memref markers
+           0 skipped memref markers
            6 other markers
            8 encodings

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -309,6 +309,17 @@ make_marker(uint64_t type, int64_t value)
     return entry;
 }
 
+offline_entry_t
+make_gather_base(uint64_t addr)
+{
+    offline_entry_t entry;
+    entry.extended.type = OFFLINE_TYPE_EXTENDED;
+    entry.extended.ext = OFFLINE_EXT_TYPE_GATHER_BASE;
+    entry.extended.valueA = addr;
+    entry.extended.valueB = 1;
+    return entry;
+}
+
 bool
 check_entry(std::vector<trace_entry_t> &entries, int &idx, unsigned short expected_type,
             int expected_size, addr_t expected_addr = 0)
@@ -4385,6 +4396,238 @@ test_missing_memref(void *drcontext)
     return true;
 }
 
+bool
+test_skipped_memrefs(void *drcontext)
+{
+#ifdef AARCH64
+    std::cerr << "\n===============\nTesting skipped memrefs\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    constexpr int VECTOR_LENGTH = 16; // In bytes.
+    dr_set_vector_length(VECTOR_LENGTH * 8);
+    // First we do reg+imm memref with different element sizes and vector counts.
+    // Test with a displacement.
+    constexpr int DISP = VECTOR_LENGTH;
+    instr_t *ld1b_imm = INSTR_CREATE_ld1b_sve_pred(
+        drcontext, opnd_create_reg_element_vector(DR_REG_Z12, OPSZ_1),
+        opnd_create_predicate_reg(DR_REG_P4, /*is_merge=*/false),
+        opnd_create_base_disp(REG2, DR_REG_NULL, 0, DISP, OPSZ_1));
+    // Test with elision (base addr hasn't changed).
+    instr_t *ld1h_imm = INSTR_CREATE_ld1h_sve_pred(
+        drcontext, opnd_create_reg_element_vector(DR_REG_Z12, OPSZ_2),
+        opnd_create_predicate_reg(DR_REG_P4, /*is_merge=*/false),
+        opnd_create_base_disp(REG2, DR_REG_NULL, 0, 0, OPSZ_2));
+    // Clear the base so no elision.
+    instr_t *move =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instr_t *ld2w_imm = INSTR_CREATE_ld2w_sve_pred(
+        drcontext, opnd_create_reg_element_vector(DR_REG_Z12, OPSZ_4),
+        opnd_create_predicate_reg(DR_REG_P4, /*is_merge=*/false),
+        opnd_create_base_disp(REG2, DR_REG_NULL, 0, 0, OPSZ_4));
+    instr_t *ld4d_imm = INSTR_CREATE_ld4d_sve_pred(
+        drcontext, opnd_create_reg_element_vector(DR_REG_Z12, OPSZ_8),
+        opnd_create_predicate_reg(DR_REG_P4, /*is_merge=*/false),
+        // REG1 so no elision.
+        opnd_create_base_disp(REG1, DR_REG_NULL, 0, 0, OPSZ_8));
+    // Test reg+reg.
+    instr_t *st1w_reg = INSTR_CREATE_st1w_sve_pred(
+        drcontext, opnd_create_reg_element_vector(DR_REG_Z12, OPSZ_4),
+        opnd_create_predicate_reg(DR_REG_P4, /*is_merge=*/false),
+        opnd_create_base_disp_shift_aarch64(REG2, REG1, DR_EXTEND_UXTX, /*scaled=*/true,
+                                            0, DR_OPND_DEFAULT, OPSZ_4, 2));
+
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, ld1b_imm);
+    instrlist_append(ilist, ld1h_imm);
+    instrlist_append(ilist, move);
+    instrlist_append(ilist, ld2w_imm);
+    instrlist_append(ilist, ld4d_imm);
+    instrlist_append(ilist, st1w_reg);
+
+    size_t offs_nop = 0;
+    size_t offs_ld1b_imm = offs_nop + instr_length(drcontext, nop);
+    size_t offs_ld1h_imm = offs_ld1b_imm + instr_length(drcontext, ld1b_imm);
+    size_t offs_move = offs_ld1h_imm + instr_length(drcontext, ld1h_imm);
+    size_t offs_ld2w_imm = offs_move + instr_length(drcontext, move);
+    size_t offs_ld4d_imm = offs_ld2w_imm + instr_length(drcontext, ld2w_imm);
+    size_t offs_st1w_reg = offs_ld4d_imm + instr_length(drcontext, ld4d_imm);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_VECTOR_LENGTH, VECTOR_LENGTH));
+    constexpr uint64_t TIME_VALUE = 0x0013000000000000;
+    raw.push_back(make_timestamp(TIME_VALUE));
+    raw.push_back(make_core());
+    // The ld1b's non-masked-out addresses are every other one.
+    raw.push_back(make_block(offs_ld1b_imm, 1));
+    constexpr uint64_t BASE_ADDR_LD1B = 0x1234;
+    // The tracer stores addresses w/o the disp.
+    raw.push_back(make_gather_base(BASE_ADDR_LD1B - DISP));
+    raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 1));
+    raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 3));
+    raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 5));
+    raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 7));
+    raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 9));
+    raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 11));
+    raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 13));
+    raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 15));
+    // The ld1h's non-masked-out addresses are just the last 2.
+    raw.push_back(make_block(offs_ld1h_imm, 1));
+    constexpr uint64_t BASE_ADDR_LD1H = 0x123456;
+    raw.push_back(make_gather_base(BASE_ADDR_LD1H));
+    raw.push_back(make_memref(BASE_ADDR_LD1H + 12));
+    raw.push_back(make_memref(BASE_ADDR_LD1H + 14));
+    raw.push_back(make_block(offs_move, 1));
+    // The ld2w's non-masked-out addresses are just the first 2.
+    raw.push_back(make_block(offs_ld2w_imm, 1));
+    constexpr uint64_t BASE_ADDR_LD2W = 0x12345678;
+    raw.push_back(make_gather_base(BASE_ADDR_LD2W));
+    raw.push_back(make_memref(BASE_ADDR_LD2W + 0));
+    raw.push_back(make_memref(BASE_ADDR_LD2W + 4));
+    // The ld4d has no masked-out addresses.
+    raw.push_back(make_block(offs_ld4d_imm, 1));
+    constexpr uint64_t BASE_ADDR_LD4D = 0x5678;
+    raw.push_back(make_gather_base(BASE_ADDR_LD4D));
+    raw.push_back(make_memref(BASE_ADDR_LD4D + 0));
+    raw.push_back(make_memref(BASE_ADDR_LD4D + 8));
+    raw.push_back(make_memref(BASE_ADDR_LD4D + 16));
+    raw.push_back(make_memref(BASE_ADDR_LD4D + 24));
+    raw.push_back(make_memref(BASE_ADDR_LD4D + 32));
+    raw.push_back(make_memref(BASE_ADDR_LD4D + 40));
+    raw.push_back(make_memref(BASE_ADDR_LD4D + 48));
+    raw.push_back(make_memref(BASE_ADDR_LD4D + 56));
+    // The st1w has all addresses masked out.
+    raw.push_back(make_block(offs_st1w_reg, 1));
+    constexpr uint64_t BASE_ADDR_ST1W = 0x4320;
+    // This is reg+reg with no displacement.
+    raw.push_back(make_gather_base(BASE_ADDR_ST1W));
+    raw.push_back(make_timestamp(TIME_VALUE));
+    raw.push_back(make_core());
+    raw.push_back(make_exit());
+
+    std::vector<uint64_t> stats;
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries, &stats))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VECTOR_LENGTH,
+                    VECTOR_LENGTH) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,
+                    TIME_VALUE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        // The ld1b.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_ld1b_imm) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1B) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1B + 1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1B + 2) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1B + 3) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1B + 4) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1B + 5) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1B + 6) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1B + 7) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1B + 8) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1B + 9) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1B + 10) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1B + 11) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1B + 12) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1B + 13) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1B + 14) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1B + 15) &&
+        // The ld1h.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_ld1h_imm) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1H) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1H + 2) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1H + 4) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1H + 6) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1H + 8) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD1H + 10) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1H + 12) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD1H + 14) &&
+        // The move.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move) &&
+        // The ld2w.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_ld2w_imm) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD2W) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD2W + 4) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD2W + 8) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD2W + 12) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD2W + 16) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD2W + 20) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD2W + 24) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_LD2W + 28) &&
+        // The ld4d.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_ld4d_imm) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD4D) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD4D + 8) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD4D + 16) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD4D + 24) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD4D + 32) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD4D + 40) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD4D + 48) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1, BASE_ADDR_LD4D + 56) &&
+        // The st1w.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_st1w_reg) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_ST1W) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_ST1W + 4) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_ST1W + 8) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SKIPPED_MEMREF,
+                    BASE_ADDR_ST1W + 12) &&
+        // Tail of trace.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,
+                    TIME_VALUE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+#elif defined(X86)
+    // TODO i#7914: Add x86 contiguous skipped memref support.
+    return true;
+#else
+    // Not supported in tracer so no tests here.
+    return true;
+#endif
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -4411,7 +4654,7 @@ test_main(int argc, const char *argv[])
         !test_is_maybe_blocking_syscall(drcontext) || !test_ifiltered(drcontext) ||
         !test_asynchronous_signal(drcontext) || !test_syscall_injection(drcontext) ||
         !test_negative_timestamps(drcontext) || !test_top_byte_ignore(drcontext) ||
-        !test_missing_memref(drcontext))
+        !test_missing_memref(drcontext) || !test_skipped_memrefs(drcontext))
         return 1;
     return 0;
 }

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -314,7 +314,7 @@ make_gather_base(uint64_t addr)
 {
     offline_entry_t entry;
     entry.extended.type = OFFLINE_TYPE_EXTENDED;
-    entry.extended.ext = OFFLINE_EXT_TYPE_GATHER_BASE;
+    entry.extended.ext = OFFLINE_EXT_TYPE_SCATTER_GATHER_BASE;
     entry.extended.valueA = addr;
     entry.extended.valueB = 1;
     return entry;
@@ -4403,21 +4403,23 @@ test_skipped_memrefs(void *drcontext)
     std::cerr << "\n===============\nTesting skipped memrefs\n";
     instrlist_t *ilist = instrlist_create(drcontext);
     instr_t *nop = XINST_CREATE_nop(drcontext);
-    constexpr int VECTOR_LENGTH = 16; // In bytes.
-    dr_set_vector_length(VECTOR_LENGTH * 8);
+    constexpr int VECTOR_LENGTH_BYTES = 16; // In bytes.
+    dr_set_vector_length(VECTOR_LENGTH_BYTES * 8);
     // First we do reg+imm memref with different element sizes and vector counts.
     // Test with a displacement.
-    constexpr int DISP = VECTOR_LENGTH;
+    constexpr int DISP = VECTOR_LENGTH_BYTES;
     instr_t *ld1b_imm = INSTR_CREATE_ld1b_sve_pred(
         drcontext, opnd_create_reg_element_vector(DR_REG_Z12, OPSZ_1),
         opnd_create_predicate_reg(DR_REG_P4, /*is_merge=*/false),
         opnd_create_base_disp(REG2, DR_REG_NULL, 0, DISP, OPSZ_1));
-    // Test with elision (base addr hasn't changed).
+    // Test with the potential for elision (base register hasn't changed) -- though
+    // today we won't elide b/c these are in separate blocks and we avoid elision
+    // for predicated/conditional.
     instr_t *ld1h_imm = INSTR_CREATE_ld1h_sve_pred(
         drcontext, opnd_create_reg_element_vector(DR_REG_Z12, OPSZ_2),
         opnd_create_predicate_reg(DR_REG_P4, /*is_merge=*/false),
         opnd_create_base_disp(REG2, DR_REG_NULL, 0, 0, OPSZ_2));
-    // Clear the base so no elision.
+    // Clear the base so no elision for sure (though today there's already none).
     instr_t *move =
         XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
     instr_t *ld2w_imm = INSTR_CREATE_ld2w_sve_pred(
@@ -4457,7 +4459,7 @@ test_skipped_memrefs(void *drcontext)
     raw.push_back(make_tid());
     raw.push_back(make_pid());
     raw.push_back(make_line_size());
-    raw.push_back(make_marker(TRACE_MARKER_TYPE_VECTOR_LENGTH, VECTOR_LENGTH));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_VECTOR_LENGTH, VECTOR_LENGTH_BYTES));
     constexpr uint64_t TIME_VALUE = 0x0013000000000000;
     raw.push_back(make_timestamp(TIME_VALUE));
     raw.push_back(make_core());
@@ -4476,12 +4478,12 @@ test_skipped_memrefs(void *drcontext)
     raw.push_back(make_memref(BASE_ADDR_LD1B - DISP + 15));
     // The ld1h's non-masked-out addresses are just the last 2.
     raw.push_back(make_block(offs_ld1h_imm, 1));
-    constexpr uint64_t BASE_ADDR_LD1H = 0x123456;
+    constexpr uint64_t BASE_ADDR_LD1H = BASE_ADDR_LD1B - DISP;
     raw.push_back(make_gather_base(BASE_ADDR_LD1H));
     raw.push_back(make_memref(BASE_ADDR_LD1H + 12));
     raw.push_back(make_memref(BASE_ADDR_LD1H + 14));
     raw.push_back(make_block(offs_move, 1));
-    // The ld2w's non-masked-out addresses are just the first 2.
+    // The ld2w just has one non-masked entry, so 2 addresses (one for each vector).
     raw.push_back(make_block(offs_ld2w_imm, 1));
     constexpr uint64_t BASE_ADDR_LD2W = 0x12345678;
     raw.push_back(make_gather_base(BASE_ADDR_LD2W));
@@ -4523,7 +4525,7 @@ test_skipped_memrefs(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_MARKER,
                     TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VECTOR_LENGTH,
-                    VECTOR_LENGTH) &&
+                    VECTOR_LENGTH_BYTES) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,
                     TIME_VALUE) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -217,6 +217,9 @@ basic_counts_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             case TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL:
                 ++counters->syscall_blocking_markers;
                 break;
+            case TRACE_MARKER_TYPE_SKIPPED_MEMREF:
+                ++counters->skipped_memref_markers;
+                break;
             case TRACE_MARKER_TYPE_SYSCALL_TRACE_START:
             case TRACE_MARKER_TYPE_CONTEXT_SWITCH_START:
                 per_shard->is_kernel = true;
@@ -340,6 +343,8 @@ basic_counts_t::print_counters(const counters_t &counters, const std::string &pr
               << " system call number markers\n";
     std::cerr << std::setw(12) << counters.syscall_blocking_markers << prefix
               << " blocking system call markers\n";
+    std::cerr << std::setw(12) << counters.skipped_memref_markers << prefix
+              << " skipped memref markers\n";
     std::cerr << std::setw(12) << counters.other_markers << prefix << " other markers\n";
     std::cerr << std::setw(12) << counters.encodings << prefix << " encodings\n";
 }

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -115,6 +115,7 @@ public:
             phys_unavail_markers += rhs.phys_unavail_markers;
             syscall_number_markers += rhs.syscall_number_markers;
             syscall_blocking_markers += rhs.syscall_blocking_markers;
+            skipped_memref_markers += rhs.skipped_memref_markers;
             other_markers += rhs.other_markers;
             icache_flushes += rhs.icache_flushes;
             dcache_flushes += rhs.dcache_flushes;
@@ -151,6 +152,7 @@ public:
             phys_unavail_markers -= rhs.phys_unavail_markers;
             syscall_number_markers -= rhs.syscall_number_markers;
             syscall_blocking_markers -= rhs.syscall_blocking_markers;
+            skipped_memref_markers -= rhs.skipped_memref_markers;
             other_markers -= rhs.other_markers;
             icache_flushes -= rhs.icache_flushes;
             dcache_flushes -= rhs.dcache_flushes;
@@ -187,6 +189,7 @@ public:
                 phys_unavail_markers == rhs.phys_unavail_markers &&
                 syscall_number_markers == rhs.syscall_number_markers &&
                 syscall_blocking_markers == rhs.syscall_blocking_markers &&
+                skipped_memref_markers == rhs.skipped_memref_markers &&
                 other_markers == rhs.other_markers &&
                 icache_flushes == rhs.icache_flushes &&
                 dcache_flushes == rhs.dcache_flushes && encodings == rhs.encodings &&
@@ -215,6 +218,7 @@ public:
         int64_t phys_unavail_markers = 0;
         int64_t syscall_number_markers = 0;
         int64_t syscall_blocking_markers = 0;
+        int64_t skipped_memref_markers = 0;
         int64_t other_markers = 0;
         int64_t icache_flushes = 0;
         int64_t dcache_flushes = 0;

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -466,6 +466,10 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         case TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN:
             std::cerr << "<marker: hardware context return\n";
             break;
+        case TRACE_MARKER_TYPE_SKIPPED_MEMREF:
+            std::cerr << "<marker: skipped memref 0x" << std::hex
+                      << memref.marker.marker_value << std::dec << "\n";
+            break;
         default:
             std::cerr << "<marker: type " << memref.marker.marker_type << "; value "
                       << memref.marker.marker_value << ">\n";

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -268,6 +268,10 @@ public:
     instrument_rseq_entry(void *drcontext, instrlist_t *ilist, instr_t *where,
                           instr_t *rseq_label, reg_id_t reg_ptr, int adjust) = 0;
 
+    virtual int
+    instrument_gather_base(void *drcontext, instrlist_t *ilist, instr_t *where,
+                           reg_id_t reg_ptr, int adjust, opnd_t ref) = 0;
+
     virtual void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
                 bool repstr_expanded, bool memref_needs_full_info) = 0;
@@ -387,6 +391,10 @@ public:
     instrument_rseq_entry(void *drcontext, instrlist_t *ilist, instr_t *where,
                           instr_t *rseq_label, reg_id_t reg_ptr, int adjust) override;
 
+    int
+    instrument_gather_base(void *drcontext, instrlist_t *ilist, instr_t *where,
+                           reg_id_t reg_ptr, int adjust, opnd_t ref) override;
+
     void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
                 bool repstr_expanded, bool memref_needs_full_info) override;
@@ -473,6 +481,10 @@ public:
     int
     instrument_rseq_entry(void *drcontext, instrlist_t *ilist, instr_t *where,
                           instr_t *rseq_label, reg_id_t reg_ptr, int adjust) override;
+
+    int
+    instrument_gather_base(void *drcontext, instrlist_t *ilist, instr_t *where,
+                           reg_id_t reg_ptr, int adjust, opnd_t ref) override;
 
     void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -885,10 +885,13 @@ offline_instru_t::instrument_gather_base(void *drcontext, instrlist_t *ilist,
     MINSERT(
         ilist, where,
         INSTR_CREATE_or(drcontext, opnd_create_reg(reg_addr), opnd_create_reg(reg_ptr)));
-#else
+#elif defined(AARCH64)
     MINSERT(ilist, where,
             INSTR_CREATE_orr(drcontext, opnd_create_reg(reg_addr),
                              opnd_create_reg(reg_addr), opnd_create_reg(reg_ptr)));
+#else
+    DR_ASSERT(false && "Only x86 and aarch64 are supported for scatter/gather skips");
+    return 0;
 #endif
     // Re-load because reg_ptr was clobbered.
     insert_load_buf_ptr_(drcontext, ilist, where, reg_ptr);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -844,6 +844,63 @@ offline_instru_t::instrument_rseq_entry(void *drcontext, instrlist_t *ilist,
     return adjust;
 }
 
+int
+offline_instru_t::instrument_gather_base(void *drcontext, instrlist_t *ilist,
+                                         instr_t *where, reg_id_t reg_ptr, int adjust,
+                                         opnd_t ref)
+{
+    int disp = adjust;
+    reg_id_t reg_addr = DR_REG_NULL;
+    drreg_status_t res =
+        drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_addr);
+    DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
+    bool reg_ptr_used;
+    insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref, &reg_ptr_used);
+    // Now set the top bits (we don't care if we lose top bits of non-canonical addrs).
+    offline_entry_t entry_top_zero;
+    entry_top_zero.extended.type = 0;
+    entry_top_zero.extended.ext = 0;
+    entry_top_zero.extended.valueB = 0;
+    entry_top_zero.extended.valueA = 0xffffffffffff;
+    instrlist_insert_mov_immed_ptrsz(drcontext, (ptr_int_t)entry_top_zero.combined_value,
+                                     opnd_create_reg(reg_ptr), ilist, where, NULL, NULL);
+#ifdef X86
+    MINSERT(
+        ilist, where,
+        INSTR_CREATE_and(drcontext, opnd_create_reg(reg_addr), opnd_create_reg(reg_ptr)));
+#else
+    MINSERT(ilist, where,
+            INSTR_CREATE_and(drcontext, opnd_create_reg(reg_addr),
+                             opnd_create_reg(reg_addr), opnd_create_reg(reg_ptr)));
+#endif
+    offline_entry_t entry_top_set;
+    entry_top_set.extended.type = OFFLINE_TYPE_EXTENDED;
+    entry_top_set.extended.ext = OFFLINE_EXT_TYPE_GATHER_BASE;
+    // We set a bit here to avoid this being confused with an address.
+    entry_top_set.extended.valueB = 1;
+    entry_top_set.extended.valueA = 0;
+    instrlist_insert_mov_immed_ptrsz(drcontext, (ptr_int_t)entry_top_set.combined_value,
+                                     opnd_create_reg(reg_ptr), ilist, where, NULL, NULL);
+#ifdef X86
+    MINSERT(
+        ilist, where,
+        INSTR_CREATE_or(drcontext, opnd_create_reg(reg_addr), opnd_create_reg(reg_ptr)));
+#else
+    MINSERT(ilist, where,
+            INSTR_CREATE_orr(drcontext, opnd_create_reg(reg_addr),
+                             opnd_create_reg(reg_addr), opnd_create_reg(reg_ptr)));
+#endif
+    // Re-load because reg_ptr was clobbered.
+    insert_load_buf_ptr_(drcontext, ilist, where, reg_ptr);
+    MINSERT(ilist, where,
+            XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(reg_ptr, disp),
+                               opnd_create_reg(reg_addr)));
+    res = drreg_unreserve_register(drcontext, ilist, where, reg_addr);
+    DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
+    adjust += sizeof(offline_entry_t);
+    return adjust;
+}
+
 void
 offline_instru_t::bb_analysis(void *drcontext, void *tag, void **bb_field,
                               instrlist_t *ilist, bool repstr_expanded,

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -854,9 +854,12 @@ offline_instru_t::instrument_gather_base(void *drcontext, instrlist_t *ilist,
     drreg_status_t res =
         drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_addr);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
-    bool reg_ptr_used;
-    insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref, &reg_ptr_used);
+    bool reg_ptr_used_unused;
+    insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref,
+                       &reg_ptr_used_unused);
     // Now set the top bits (we don't care if we lose top bits of non-canonical addrs).
+    // TODO i#7914: Store a different sentinel in valueB when the top bits
+    // in canonical form should be 1's.
     offline_entry_t entry_top_zero;
     entry_top_zero.extended.type = 0;
     entry_top_zero.extended.ext = 0;
@@ -875,7 +878,7 @@ offline_instru_t::instrument_gather_base(void *drcontext, instrlist_t *ilist,
 #endif
     offline_entry_t entry_top_set;
     entry_top_set.extended.type = OFFLINE_TYPE_EXTENDED;
-    entry_top_set.extended.ext = OFFLINE_EXT_TYPE_GATHER_BASE;
+    entry_top_set.extended.ext = OFFLINE_EXT_TYPE_SCATTER_GATHER_BASE;
     // We set a bit here to avoid this being confused with an address.
     entry_top_set.extended.valueB = 1;
     entry_top_set.extended.valueA = 0;

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -487,6 +487,15 @@ online_instru_t::instrument_rseq_entry(void *drcontext, instrlist_t *ilist,
 }
 
 int
+online_instru_t::instrument_gather_base(void *drcontext, instrlist_t *ilist,
+                                        instr_t *where, reg_id_t reg_ptr, int adjust,
+                                        opnd_t ref)
+{
+    // Skipped memrefs are not supported in online mode.
+    return adjust;
+}
+
+int
 online_instru_t::instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                                     reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,
                                     int num_delay_instrs)

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1969,10 +1969,15 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                         mem_element_size = opnd_size_in_bytes(opnd_get_size(memref));
                         // dr_get_vector_length() is in bits.
                         element_count = dr_get_vector_length() / 8 / reg_element_size;
+                        // We want the sum across all vectors, if multiple.
+                        int vector_count = instr->scatter_gather_vector_count();
+                        DR_ASSERT(vector_count > 0);
+                        element_count *= vector_count;
                         log(4,
                             "Scatter/gather skip info: base=%p reg_el_sz=%d mem_el_sz=%d "
-                            "el_cnt=%d\n",
-                            base_addr, reg_element_size, mem_element_size, element_count);
+                            "el_cnt=%d (for %d vectors)\n",
+                            base_addr, reg_element_size, mem_element_size, element_count,
+                            vector_count);
                     } else {
                         unread_last_entry(tdata);
                     }
@@ -3058,6 +3063,9 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, DR_PARAM_INOUT ap
             opnd_size_in_bytes(opnd_get_vector_element_size(
                 instr_is_scatter(instr) ? instr_get_src(instr, 0)
                                         : instr_get_dst(instr, 0)));
+        desc->scatter_gather_vector_count_ = instr_is_scatter(instr)
+            ? (instr_num_srcs(instr) - 1 /*predicate*/)
+            : instr_num_dsts(instr);
     }
 #endif
     desc->type_ = ir_utils_t::instr_to_instr_type(instr);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3059,6 +3059,8 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, DR_PARAM_INOUT ap
 #if defined(X86) || defined(AARCH64)
     if (instr_is_scatter(instr) || instr_is_gather(instr)) {
         desc->packed_ |= kIsScatterOrGatherMask;
+        // TODO i#7914: Add x86 contiguous skipped memref support.
+#    ifdef AARCH64
         desc->scatter_gather_element_size_ =
             static_cast<byte>(opnd_size_in_bytes(opnd_get_vector_element_size(
                 instr_is_scatter(instr) ? instr_get_src(instr, 0)
@@ -3066,6 +3068,7 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, DR_PARAM_INOUT ap
         desc->scatter_gather_vector_count_ = static_cast<byte>(
             instr_is_scatter(instr) ? (instr_num_srcs(instr) - 1 /*predicate*/)
                                     : instr_num_dsts(instr));
+#    endif
     }
 #endif
     desc->type_ = ir_utils_t::instr_to_instr_type(instr);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1938,11 +1938,52 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                 // continue reading entries until we find a non-memref entry.
                 // This works only because drx_expand_scatter_gather ensures that the
                 // expansion has its own basic block, with no other app instr in it.
-                while (!reached_end_of_memrefs) {
+                //
+                // For a contiguous scatter/gather we do know the count and
+                // offsets statically and can fill in skipped memrefs if we
+                // have the base address, which we do via a special record
+                // read below.
+                bool add_skipped_markers = false;
+                addr_t base_addr = 0;
+                int mem_element_size = 0;
+                int element_count = 0;
+                // Conservative upper bound.
+                constexpr int MAX_SG_ELEMENTS = 2048;
+                trace_entry_t sg_buf[MAX_SG_ELEMENTS];
+                trace_entry_t *sg_buf_cur = sg_buf;
+                in_entry = get_next_entry(tdata);
+                if (in_entry != nullptr) {
+                    if (in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
+                        in_entry->extended.ext == OFFLINE_EXT_TYPE_GATHER_BASE) {
+                        add_skipped_markers = true;
+                        base_addr = in_entry->extended.valueA;
+                        opnd_t memref = is_scatter ? instr->mem_dest_at(0).opnd
+                                                   : instr->mem_src_at(0).opnd;
+                        if (!TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS,
+                                     get_file_type(tdata)) &&
+                            tdata->instru_offline.opnd_disp_is_elidable(memref)) {
+                            // We stored only the base reg, as an optimization.
+                            base_addr += opnd_get_disp(memref);
+                        }
+                        int reg_element_size = instr->scatter_gather_element_size();
+                        mem_element_size = opnd_size_in_bytes(opnd_get_size(memref));
+                        element_count = dr_get_vector_length() / reg_element_size;
+                        log(4,
+                            "Scatter/gather skip info: base=%p reg_el_sz=%d mem_el_sz=%d "
+                            "el_cnt=%d\n",
+                            base_addr, reg_element_size, mem_element_size, element_count);
+                    } else {
+                        unread_last_entry(tdata);
+                    }
+                }
+                int memref_count = 0;
+                for (; !reached_end_of_memrefs; ++memref_count) {
                     // XXX: Add sanity check for max count of store/load memrefs
-                    // possible for a given scatter/gather instr.
+                    // possible for a given scatter/gather instr. For now we have
+                    // a conservative single max.
+                    DR_ASSERT(memref_count < MAX_SG_ELEMENTS);
                     if (!append_memref(
-                            tdata, &buf, instr,
+                            tdata, &sg_buf_cur, instr,
                             // These memrefs were output by multiple store/load instrs in
                             // the expanded scatter/gather sequence. In raw2trace we see
                             // only the original app instr though. So we use the 0th
@@ -1952,6 +1993,43 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                             expect_all_memrefs, consumed_memrefs))
                         return false;
                 }
+                --memref_count; // The final append_memref did not find one.
+                DR_ASSERT(!add_skipped_markers || memref_count <= element_count);
+                sg_buf_cur = sg_buf;
+                int element_index = 0;
+                for (int memref_index = 0; memref_index < memref_count ||
+                     (add_skipped_markers && element_index < element_count);
+                     ++memref_index) {
+                    if (add_skipped_markers) {
+                        addr_t next_addr = base_addr + element_index * mem_element_size;
+                        log(4, "Scatter/gather el %d: next_addr=%p cur memref %d %p\n",
+                            element_index, next_addr, memref_index,
+                            memref_index < memref_count ? sg_buf_cur->addr : 0);
+                        while (element_index < element_count &&
+                               (memref_index >= memref_count ||
+                                sg_buf_cur->addr > next_addr)) {
+                            log(4, "Scatter/gather el %d: filling in skipped addr=%p\n",
+                                element_index, next_addr);
+                            buf->type = TRACE_TYPE_MARKER;
+                            buf->size = TRACE_MARKER_TYPE_SKIPPED_MEMREF;
+                            buf->addr = next_addr;
+                            ++buf;
+                            ++element_index;
+                            next_addr = base_addr + element_index * mem_element_size;
+                        }
+                        DR_ASSERT(memref_index >= memref_count ||
+                                  sg_buf_cur->addr == next_addr);
+                    }
+                    if (memref_index < memref_count) {
+                        log(4, "Scatter/gather el %d writing memref %d %p\n",
+                            element_index, memref_index, sg_buf_cur->addr);
+                        *buf = *sg_buf_cur;
+                        ++buf;
+                        ++sg_buf_cur;
+                        ++element_index;
+                    }
+                }
+                DR_ASSERT(!add_skipped_markers || element_index == element_count);
             } else if (instrs_are_separate) {
                 // There is only one memref entry (each memref is after a count=0 PC
                 // entry). Full info (type and size) is provided via
@@ -2973,8 +3051,11 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, DR_PARAM_INOUT ap
 #endif
 
 #if defined(X86) || defined(AARCH64)
-    if (instr_is_scatter(instr) || instr_is_gather(instr))
+    if (instr_is_scatter(instr) || instr_is_gather(instr)) {
         desc->packed_ |= kIsScatterOrGatherMask;
+        desc->scatter_gather_element_size_ = opnd_get_vector_element_size(
+            instr_is_scatter(instr) ? instr_get_src(instr, 0) : instr_get_dst(instr, 0));
+    }
 #endif
     desc->type_ = ir_utils_t::instr_to_instr_type(instr);
     desc->prefetch_type_ = is_prefetch ? instru_t::instr_to_prefetch_type(instr) : 0;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1967,7 +1967,8 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                         }
                         int reg_element_size = instr->scatter_gather_element_size();
                         mem_element_size = opnd_size_in_bytes(opnd_get_size(memref));
-                        element_count = dr_get_vector_length() / reg_element_size;
+                        // dr_get_vector_length() is in bits.
+                        element_count = dr_get_vector_length() / 8 / reg_element_size;
                         log(4,
                             "Scatter/gather skip info: base=%p reg_el_sz=%d mem_el_sz=%d "
                             "el_cnt=%d\n",
@@ -3053,8 +3054,10 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, DR_PARAM_INOUT ap
 #if defined(X86) || defined(AARCH64)
     if (instr_is_scatter(instr) || instr_is_gather(instr)) {
         desc->packed_ |= kIsScatterOrGatherMask;
-        desc->scatter_gather_element_size_ = opnd_get_vector_element_size(
-            instr_is_scatter(instr) ? instr_get_src(instr, 0) : instr_get_dst(instr, 0));
+        desc->scatter_gather_element_size_ =
+            opnd_size_in_bytes(opnd_get_vector_element_size(
+                instr_is_scatter(instr) ? instr_get_src(instr, 0)
+                                        : instr_get_dst(instr, 0)));
     }
 #endif
     desc->type_ = ir_utils_t::instr_to_instr_type(instr);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3060,12 +3060,12 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, DR_PARAM_INOUT ap
     if (instr_is_scatter(instr) || instr_is_gather(instr)) {
         desc->packed_ |= kIsScatterOrGatherMask;
         desc->scatter_gather_element_size_ =
-            opnd_size_in_bytes(opnd_get_vector_element_size(
+            static_cast<byte>(opnd_size_in_bytes(opnd_get_vector_element_size(
                 instr_is_scatter(instr) ? instr_get_src(instr, 0)
-                                        : instr_get_dst(instr, 0)));
-        desc->scatter_gather_vector_count_ = instr_is_scatter(instr)
-            ? (instr_num_srcs(instr) - 1 /*predicate*/)
-            : instr_num_dsts(instr);
+                                        : instr_get_dst(instr, 0))));
+        desc->scatter_gather_vector_count_ = static_cast<byte>(
+            instr_is_scatter(instr) ? (instr_num_srcs(instr) - 1 /*predicate*/)
+                                    : instr_num_dsts(instr));
     }
 #endif
     desc->type_ = ir_utils_t::instr_to_instr_type(instr);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1953,8 +1953,12 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                 trace_entry_t *sg_buf_cur = sg_buf;
                 in_entry = get_next_entry(tdata);
                 if (in_entry != nullptr) {
-                    if (in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
-                        in_entry->extended.ext == OFFLINE_EXT_TYPE_GATHER_BASE) {
+                    if (!(in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
+                          in_entry->extended.ext ==
+                              OFFLINE_EXT_TYPE_SCATTER_GATHER_BASE)) {
+                        // Support older traces without such records.
+                        unread_last_entry(tdata);
+                    } else {
                         add_skipped_markers = true;
                         base_addr = in_entry->extended.valueA;
                         opnd_t memref = is_scatter ? instr->mem_dest_at(0).opnd
@@ -1963,13 +1967,17 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                                      get_file_type(tdata)) &&
                             tdata->instru_offline.opnd_disp_is_elidable(memref)) {
                             // We stored only the base reg, as an optimization.
+                            // This happens even with predicated instructions where we
+                            // don't do base reg elision.
                             base_addr += opnd_get_disp(memref);
                         }
                         int reg_element_size = instr->scatter_gather_element_size();
+                        DR_ASSERT(reg_element_size > 0);
                         mem_element_size = opnd_size_in_bytes(opnd_get_size(memref));
                         // dr_get_vector_length() is in bits.
                         element_count = dr_get_vector_length() / 8 / reg_element_size;
-                        // We want the sum across all vectors, if multiple.
+                        // We want the sum across all vectors, if multiple: e.g.,
+                        // LD4H writes into 4 separate vector registers.
                         int vector_count = instr->scatter_gather_vector_count();
                         DR_ASSERT(vector_count > 0);
                         element_count *= vector_count;
@@ -1978,8 +1986,6 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                             "el_cnt=%d (for %d vectors)\n",
                             base_addr, reg_element_size, mem_element_size, element_count,
                             vector_count);
-                    } else {
-                        unread_last_entry(tdata);
                     }
                 }
                 int memref_count = 0;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -317,6 +317,14 @@ private:
         return branch_target_pc_;
     }
 
+    // Returns the vector element size in bytes for a scatter/gather instruction.
+    // Returns 0 for non-scatter-gather instructions.
+    byte
+    scatter_gather_element_size() const
+    {
+        return scatter_gather_element_size_;
+    }
+
     static const int kReadsMemMask = 0x0001;
     static const int kWritesMemMask = 0x0002;
     static const int kIsPrefetchMask = 0x0004;
@@ -344,6 +352,7 @@ private:
     uint16_t prefetch_type_ = 0;
     uint16_t flush_type_ = 0;
     byte length_ = 0;
+    byte scatter_gather_element_size_ = 0;
     app_pc branch_target_pc_ = 0;
 
     // Squash srcs and dests to save memory usage. We may want to

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -325,6 +325,13 @@ private:
         return scatter_gather_element_size_;
     }
 
+    // Some scatter/gather read from or write to 2, 3, or 4 vector registers at once.
+    byte
+    scatter_gather_vector_count() const
+    {
+        return scatter_gather_vector_count_;
+    }
+
     static const int kReadsMemMask = 0x0001;
     static const int kWritesMemMask = 0x0002;
     static const int kIsPrefetchMask = 0x0004;
@@ -352,7 +359,6 @@ private:
     uint16_t prefetch_type_ = 0;
     uint16_t flush_type_ = 0;
     byte length_ = 0;
-    byte scatter_gather_element_size_ = 0; // Size in bytes.
     app_pc branch_target_pc_ = 0;
 
     // Squash srcs and dests to save memory usage. We may want to
@@ -362,6 +368,10 @@ private:
     std::vector<memref_summary_t> mem_srcs_and_dests_;
     uint8_t num_mem_srcs_ = 0;
     byte packed_ = 0;
+
+    byte scatter_gather_element_size_ = 0; // Size in bytes.
+    // Some scatter/gather read from or write to 2, 3, or 4 vector registers at once.
+    byte scatter_gather_vector_count_ = 0;
 };
 
 /**

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -352,7 +352,7 @@ private:
     uint16_t prefetch_type_ = 0;
     uint16_t flush_type_ = 0;
     byte length_ = 0;
-    byte scatter_gather_element_size_ = 0;
+    byte scatter_gather_element_size_ = 0; // Size in bytes.
     app_pc branch_target_pc_ = 0;
 
     // Squash srcs and dests to save memory usage. We may want to

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1424,6 +1424,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         ud->last_app_pc = instr_get_app_pc(instr_fetch);
     }
 
+    // TODO i#7914: Add x86 contiguous skipped memref support.
 #ifdef AARCH64
     if (instr_fetch != NULL &&
         (instr_is_gather(instr_fetch) || instr_is_scatter(instr_fetch))) {

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1424,6 +1424,21 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         ud->last_app_pc = instr_get_app_pc(instr_fetch);
     }
 
+#ifdef AARCH64
+    if (instr_fetch != NULL &&
+        (instr_is_gather(instr_fetch) || instr_is_scatter(instr_fetch))) {
+        opnd_t memop = instr_is_gather(instr_fetch) ? instr_get_src(instr_fetch, 0)
+                                                    : instr_get_dst(instr_fetch, 0);
+        DR_ASSERT(opnd_is_memory_reference(memop));
+        bool is_contiguous =
+            !(reg_is_z(opnd_get_base(memop)) || reg_is_z(opnd_get_index(memop)));
+        if (is_contiguous) {
+            adjust = instru->instrument_gather_base(drcontext, bb, where, reg_ptr, adjust,
+                                                    memop);
+        }
+    }
+#endif
+
     /* Data entries. */
     if (instr_operands != NULL &&
         (instr_reads_memory(instr_operands) || instr_writes_memory(instr_operands))) {


### PR DESCRIPTION
Initial step toward recording skipped memrefs: records AArch64 contiguous scatter/gather skipped memrefs.  This is done by recording a new raw record type holding the base address, with raw2trace filling in any skipped memrefs as the addresses are knowable from the base address and instruction encoding.

Each skipped memref is stored as a new record type TRACE_MARKER_TYPE_SKIPPED_MEMREF in the final trace.Neither the memory reference size nor type (read or write) is included: it is assumed that they can be inferred from the instruction fetch entry.

A new skipped_memref_markers count is added to basic_counts and used to verify operation on the allasm scattergather test.

Some examples:

```
        2404         274:  W0.T825222 ifetch       4 byte(s) @ 0x0000000000400248 a5e1ec3c   ld4d   +0x40(%x1)[8byte] %p3/z -> %z28.d %z29.d %z30.d %z31.d
        2405         274:  W0.T825222 read         8 byte(s) @ 0x000000000041044e by PC 0x0000000000400248
        2406         274:  W0.T825222 read         8 byte(s) @ 0x0000000000410456 by PC 0x0000000000400248
        2407         274:  W0.T825222 read         8 byte(s) @ 0x000000000041045e by PC 0x0000000000400248
        2408         274:  W0.T825222 read         8 byte(s) @ 0x0000000000410466 by PC 0x0000000000400248
        2409         274:  W0.T825222 <marker: skipped memref 0x41046e
        2410         274:  W0.T825222 <marker: skipped memref 0x410476
        2411         274:  W0.T825222 <marker: skipped memref 0x41047e
        2412         274:  W0.T825222 <marker: skipped memref 0x410486
        2413         275:  W0.T825222 ifetch       4 byte(s) @ 0x000000000040024c e401e03c   st1b   %z28.b %p0 -> +0x10(%x1)[1byte]
```

```
        2525         287:  W0.T825222 ifetch       4 byte(s) @ 0x000000000040027c e531e83c   st2w   %z28.s %z29.s %p2 -> +0x20(%x1)[4byte]
        2526         287:  W0.T825222 write        4 byte(s) @ 0x000000000041040e by PC 0x000000000040027c
        2527         287:  W0.T825222 write        4 byte(s) @ 0x0000000000410412 by PC 0x000000000040027c
        2528         287:  W0.T825222 <marker: skipped memref 0x410416
        2529         287:  W0.T825222 <marker: skipped memref 0x41041a
        2530         287:  W0.T825222 <marker: skipped memref 0x41041e
        2531         287:  W0.T825222 <marker: skipped memref 0x410422
        2532         287:  W0.T825222 <marker: skipped memref 0x410426
        2533         287:  W0.T825222 <marker: skipped memref 0x41042a
        2534         288:  W0.T825222 ifetch       4 byte(s) @ 0x0000000000400280 e5b1ec3c   st2d   %z28.d %z29.d %p3 -> +0x20(%x1)[8byte]
```


Issue: #7914