### PR TITLE
i#7952: Skip ELF header checks for vvar_vclock

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -2080,7 +2080,7 @@ reload_dynamorio(void **init_sp, app_pc conflict_start, app_pc conflict_end)
     elf_loader_t dr_ld;
     os_privmod_data_t opd;
     byte *dr_map;
-    /* We expect at most vvar+vdso+stack+vsyscall => 5 different mappings
+    /* We expect at most vvar+vvar_vclock+vdso+stack+vsyscall => 6 different mappings
      * even if they were all in the conflict area.
      */
 #        define MAX_TEMP_MAPS 16

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -357,7 +357,8 @@ memquery_from_os(const byte *pc, DR_PARAM_OUT dr_mem_info_t *info,
                  * pieces by our vsyscall hook, so we don't check for a precise match.
                  */
                 info->prot = (MEMPROT_READ | MEMPROT_EXEC | MEMPROT_VDSO);
-            } else if (strcmp(iter.comment, "[vvar]") == 0) {
+            } else if (strncmp(iter.comment, VVAR_PAGE_MAPS_NAME_PREFIX,
+                               strlen(VVAR_PAGE_MAPS_NAME_PREFIX)) == 0) {
                 /* The VVAR pages were added in kernel 3.0 but not labeled until
                  * 3.15.  We document that we do not label prior to 3.15.
                  * DrMem#1778 seems to only happen on 3.19+ in any case.

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3693,7 +3693,7 @@ os_heap_reserve_in_region(void *start, void *end, size_t size,
         end == (void *)ALIGN_BACKWARD(POINTER_MAX, PAGE_SIZE))
         return os_heap_reserve(NULL, size, error_code, executable);
 
-        /* loop to handle races */
+    /* loop to handle races */
 #define RESERVE_IN_REGION_MAX_ITERS 128
     while (find_free_memory_in_region(find_start, end, size, &try_start, &try_end)) {
         /* If there's space we'd prefer the end, to avoid the common case of
@@ -10267,6 +10267,13 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules)
                                     iter->comment, iter->inode);
                 }
             }
+        } else if (strncmp(iter->comment, VVAR_PAGE_MAPS_NAME_PREFIX,
+                           strlen(VVAR_PAGE_MAPS_NAME_PREFIX)) == 0) {
+            /* Do not try to look for module headers in vvar regions as we can
+             * easily trigger SIGBUS every time and while our safe_read should
+             * handle that it doesn't in all cases (i#7952) and it adds extra
+             * overhead and debuggability pain.
+             */
         } else if (add_modules &&
                    mmap_check_for_module_overlap(iter->vm_start, size,
                                                  TEST(MEMPROT_READ, iter->prot),
@@ -10657,11 +10664,11 @@ mutex_wait_contended_lock(mutex_t *lock, priv_mcontext_t *mc)
             if (mc != NULL)
                 set_synch_state(dcontext, THREAD_SYNCH_VALID_MCONTEXT);
 
-                /* Unfortunately the synch semantics are different for Linux vs Mac.
-                 * We have to use lock_requests as the futex to avoid waiting if
-                 * lock_requests changes, while on Mac the underlying synch prevents
-                 * a wait there.
-                 */
+            /* Unfortunately the synch semantics are different for Linux vs Mac.
+             * We have to use lock_requests as the futex to avoid waiting if
+             * lock_requests changes, while on Mac the underlying synch prevents
+             * a wait there.
+             */
 #ifdef LINUX
             /* We'll abort the wait if lock_requests has changed at all.
              * We can't have a series of changes that result in no apparent

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -427,6 +427,8 @@ extern app_pc vsyscall_sysenter_return_pc;
 /* pc where our hook-displaced code was copied */
 extern app_pc vsyscall_sysenter_displaced_pc;
 #define VSYSCALL_PAGE_MAPS_NAME "[vdso]"
+/* We use this to match "[vvar]" and "[vvar_vclock]". */
+#define VVAR_PAGE_MAPS_NAME_PREFIX "[vvar"
 
 bool
 was_thread_create_syscall(dcontext_t *dcontext);
@@ -462,7 +464,7 @@ is_DR_segment_reader_entry(app_pc pc);
 #    define NUM_RT 0 /* no RT signals */
 #endif
 /* MAX_SIGNUM is the highest valid signum. */
-#define MAX_SIGNUM ((OFFS_RT) + (NUM_RT)-1)
+#define MAX_SIGNUM ((OFFS_RT) + (NUM_RT) - 1)
 /* i#336: MAX_SIGNUM is a valid signal, so we must allocate space for it.
  */
 #define SIGARRAY_SIZE (MAX_SIGNUM + 1)


### PR DESCRIPTION
We're seeing weird behavior from some safe_read SIGBUS instances trying to see if vvar_vclock has an ELF header. It's looking like a kernel bug. We'd prefer to skip the SIGBUS instances happening multiple times in any case, so we add special handling to avoid looking for modules in vvar* regions.

The existing behavior of "[vvar]" returning the special MEMPROT_VDSO is extended to also include "[vvar_vclock]" for
DynamoRIO/drmemory#1778.

Tested: the static_noclient test crashes with SIGBUS without this fix on my machine every time; now it passes.

Fixes #7952