### PR TITLE
i#7924: Allow 3 page vdso

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * Copyright (c) 2025 Foundation of Research and Technology, Hellas.

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -10120,7 +10120,9 @@ found_vsyscall_page(memquery_iter_t *iter _IF_DEBUG(DR_PARAM_OUT const char **ma
      */
     ASSERT(iter->vm_end - iter->vm_start == PAGE_SIZE ||
            /* i#1583: recent kernels have 2-page vdso */
-           iter->vm_end - iter->vm_start == 2 * PAGE_SIZE);
+           iter->vm_end - iter->vm_start == 2 * PAGE_SIZE ||
+           /* i#7924: recent kernels have 3-page vdso */
+           iter->vm_end - iter->vm_start == 3 * PAGE_SIZE);
     ASSERT(!dynamo_initialized); /* .data should be +w */
     /* we're not considering as "image" even if part of ld.so (xref i#89) and
      * thus we aren't adjusting our code origins policies to remove the


### PR DESCRIPTION
Relax checks for vdso being just 1 or 2 pages, to handle the 3-page vdso on recent Linux kernels.

Tested on my workstation running Linux 7.0.11: `linux.xarch` used to generated an assertion failure on
```
iter->vm_end - iter->vm_start == PAGE_SIZE || iter->vm_end - iter->vm_start == 2 * PAGE_SIZE
```
Now this assertion passes. Though the test still fails due to other unrelated issues.

Issue: #7924 