### PR TITLE
i#7936: Resolve bool definition conflicts in globals_api.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1282,35 +1282,36 @@ endif (NOT DISABLE_WARNINGS)
 
 # Now that the compilation flags are decided, we verify type sizes. Particularly,
 # the availability of bool on C depends on -std=gnu99 set above.
+include(CheckTypeSize)
+CHECK_TYPE_SIZE(bool DR_DO_NOT_DEFINE_bool)
+CHECK_TYPE_SIZE(_Bool DR__Bool_EXISTS)
+
+if (DR_DO_NOT_DEFINE_bool)
+  # i#488: ensure bool compatibility with C++
+  if (NOT ${DR_DO_NOT_DEFINE_bool} EQUAL 1)
+    message(FATAL_ERROR "incompatible pre-defined \"bool\" type is larger than 1 byte")
+  endif (NOT ${DR_DO_NOT_DEFINE_bool} EQUAL 1)
+endif (DR_DO_NOT_DEFINE_bool)
+
+if (DR__Bool_EXISTS)
+  if (NOT ${DR__Bool_EXISTS} EQUAL 1)
+    message(FATAL_ERROR "incompatible \"_Bool\" type is larger than 1 byte")
+  endif (NOT ${DR__Bool_EXISTS} EQUAL 1)
+endif (DR__Bool_EXISTS)
+
 if (UNIX) # unlikely to be an issue on Windows
   # Check for uint, etc. typedef conflicts like on rhel3 (i#18)
   # and set DR_DO_NOT_DEFINE_*
   # Note that for later gcc uint and ushort seem to be "soft typedefs":
   # defined, but overridable: ?!?
-  include(CheckTypeSize)
   CHECK_TYPE_SIZE(uint DR_DO_NOT_DEFINE_uint)
   CHECK_TYPE_SIZE(ushort DR_DO_NOT_DEFINE_ushort)
-  CHECK_TYPE_SIZE(bool DR_DO_NOT_DEFINE_bool)
   CHECK_TYPE_SIZE(byte DR_DO_NOT_DEFINE_byte)
   CHECK_TYPE_SIZE(sbyte DR_DO_NOT_DEFINE_sbyte)
   CHECK_TYPE_SIZE(uint32 DR_DO_NOT_DEFINE_uint32)
   CHECK_TYPE_SIZE(uint64 DR_DO_NOT_DEFINE_uint64)
   CHECK_TYPE_SIZE(int32 DR_DO_NOT_DEFINE_int32)
   CHECK_TYPE_SIZE(int64 DR_DO_NOT_DEFINE_int64)
