### PR TITLE
i#7955: Fix sigmask test signal race

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7972,6 +7972,13 @@ pre_system_call(dcontext_t *dcontext)
            asmlinkage int
            sys_rt_sigsuspend(sigset_t *unewset, size_t sigsetsize)
          */
+        /* TODO i#7955: If a signal is already pending (either because it was blocked
+         * and is now unblocked by sigsuspend, or because it was already unblocked
+         * but delayed by DR), executing sigsuspend may hang because the signal
+         * signal was already consumed by DR's signal handler. We should
+         * detect this (e.g., check signals_pending > 0 after handle_sigsuspend)
+         * and preemptively deliver the signal and skip/re-execute the syscall.
+         */
         handle_sigsuspend(dcontext, (kernel_sigset_t *)sys_param(dcontext, 0),
                           (size_t)sys_param(dcontext, 1));
         break;

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7975,9 +7975,9 @@ pre_system_call(dcontext_t *dcontext)
         /* TODO i#7955: If a signal is already pending (either because it was blocked
          * and is now unblocked by sigsuspend, or because it was already unblocked
          * but delayed by DR), executing sigsuspend may hang because the signal
-         * signal was already consumed by DR's signal handler. We should
-         * detect this (e.g., check signals_pending > 0 after handle_sigsuspend)
-         * and preemptively deliver the signal and skip/re-execute the syscall.
+         * was already consumed by DR's signal handler. We should detect this (e.g.,
+         * check signals_pending > 0 after handle_sigsuspend) and preemptively deliver
+         * the signal and skip/re-execute the syscall.
          */
         handle_sigsuspend(dcontext, (kernel_sigset_t *)sys_param(dcontext, 0),
                           (size_t)sys_param(dcontext, 1));

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -249,7 +249,9 @@ main(int argc, char **argv)
         exit(1);
     }
     sigemptyset(&set);
+    bool did_sigsuspend = false;
     while (!should_exit) {
+        did_sigsuspend = true;
         /* We expect just one signal but best practice is to always loop. */
         sigsuspend(&set);
     }
@@ -259,6 +261,9 @@ main(int argc, char **argv)
     destroy_cond_var(child_ready);
     destroy_cond_var(child_exit);
 
+    if (!did_sigsuspend) {
+        print("ERROR: app did not execute the sigsuspend\n");
+    }
     print("all done\n");
 
     return 0;

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -126,6 +126,15 @@ test_alarm_signals(void *arg)
     /* Test alarm signals not being rerouted from handlers. */
     pthread_t init_thread = (pthread_t)arg;
     unblocked_thread = pthread_self();
+    /* We must unblock SIGALRM in the helper thread because it inherited the
+     * blocked mask from the main thread, and we need it unblocked here so that
+     * process-wide SIGALRM signals (from setitimer) can be delivered to this
+     * thread to verify they are not incorrectly rerouted by DR.
+     */
+    sigset_t unblock_set;
+    sigemptyset(&unblock_set);
+    sigaddset(&unblock_set, SIGALRM);
+    pthread_sigmask(SIG_UNBLOCK, &unblock_set, NULL);
     intercept_signal(SIGALRM, alarm_handler, false);
 
     /* Get init thread inside its handler. */
@@ -223,6 +232,18 @@ main(int argc, char **argv)
      * It would be nice to have a guarantee that the signal will come here but
      * that doesn't seem possible.
      */
+
+    /* We block SIGALRM here to avoid a race condition where the helper thread
+     * sends SIGALRM via pthread_kill before this main thread actually enters
+     * sigsuspend. If that happens, the signal is delivered early, and the
+     * subsequent sigsuspend would block indefinitely because no further signals
+     * are sent. Sigsuspend will atomically unblock it (since 'set' is empty
+     * for sigsuspend below).
+     */
+    sigemptyset(&set);
+    sigaddset(&set, SIGALRM);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+
     if (pthread_create(&thread, NULL, test_alarm_signals, (void *)pthread_self()) != 0) {
         perror("failed to create thread");
         exit(1);


### PR DESCRIPTION
Blocks the SIGALRM in the main thread to prevent a case where the helper thread runs quickly and sends the signal before the main thread has had a chance to block in sigsuspend; the sigsuspend unblocks SIGALRM. SIGALRM is also unblocked by the helper thread so it can receive the itimer signals.

This fixes linux.sigmask and linux.sigmask-noalarm in local runs with 100x iterations, which would previously hang sometimes.

Adds a TODO for an edge case where we don't want DR to execute the app sigsuspend if a newly or previously unblocked signal is already pending. This is fixed by the subsequent PR #7958.

Issue: #7955