### PR TITLE
i#7909 unknown cache: Add 48KB cache size enum

### DIFF
--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -439,16 +439,17 @@ typedef enum {
  * proc_get_cache_size_str().
  */
 typedef enum {
-    CACHE_SIZE_8_KB,   /**< L1 or L2 cache size of 8 KB. */
-    CACHE_SIZE_16_KB,  /**< L1 or L2 cache size of 16 KB. */
-    CACHE_SIZE_32_KB,  /**< L1 or L2 cache size of 32 KB. */
-    CACHE_SIZE_64_KB,  /**< L1 or L2 cache size of 64 KB. */
-    CACHE_SIZE_128_KB, /**< L1 or L2 cache size of 128 KB. */
-    CACHE_SIZE_256_KB, /**< L1 or L2 cache size of 256 KB. */
-    CACHE_SIZE_512_KB, /**< L1 or L2 cache size of 512 KB. */
-    CACHE_SIZE_1_MB,   /**< L1 or L2 cache size of 1 MB. */
-    CACHE_SIZE_2_MB,   /**< L1 or L2 cache size of 2 MB. */
-    CACHE_SIZE_UNKNOWN /**< Unknown L1 or L2 cache size. */
+    CACHE_SIZE_8_KB,    /**< L1 or L2 cache size of 8 KB. */
+    CACHE_SIZE_16_KB,   /**< L1 or L2 cache size of 16 KB. */
+    CACHE_SIZE_32_KB,   /**< L1 or L2 cache size of 32 KB. */
+    CACHE_SIZE_64_KB,   /**< L1 or L2 cache size of 64 KB. */
+    CACHE_SIZE_128_KB,  /**< L1 or L2 cache size of 128 KB. */
+    CACHE_SIZE_256_KB,  /**< L1 or L2 cache size of 256 KB. */
+    CACHE_SIZE_512_KB,  /**< L1 or L2 cache size of 512 KB. */
+    CACHE_SIZE_1_MB,    /**< L1 or L2 cache size of 1 MB. */
+    CACHE_SIZE_2_MB,    /**< L1 or L2 cache size of 2 MB. */
+    CACHE_SIZE_UNKNOWN, /**< Unknown L1 or L2 cache size. */
+    CACHE_SIZE_48_KB,   /**< L1 or L2 cache size of 48 KB. */
 } cache_size_t;
 
 DR_API

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -103,6 +103,7 @@ proc_set_cache_size(uint val, uint *dst)
     case 8: *dst = CACHE_SIZE_8_KB; break;
     case 16: *dst = CACHE_SIZE_16_KB; break;
     case 32: *dst = CACHE_SIZE_32_KB; break;
+    case 48: *dst = CACHE_SIZE_48_KB; break;
     case 64: *dst = CACHE_SIZE_64_KB; break;
     case 128: *dst = CACHE_SIZE_128_KB; break;
     case 256: *dst = CACHE_SIZE_256_KB; break;
@@ -255,9 +256,10 @@ proc_get_L2_cache_size(void)
 const char *
 proc_get_cache_size_str(cache_size_t size)
 {
-    static const char *strings[] = { "8 KB",   "16 KB",  "32 KB", "64 KB", "128 KB",
-                                     "256 KB", "512 KB", "1 MB",  "2 MB",  "unknown" };
-    CLIENT_ASSERT(size <= CACHE_SIZE_UNKNOWN, "proc_get_cache_size_str: invalid size");
+    static const char *strings[] = { "8 KB",   "16 KB",   "32 KB",  "64 KB",
+                                     "128 KB", "256 KB",  "512 KB", "1 MB",
+                                     "2 MB",   "unknown", "48 KB" };
+    CLIENT_ASSERT(size <= CACHE_SIZE_48_KB, "proc_get_cache_size_str: invalid size");
     return strings[size];
 }
 


### PR DESCRIPTION
Adds support for a 48KB cache size by adding an enum value.

We don't have a mock hardware query set up so it's not simple to add a test, unfortunately.

Fixes #7909