### PR TITLE
Fix const-qualifier warning for dwarf_getsrclines.c patch

### DIFF
--- a/ext/drsyms/elfutils/dwarf_getsrclines.c.patch
+++ b/ext/drsyms/elfutils/dwarf_getsrclines.c.patch
@@ -13,3 +13,30 @@ index 69e10c7b..473255dd 100644
  #define MAX_STACK_DIRS  (MAX_STACK_ALLOC / 16)
  
    /* Initial statement program state (except for stmt_list, see below).  */
+@@ -329,7 +329,7 @@ read_srclines (Dwarf *dbg,
+       const unsigned char *dirp = linep;
+       while (dirp < lineendp && *dirp != 0)
+ 	{
+-	  uint8_t *endp = memchr (dirp, '\0', lineendp - dirp);
++	  const uint8_t *endp = memchr (dirp, '\0', lineendp - dirp);
+ 	  if (endp == NULL)
+ 	    goto invalid_data;
+ 	  ++ndirs;
+@@ -405,7 +405,7 @@ read_srclines (Dwarf *dbg,
+       for (unsigned int n = 1; n < ndirlist; n++)
+ 	{
+ 	  dirarray[n].dir = (char *) linep;
+-	  uint8_t *endp = memchr (linep, '\0', lineendp - linep);
++	  const uint8_t *endp = memchr (linep, '\0', lineendp - linep);
+ 	  assert (endp != NULL); // Checked above when calculating ndirlist.
+ 	  dirarray[n].len = endp - linep;
+ 	  linep = endp + 1;
+@@ -793,7 +793,7 @@ read_srclines (Dwarf *dbg,
+ 	    case DW_LNE_define_file:
+ 	      {
+ 		char *fname = (char *) linep;
+-		uint8_t *endp = memchr (linep, '\0', lineendp - linep);
++		const uint8_t *endp = memchr (linep, '\0', lineendp - linep);
+ 		if (endp == NULL)
+ 		  goto invalid_data;
+ 		size_t fnamelen = endp - linep;


### PR DESCRIPTION
Add `const` to three endp variables in the bundled elfutils patch to fix -Wdiscarded-qualifiers
warning when compiling with gcc 16.1.1.

This is already fixed in elfutils 0.195
(https://sourceware.org/pipermail/elfutils-devel/2025q4/008767.html) Temporary fix until elfutils submodule is bumped

Before:
```
$ cmake --build build
[552/1038] Building C object ext/drsyms/CMakeFiles/dw_pic.dir/dwarf_getsrclines.c.o
/home/cpprust/work/fork/dynamorio/build/ext/drsyms/dwarf_getsrclines.c: In function ‘read_srclines’:
/home/cpprust/work/fork/dynamorio/build/ext/drsyms/dwarf_getsrclines.c:332:27: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  332 |           uint8_t *endp = memchr (dirp, '\0', lineendp - dirp);
      |                           ^~~~~~
/home/cpprust/work/fork/dynamorio/build/ext/drsyms/dwarf_getsrclines.c:408:27: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  408 |           uint8_t *endp = memchr (linep, '\0', lineendp - linep);
      |                           ^~~~~~
/home/cpprust/work/fork/dynamorio/build/ext/drsyms/dwarf_getsrclines.c:796:33: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  796 |                 uint8_t *endp = memchr (linep, '\0', lineendp - linep);
      |                                 ^~~~~~
[1038/1038] Linking CXX executable clients/bin64/drcachesim_ops
```

After:
```
$ cmake --build build
[1038/1038] Linking CXX executable clients/bin64/drcachesim_ops
```