### PR TITLE
i#7929: Handle SIGBUS in DR init on attach

### DIFF
--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -2074,7 +2074,7 @@ inject_ptrace(dr_inject_info_t *info, const char *library_path)
     /* This should run something equivalent to dynamorio_app_init(), and then
      * return.
      * XXX: we can actually fault during dynamorio_app_init() due to safe_reads,
-     * so we have to expect SIGSEGV and let it be delivered.
+     * so we have to expect SIGSEGV or SIGBUS and let it be delivered.
      * XXX: SIGILL is delivered from signal_arch_init() and we should pass it
      * to its original handler.
      */
@@ -2098,7 +2098,7 @@ inject_ptrace(dr_inject_info_t *info, const char *library_path)
             return false;
         }
         signal = WSTOPSIG(status);
-    } while (signal == SIGSEGV || signal == SIGILL);
+    } while (signal == SIGSEGV || signal == SIGBUS || signal == SIGILL);
 
     /* When we get SIGTRAP, DR has initialized. */
     if (signal != SIGTRAP) {


### PR DESCRIPTION
Adds SIGBUS to the set of expected signals during DR init when attaching on Linux. This fixes failures to attach on some machines.

Tested: client.attach_test, client.attach_blocking, client.attach_memory_dump_test, and client.attach-memory-dump-syscall-test now pass on a machine where they failed every time before.

Fixes #7929