### PR TITLE
i#7927: Increase scheduler.unit_tests timeout

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -920,7 +920,8 @@ if (BUILD_TESTS)
   add_test(NAME tool.scheduler.unit_tests
     COMMAND tool.scheduler.unit_tests
     ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)
-  set_tests_properties(tool.scheduler.unit_tests PROPERTIES TIMEOUT ${test_seconds})
+  # This test can take longer than 90s on slower loaded machines.
+  set_tests_properties(tool.scheduler.unit_tests PROPERTIES TIMEOUT 180)
 
   add_executable(tool.drcacheoff.flexible_queue_tests tests/flexible_queue_tests.cpp)
   add_win32_flags(tool.drcacheoff.flexible_queue_tests ON)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -920,8 +920,9 @@ if (BUILD_TESTS)
   add_test(NAME tool.scheduler.unit_tests
     COMMAND tool.scheduler.unit_tests
     ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)
-  # This test can take longer than 90s on slower loaded machines.
-  set_tests_properties(tool.scheduler.unit_tests PROPERTIES TIMEOUT 180)
+  # This test can take much longer than 90s on slower loaded machines: we've
+  # seen 241 seconds when run with "-j 12" on a VM.
+  set_tests_properties(tool.scheduler.unit_tests PROPERTIES TIMEOUT 360)
 
   add_executable(tool.drcacheoff.flexible_queue_tests tests/flexible_queue_tests.cpp)
   add_win32_flags(tool.drcacheoff.flexible_queue_tests ON)


### PR DESCRIPTION
Increases the scheduler.unit_tests timeout from 90s to 360s as this test is long and can time out in some runs on slower loaded machines (I observed 241s with "-j 12" on a VM).

Tested:

I hit this every time when running "ctest -j 12" before. With the fix it no longer fails in a parallel run.

Fixes #7927