### PR TITLE
i#7922: Avoid file name conflicts in drsyscall tests

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6793,9 +6793,10 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
     drsyscall_record_lib)
 
   if (X64)
-    file(COPY syscall_record_file.test DESTINATION "${PROJECT_BINARY_DIR}/suite/tests")
     set(syscall_record_test_file
-      "${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.test")
+      # Add a "trim_" prefix to avoid deletion by client.syscall-records-test.
+      "${PROJECT_BINARY_DIR}/suite/tests/trim_syscall_record_file.test")
+    file(COPY_FILE syscall_record_file.test "${syscall_record_test_file}")
     set(tool.drsyscall-record-trimmer-test_runcmp
       "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
     set(tool.drsyscall-record-trimmer-test_expectbase "drsyscall-record-trimmer-test")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6796,7 +6796,7 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
     set(syscall_record_test_file
       # Add a "trim_" prefix to avoid deletion by client.syscall-records-test.
       "${PROJECT_BINARY_DIR}/suite/tests/trim_syscall_record_file.test")
-    file(COPY_FILE syscall_record_file.test "${syscall_record_test_file}")
+    configure_file(syscall_record_file.test "${syscall_record_test_file}" COPYONLY)
     set(tool.drsyscall-record-trimmer-test_runcmp
       "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
     set(tool.drsyscall-record-trimmer-test_expectbase "drsyscall-record-trimmer-test")


### PR DESCRIPTION
The drsyscall-record-trimmer-test was failing when run with other tests because it uses an input file "syscall_record_file.test" while the syscall-records-test was deleting the glob "syscall_record_file.*" (since its test produces various numeric suffixes on that name).  This is fixed by adding a prefix to the trimmer test's input and output files.

Tested in a parallel run where it failed multiple times before but now passes.

Fixes #7922