-  # we could do CHECK_SYMBOL_EXISTS for MAX and MIN but they're not
-  # in standard headers so up to user to define if an issue
-  if (DR_DO_NOT_DEFINE_bool)
-    # i#488: ensure bool compatibility with C++
-    if (NOT ${DR_DO_NOT_DEFINE_bool} EQUAL 1)
-      message(FATAL_ERROR "incompatible pre-defined \"bool\" type is larger than 1 byte")
-    endif (NOT ${DR_DO_NOT_DEFINE_bool} EQUAL 1)
-  endif (DR_DO_NOT_DEFINE_bool)
-  CHECK_TYPE_SIZE(_Bool DR__Bool_EXISTS)
-  if (DR__Bool_EXISTS)
-    if (NOT ${DR__Bool_EXISTS} EQUAL 1)
-      message(FATAL_ERROR "incompatible \"_Bool\" type is larger than 1 byte")
-    endif (NOT ${DR__Bool_EXISTS} EQUAL 1)
-  endif (DR__Bool_EXISTS)
 endif (UNIX)
 
 if (LINUX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1312,6 +1312,8 @@ if (UNIX) # unlikely to be an issue on Windows
   CHECK_TYPE_SIZE(uint64 DR_DO_NOT_DEFINE_uint64)
   CHECK_TYPE_SIZE(int32 DR_DO_NOT_DEFINE_int32)
   CHECK_TYPE_SIZE(int64 DR_DO_NOT_DEFINE_int64)
+  # We could do CHECK_SYMBOL_EXISTS for MAX and MIN but they're not
+  # in standard headers so up to user to define if an issue.
 endif (UNIX)
 
 if (LINUX)

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -121,6 +121,7 @@
 #            if defined(DR__Bool_EXISTS) & !defined(bool)
 /* prefer _Bool as it avoids truncation casting non-zero to zero */
 typedef _Bool bool;
+#                define DR_BOOL_DEFINED 1
 #            endif
 #        endif
 #        ifndef true

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -296,7 +296,7 @@ typedef size_t app_rva_t;
 
 #define PTR_UINT_0 ((ptr_uint_t)0U)
 #define PTR_UINT_1 ((ptr_uint_t)1U)
-#define PTR_UINT_MINUS_1 ((ptr_uint_t) - 1)
+#define PTR_UINT_MINUS_1 ((ptr_uint_t)-1)
 
 #ifdef WINDOWS
 typedef ptr_uint_t thread_id_t;

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -55,7 +55,13 @@
 #    include <stdio.h>
 #    include <stdlib.h>
 #endif
-#include <stdarg.h> /* for varargs */
+#include <stdarg.h>  /* for varargs */
+#include <stdbool.h> /* for bool */
+
+#ifdef DYNAMORIO_INTERNAL
+/* Use typedef below to avoid token pasting issues with macros in core. */
+#    undef bool
+#endif
 
 #ifndef DYNAMORIO_INTERNAL
 /* A client's target operating system and architecture must be specified. */
@@ -112,12 +118,9 @@
 #            define inline __inline__
 #        endif
 #        ifndef DR_DO_NOT_DEFINE_bool
-#            ifdef DR__Bool_EXISTS
+#            if defined(DR__Bool_EXISTS) & !defined(bool)
 /* prefer _Bool as it avoids truncation casting non-zero to zero */
 typedef _Bool bool;
-#            else
-/* char-sized for compatibility with C++ */
-typedef char bool;
 #            endif
 #        endif
 #        ifndef true
@@ -289,7 +292,7 @@ typedef size_t app_rva_t;
 
 #define PTR_UINT_0 ((ptr_uint_t)0U)
 #define PTR_UINT_1 ((ptr_uint_t)1U)
-#define PTR_UINT_MINUS_1 ((ptr_uint_t)-1)
+#define PTR_UINT_MINUS_1 ((ptr_uint_t) - 1)
 
 #ifdef WINDOWS
 typedef ptr_uint_t thread_id_t;

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -55,8 +55,11 @@
 #    include <stdio.h>
 #    include <stdlib.h>
 #endif
-#include <stdarg.h>  /* for varargs */
-#include <stdbool.h> /* for bool */
+#include <stdarg.h> /* for varargs */
+
+#ifndef DYNAMORIO_INTERNAL
+#    include <stdbool.h> /* for bool */
+#endif
 
 #ifdef DYNAMORIO_INTERNAL
 /* Use typedef below to avoid token pasting issues with macros in core. */
@@ -118,7 +121,7 @@
 #            define inline __inline__
 #        endif
 #        ifndef DR_DO_NOT_DEFINE_bool
-#            if defined(DR__Bool_EXISTS) & !defined(bool)
+#            if defined(DR__Bool_EXISTS) && !defined(DYNAMORIO_INTERNAL)
 /* prefer _Bool as it avoids truncation casting non-zero to zero */
 typedef _Bool bool;
 #                define DR_BOOL_DEFINED 1
@@ -293,7 +296,7 @@ typedef size_t app_rva_t;
 
 #define PTR_UINT_0 ((ptr_uint_t)0U)
 #define PTR_UINT_1 ((ptr_uint_t)1U)
-#define PTR_UINT_MINUS_1 ((ptr_uint_t)-1)
+#define PTR_UINT_MINUS_1 ((ptr_uint_t) - 1)
 
 #ifdef WINDOWS
 typedef ptr_uint_t thread_id_t;

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -121,7 +121,7 @@
 #            define inline __inline__
 #        endif
 #        ifndef DR_DO_NOT_DEFINE_bool
-#            if defined(DR__Bool_EXISTS) && !defined(DYNAMORIO_INTERNAL)
+#            if defined(DR__Bool_EXISTS) && defined(DYNAMORIO_INTERNAL)
 /* prefer _Bool as it avoids truncation casting non-zero to zero */
 typedef _Bool bool;
 #                define DR_BOOL_DEFINED 1

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -292,7 +292,7 @@ typedef size_t app_rva_t;
 
 #define PTR_UINT_0 ((ptr_uint_t)0U)
 #define PTR_UINT_1 ((ptr_uint_t)1U)
-#define PTR_UINT_MINUS_1 ((ptr_uint_t) - 1)
+#define PTR_UINT_MINUS_1 ((ptr_uint_t)-1)
 
 #ifdef WINDOWS
 typedef ptr_uint_t thread_id_t;

--- a/core/options.c
+++ b/core/options.c
@@ -66,7 +66,7 @@ typedef unsigned int uint;
 
 #    define print_file(f, s, x)
 
-#    ifndef bool
+#    if !defined(bool) && !defined(DR_BOOL_DEFINED)
 typedef char bool;
 #    endif
 #    ifndef true

--- a/core/options.c
+++ b/core/options.c
@@ -66,7 +66,7 @@ typedef unsigned int uint;
 
 #    define print_file(f, s, x)
 
-#    if !defined(bool) && !defined(DR_BOOL_DEFINED)
+#    if !defined(DR_BOOL_DEFINED)
 typedef char bool;
 #    endif
 #    ifndef true

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -67,10 +67,6 @@
  * appended to if multiple option instances are specified
  */
 
-#ifdef bool
-/* Avoid problems with bool macros on Mac. */
-#    undef bool
-#endif
 
 /* Shortcuts for the common cases */
 #define OPTION_DEFAULT(type, name, value, description) \

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -67,7 +67,6 @@
  * appended to if multiple option instances are specified
  */
 
-
 /* Shortcuts for the common cases */
 #define OPTION_DEFAULT(type, name, value, description) \
     OPTION_COMMAND(type, name, value, #name, {}, description, STATIC, OP_PCACHE_NOP)

--- a/core/win32/ntdll.h
+++ b/core/win32/ntdll.h
@@ -460,7 +460,7 @@ typedef struct _PROCESS_DEVICEMAP_INFORMATION {
 } PROCESS_DEVICEMAP_INFORMATION, *PPROCESS_DEVICEMAP_INFORMATION;
 
 #if defined(NOT_DYNAMORIO_CORE)
-#    ifndef bool
+#    if !defined(bool) && !defined(DR_BOOL_DEFINED)
 typedef char bool;
 #    endif /* bool */
 typedef unsigned __int64 uint64;

--- a/core/win32/ntdll.h
+++ b/core/win32/ntdll.h
@@ -86,13 +86,13 @@
  */
 
 #define NT_CURRENT_PROCESS ((HANDLE)PTR_UINT_MINUS_1)
-#define NT_CURRENT_THREAD ((HANDLE)(ptr_uint_t) - 2)
+#define NT_CURRENT_THREAD ((HANDLE)(ptr_uint_t)-2)
 
 /* This macro is defined in wincon.h, but requires _WIN32_WINNT be XP+. _WIN32_WINNT is
  * defined in globals.h to _WIN32_WINNT_NT4, thus the need for this re-definition.
  */
 #ifndef ATTACH_PARENT_PROCESS
-#    define ATTACH_PARENT_PROCESS ((DWORD) - 1)
+#    define ATTACH_PARENT_PROCESS ((DWORD)-1)
 #endif
 
 #ifdef X64

--- a/core/win32/ntdll.h
+++ b/core/win32/ntdll.h
@@ -86,13 +86,13 @@
  */
 
 #define NT_CURRENT_PROCESS ((HANDLE)PTR_UINT_MINUS_1)
-#define NT_CURRENT_THREAD ((HANDLE)(ptr_uint_t)-2)
+#define NT_CURRENT_THREAD ((HANDLE)(ptr_uint_t) - 2)
 
 /* This macro is defined in wincon.h, but requires _WIN32_WINNT be XP+. _WIN32_WINNT is
  * defined in globals.h to _WIN32_WINNT_NT4, thus the need for this re-definition.
  */
 #ifndef ATTACH_PARENT_PROCESS
-#    define ATTACH_PARENT_PROCESS ((DWORD)-1)
+#    define ATTACH_PARENT_PROCESS ((DWORD) - 1)
 #endif
 
 #ifdef X64
@@ -460,7 +460,7 @@ typedef struct _PROCESS_DEVICEMAP_INFORMATION {
 } PROCESS_DEVICEMAP_INFORMATION, *PPROCESS_DEVICEMAP_INFORMATION;
 
 #if defined(NOT_DYNAMORIO_CORE)
-#    if !defined(bool) && !defined(DR_BOOL_DEFINED)
+#    if !defined(DR_BOOL_DEFINED)
 typedef char bool;
 #    endif /* bool */
 typedef unsigned __int64 uint64;


### PR DESCRIPTION
Resolves compilation errors caused by conflicting definitions of
the `bool` type between the DynamoRIO "core" and external clients.
To support both without requiring <stdbool.h> to be included
everywhere, we make the `bool` definition in globals_api.h
conditional.
For core compilation (where `DYNAMORIO_INTERNAL` is defined),
we undefine the `bool` macro and fall back to `typedef _Bool bool`.
For clients and extensions, we preserve the standard `bool` macro
definition.

This issue was causing a failure when building the `samples_proj` test
internally.

Fixes #7936