### PR TITLE
Fix drmemtrace SIGFPE for glibc 2.43

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -814,7 +814,8 @@ privload_os_finalize(privmod_t *privmod)
     do {
         instr_reset(GLOBAL_DCONTEXT, instr);
         pc = decode(GLOBAL_DCONTEXT, pc, instr);
-        if (instr_get_opcode(instr) == OP_mov_ld &&
+        if ((instr_get_opcode(instr) == OP_mov_ld ||
+             instr_get_opcode(instr) == OP_movdqu) &&
             opnd_is_base_disp(instr_get_src(instr, 0))) {
             int disp = opnd_get_disp(instr_get_src(instr, 0));
             if (disp > MIN_LOAD_OFFS)


### PR DESCRIPTION
Bug:
```
drrun -t drmemtrace -offline -record_heap -- /bin/ls
```
Triggers SIGFPE on Fedora 44 with glibc 2.43

Fix:
Also match OP_movdqu in core/unix/loader.c

Root cause:
1. glibc 2.43 uses movdqu instead of mov for TLS offset loads
2. Current pattern matcher only checks for OP_mov_ld
3. When pattern match fails, falls back to hardcoded offsets 0x2c8/0x2d0
4. Those offsets are wrong for glibc 2.43 (should be 0x2a0/0x2a8)
5. Wrong offsets cause __libc_early_init to divide by zero

Related to #5437

Verify:
```
$ objdump -d /lib64/libc.so.6 | grep -A30 '<__libc_early_init>:' | grep movdqu
  1484a1:       f3 0f 6f 80 a0 02 00    movdqu 0x2a0(%rax),%xmm0
```