### PR TITLE
i#7955: check pending sig before sigsuspend

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7972,6 +7972,13 @@ pre_system_call(dcontext_t *dcontext)
            asmlinkage int
            sys_rt_sigsuspend(sigset_t *unewset, size_t sigsetsize)
          */
+        /* TODO i#7955: If a signal is already pending (either because it was blocked
+         * and is now unblocked by sigsuspend, or because it was already unblocked
+         * but delayed by DR), executing sigsuspend may hang because the signal
+         * signal was already consumed by DR's signal handler. We should
+         * detect this (e.g., check signals_pending > 0 after handle_sigsuspend)
+         * and preemptively deliver the signal and skip/re-execute the syscall.
+         */
         handle_sigsuspend(dcontext, (kernel_sigset_t *)sys_param(dcontext, 0),
                           (size_t)sys_param(dcontext, 1));
         break;

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7972,15 +7972,28 @@ pre_system_call(dcontext_t *dcontext)
            asmlinkage int
            sys_rt_sigsuspend(sigset_t *unewset, size_t sigsetsize)
          */
-        /* TODO i#7955: If a signal is already pending (either because it was blocked
-         * and is now unblocked by sigsuspend, or because it was already unblocked
-         * but delayed by DR), executing sigsuspend may hang because the signal
-         * signal was already consumed by DR's signal handler. We should
-         * detect this (e.g., check signals_pending > 0 after handle_sigsuspend)
-         * and preemptively deliver the signal and skip/re-execute the syscall.
-         */
+
         handle_sigsuspend(dcontext, (kernel_sigset_t *)sys_param(dcontext, 0),
                           (size_t)sys_param(dcontext, 1));
+        if (dcontext->signals_pending > 0) {
+            /* A signal is already pending, which may be because it was blocked
+             * before and is now unblocked by the sigsuspend. Since the kernel has
+             * already delivered it, we must NOT execute the sigsuspend, otherwise
+             * it would hang. Instead, we skip it and return -EINTR.
+             * After we return back to dispatch_enter_dynamorio, dispatch_exit_fcache
+             * will check signals_pending and actually deliver the signal to the
+             * app before returning the EINTR.
+             *
+             * XXX: For pre-existing unblocked signals that were queued up by
+             * DR before the sigsuspend: it's not fully accurate to skip the
+             * sigsuspend; ideally, we should deliver the signal and then enter
+             * sigsuspend. But we choose to avoid that complexity for now; also
+             * apps generally call sigsuspend in a loop until some exit condition is
+             * met.
+             */
+            set_failure_return_val(dcontext, EINTR);
+            execute_syscall = false;
+        }
         break;
     }
 #ifdef LINUX

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4925,17 +4925,17 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
             !signal_is_fault(dcontext, sig, pc, (byte *)sc->SC_XSP, &frame->info) &&
             atomic_aligned_read_int(&info->sighand->threads_unmasked[sig]) > 0 &&
             (!sig_is_alarm_signal(sig) ||
-            /* RFC: For alarms, currently we don't do any rerouting at all if
-             * the thread to which the kernel delivered it is already in an app handler.
-             * As i#5482 says, this strategy benefits large apps particularly.
-             * Would it be nicer if we do s/&&/||/ below and make -reroute_alarm_signals
-             * default false so it can be set only for the cases that do need it?
-             * This would allow apps like sigmask.c from PR #7958 to function
-             * correctly.
-             * Is there any use case for disabling rerouting even if the thread is
-             * not in an app signal handler when the alarm is delivered to it by
-             * the kernel?
-             */
+             /* RFC: For alarms, currently we don't do any rerouting at all if
+              * the thread to which the kernel delivered it is already in an app handler.
+              * As i#5482 says, this strategy benefits large apps particularly.
+              * Would it be nicer if we do s/&&/||/ below and make -reroute_alarm_signals
+              * default false so it can be set only for the cases that do need it?
+              * This would allow apps like sigmask.c from PR #7958 to function
+              * correctly.
+              * Is there any use case for disabling rerouting even if the thread is
+              * not in an app signal handler when the alarm is delivered to it by
+              * the kernel?
+              */
              (!info->in_app_handler && DYNAMO_OPTION(reroute_alarm_signals)))) {
             /* We need to re-route this but cannot acquire the locks to search the
              * threads here.  We thus start delivery and once we come back from

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2718,6 +2718,10 @@ handle_sigsuspend(dcontext_t *dcontext, kernel_sigset_t *set, size_t sigsetsize)
         dump_sigset(dcontext, &info->app_sigblocked);
     }
 #endif
+    /* We must update the pending signals flag to allow pre_system_call to
+     * potentially skip the sigsuspend if a eligible signal is already pending.
+     */
+    check_signals_pending(dcontext, info);
     d_r_mutex_unlock(&info->sigblocked_lock);
     DOLOG(4, LOG_ASYNCH, dump_unmasked(dcontext, __FUNCTION__););
 }
@@ -7522,7 +7526,6 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
         convert_rt_mask_to_nonrt(frame, &our_mask);
     }
 #endif /* LINUX */
-
     /* Make sure we deliver pending signals that are now unblocked.
      */
     check_signals_pending(dcontext, info);

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4925,6 +4925,17 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
             !signal_is_fault(dcontext, sig, pc, (byte *)sc->SC_XSP, &frame->info) &&
             atomic_aligned_read_int(&info->sighand->threads_unmasked[sig]) > 0 &&
             (!sig_is_alarm_signal(sig) ||
+            /* RFC: For alarms, currently we don't do any rerouting at all if
+             * the thread to which the kernel delivered it is already in an app handler.
+             * As i#5482 says, this strategy benefits large apps particularly.
+             * Would it be nicer if we do s/&&/||/ below and make -reroute_alarm_signals
+             * default false so it can be set only for the cases that do need it?
+             * This would allow apps like sigmask.c from PR #7958 to function
+             * correctly.
+             * Is there any use case for disabling rerouting even if the thread is
+             * not in an app signal handler when the alarm is delivered to it by
+             * the kernel?
+             */
              (!info->in_app_handler && DYNAMO_OPTION(reroute_alarm_signals)))) {
             /* We need to re-route this but cannot acquire the locks to search the
              * threads here.  We thus start delivery and once we come back from

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2718,8 +2718,8 @@ handle_sigsuspend(dcontext_t *dcontext, kernel_sigset_t *set, size_t sigsetsize)
         dump_sigset(dcontext, &info->app_sigblocked);
     }
 #endif
-    /* We must update the pending signals flag to allow pre_system_call to
-     * potentially skip the sigsuspend if a eligible signal is already pending.
+    /* Update the pending signals flag to allow pre_system_call to potentially
+     * skip the sigsuspend if a eligible signal is already pending.
      */
     check_signals_pending(dcontext, info);
     d_r_mutex_unlock(&info->sigblocked_lock);

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,7 +52,10 @@
 
 static void *child_ready;
 static void *child_exit;
+static void *initial_sigalrm_sent;
 static volatile bool should_exit;
+static volatile int alarm_handler_runs_init_thread;
+static volatile int alarm_handler_runs_helper_thread;
 static pthread_t unblocked_thread;
 
 #define MAGIC_VALUE 0xdeadbeef
@@ -92,90 +95,19 @@ thread_routine(void *arg)
     while (true) {
         sigsuspend(&set);
     }
+    print("ERROR: unexpected return in thread_routine\n");
     return NULL;
 }
 
 static void
-alarm_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+run_reroute_test(void)
 {
-    if (pthread_self() == unblocked_thread) {
-        if (sig != SIGALRM)
-            print("Unexpected signal %d\n", sig);
-#ifdef LINUX
-        /* We take advantage of DR's lack of transparency where its reroute uses tkill
-         * but the original was process-wide so we can detect a rerouted signal.
-         * Without the logic in DR to not reroute a signal when blocked due to
-         * being inside a handler, this code is triggered and the print fails the
-         * test. Unfortunately we have no simple way of checking this on Mac.
-         */
-        if (siginfo->si_code == SI_TKILL)
-            print("signal from tkill (rerouted?) not expected\n");
-#endif
-    } else {
-        if (sig == SIGALRM && !should_exit) {
-            signal_cond_var(child_ready);
-            /* Sit in the handler with SIGALRM blocked. */
-            wait_cond_var(child_exit);
-        }
-    }
-}
-
-static void *
-test_alarm_signals(void *arg)
-{
-    /* Test alarm signals not being rerouted from handlers. */
-    pthread_t init_thread = (pthread_t)arg;
-    unblocked_thread = pthread_self();
-    /* We must unblock SIGALRM in the helper thread because it inherited the
-     * blocked mask from the main thread, and we need it unblocked here so that
-     * process-wide SIGALRM signals (from setitimer) can be delivered to this
-     * thread to verify they are not incorrectly rerouted by DR.
-     */
-    sigset_t unblock_set;
-    sigemptyset(&unblock_set);
-    sigaddset(&unblock_set, SIGALRM);
-    pthread_sigmask(SIG_UNBLOCK, &unblock_set, NULL);
-    intercept_signal(SIGALRM, alarm_handler, false);
-
-    /* Get init thread inside its handler. */
-    pthread_kill(init_thread, SIGALRM);
-    wait_cond_var(child_ready);
-    reset_cond_var(child_ready);
-
-    print("init thread now inside handler: setting up itimer\n");
-    struct itimerval t;
-    t.it_interval.tv_sec = 0;
-    t.it_interval.tv_usec = 10000;
-    t.it_value.tv_sec = 0;
-    t.it_value.tv_usec = 10000;
-    int res = setitimer(ITIMER_REAL, &t, NULL);
-    if (res != 0)
-        perror("setitimer failed");
-    /* Let a bunch of real-time signals arrive. */
-    for (int i = 0; i < 10; i++)
-        thread_sleep(25);
-    /* Turn off the itimer. */
-    memset(&t, 0, sizeof(t));
-    res = setitimer(ITIMER_REAL, &t, NULL);
-    if (res != 0)
-        perror("setitimer failed");
-
-    /* Exit. */
-    print("done with itimer; exiting\n");
-    should_exit = true;
-    signal_cond_var(child_exit);
-
-    return NULL;
-}
-
-int
-main(int argc, char **argv)
-{
+    print("In run_reroute_test\n");
     pthread_t thread;
     void *retval;
 
-    child_ready = create_cond_var();
-    child_exit = create_cond_var();
+    reset_cond_var(child_ready);
+    reset_cond_var(child_exit);
 
     if (pthread_create(&thread, NULL, thread_routine, NULL) != 0) {
         perror("failed to create thread");
@@ -223,22 +155,123 @@ main(int argc, char **argv)
     pthread_kill(thread, SIGUSR2);
     if (pthread_join(thread, &retval) != 0)
         perror("failed to join thread");
+}
 
-    /* Test alarm signal rerouting.  Since process-wide signals are overwhelmingly
-     * delivered to the initial thread (I can't get them to go anywhere else!), we
-     * need this thread to be the one sitting in a SIGALRM handler while we test whether
-     * signals are rerouted from there.  We create a thread to put us in the handler
-     * and drive the test.
-     * It would be nice to have a guarantee that the signal will come here but
-     * that doesn't seem possible.
+static void
+alarm_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+{
+    if (pthread_self() == unblocked_thread) {
+        if (sig != SIGALRM)
+            print("Unexpected signal %d\n", sig);
+#ifdef LINUX
+        /* We take advantage of DR's lack of transparency where its reroute uses tkill
+         * but the original was process-wide so we can detect a rerouted signal.
+         * Without the logic in DR to not reroute a signal when blocked due to
+         * being inside a handler, this code is triggered and the print fails the
+         * test. Unfortunately we have no simple way of checking this on Mac.
+         */
+        if (siginfo->si_code == SI_TKILL)
+            print("signal from tkill (rerouted?) not expected\n");
+#endif
+        ++alarm_handler_runs_helper_thread;
+    } else {
+        if (sig == SIGALRM && !should_exit) {
+            ++alarm_handler_runs_init_thread;
+            signal_cond_var(child_ready);
+            /* Sit in the handler with SIGALRM blocked. */
+            wait_cond_var(child_exit);
+        }
+    }
+}
+
+static void *
+test_alarm_signals(void *arg)
+{
+    /* Test alarm signals not being rerouted from handlers. */
+    pthread_t init_thread = (pthread_t)arg;
+    unblocked_thread = pthread_self();
+    /* We must unblock SIGALRM in the helper thread because it inherited the
+     * blocked mask from the main thread, and we need it unblocked here so that
+     * process-wide SIGALRM signals (from setitimer) can be delivered to this
+     * thread to verify they are not incorrectly rerouted by DR.
      */
+    sigset_t unblock_set;
+    sigemptyset(&unblock_set);
+    sigaddset(&unblock_set, SIGALRM);
+    pthread_sigmask(SIG_UNBLOCK, &unblock_set, NULL);
+    intercept_signal(SIGALRM, alarm_handler, false);
 
-    /* We block SIGALRM here to avoid a race condition where the helper thread
-     * sends SIGALRM via pthread_kill before this main thread actually enters
-     * sigsuspend. If that happens, the signal is delivered early, and the
-     * subsequent sigsuspend would block indefinitely because no further signals
-     * are sent. Sigsuspend will atomically unblock it (since 'set' is empty
-     * for sigsuspend below).
+    /* Get init thread inside its handler. */
+    pthread_kill(init_thread, SIGALRM);
+    signal_cond_var(initial_sigalrm_sent);
+
+    /* We must wait for the main thread to successfully enter its handler
+     * (signaling child_ready) before we start the itimer. If the main thread
+     * never receives the above SIGALRM and hangs in sigsuspend, we will block
+     * here and never start the itimer.
+     */
+    wait_cond_var(child_ready);
+    reset_cond_var(child_ready);
+
+    print("init thread now inside handler: setting up itimer\n");
+    struct itimerval t;
+    t.it_interval.tv_sec = 0;
+    t.it_interval.tv_usec = 10000;
+    t.it_value.tv_sec = 0;
+    t.it_value.tv_usec = 10000;
+    int res = setitimer(ITIMER_REAL, &t, NULL);
+    if (res != 0)
+        perror("setitimer failed");
+    /* Let a bunch of real-time signals arrive. */
+    for (int i = 0; i < 10; i++)
+        thread_sleep(25);
+    /* Turn off the itimer. */
+    memset(&t, 0, sizeof(t));
+    res = setitimer(ITIMER_REAL, &t, NULL);
+    if (res != 0)
+        perror("setitimer failed");
+
+    /* Exit. */
+    print("done with itimer; exiting\n");
+    should_exit = true;
+    signal_cond_var(child_exit);
+
+#ifdef DISABLED_ISSUE_2311
+    /* PR #5482 (i#2311) disabled rerouting of alarm signals while already
+     * in the app signal handler. This was done to avoid problems on large
+     * apps where rerouting sent them to other threads instead of dropping
+     * if many accumulated. The following check fails when run under DR
+     * but passed otherwise.
+     */
+    if (alarm_handler_runs_helper_thread == 0) {
+        print("ERROR: helper thread did not receive any itimer signals\n");
+    }
+#endif
+
+    return NULL;
+}
+
+static void
+run_alarm_test(bool ensure_pending_sig)
+{
+    print("In run_alarm_test with ensure_pending_sig=%d\n", ensure_pending_sig);
+
+    pthread_t thread;
+    void *retval;
+    sigset_t set;
+
+    alarm_handler_runs_helper_thread = 0;
+    alarm_handler_runs_init_thread = 0;
+    should_exit = false;
+    reset_cond_var(child_ready);
+    reset_cond_var(child_exit);
+    reset_cond_var(initial_sigalrm_sent);
+
+    /* We block SIGALRM here to avoid a race condition where the SIGALRM sent by
+     * the test_alarm_signals helper thread is delivered before this main thread
+     * actually enters sigsuspend. In that case, the sigsuspend would block
+     * indefinitely because no further signals are sent. Sigsuspend will
+     * atomically unblock it by using an empty set.
      */
     sigemptyset(&set);
     sigaddset(&set, SIGALRM);
@@ -248,16 +281,56 @@ main(int argc, char **argv)
         perror("failed to create thread");
         exit(1);
     }
+
+    if (ensure_pending_sig) {
+        /* Ensure that the SIGALRM is already pending before this thread enters
+         * sigsuspend below.
+         */
+        wait_cond_var(initial_sigalrm_sent);
+    } else {
+        /* We cannot really guarantee that the delivery of the SIGALRM will be *after*
+         * this thread has entered sigsuspend. This is best effort.
+         */
+    }
+
     sigemptyset(&set);
+    int runs_before = alarm_handler_runs_init_thread;
     while (!should_exit) {
         /* We expect just one signal but best practice is to always loop. */
         sigsuspend(&set);
     }
+
+    if (alarm_handler_runs_init_thread <= runs_before) {
+        print("ERROR: SIGALRM handler did not run in main thread!\n");
+    }
+
     if (pthread_join(thread, &retval) != 0)
         perror("failed to join thread");
+}
+
+int
+main(int argc, char **argv)
+{
+    child_ready = create_cond_var();
+    child_exit = create_cond_var();
+    initial_sigalrm_sent = create_cond_var();
+
+    run_reroute_test();
+
+    /* Test alarm signal rerouting.
+     * This is the case where the signal may or may not be already sent when we
+     * block at the sigsuspend.
+     */
+    run_alarm_test(/*ensure_pending_sig=*/false);
+
+    /* Test the case where the signal is guaranteed to be recorded as pending in the
+     * kernel before sigsuspend blocks.
+     */
+    run_alarm_test(/*ensure_pending_sig=*/true);
 
     destroy_cond_var(child_ready);
     destroy_cond_var(child_exit);
+    destroy_cond_var(initial_sigalrm_sent);
 
     print("all done\n");
 

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -102,7 +102,7 @@ thread_routine(void *arg)
 static void
 run_reroute_test(void)
 {
-    print("In run_reroute_test\n");
+    print("in run_reroute_test\n");
     pthread_t thread;
     void *retval;
 
@@ -254,7 +254,7 @@ test_alarm_signals(void *arg)
 static void
 run_alarm_test(bool ensure_pending_sig)
 {
-    print("In run_alarm_test with ensure_pending_sig=%d\n", ensure_pending_sig);
+    print("in run_alarm_test with ensure_pending_sig=%d\n", ensure_pending_sig);
 
     pthread_t thread;
     void *retval;

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -126,6 +126,15 @@ test_alarm_signals(void *arg)
     /* Test alarm signals not being rerouted from handlers. */
     pthread_t init_thread = (pthread_t)arg;
     unblocked_thread = pthread_self();
+    /* We must unblock SIGALRM in the helper thread because it inherited the
+     * blocked mask from the main thread, and we need it unblocked here so that
+     * process-wide SIGALRM signals (from setitimer) can be delivered to this
+     * thread to verify they are not incorrectly rerouted by DR.
+     */
+    sigset_t unblock_set;
+    sigemptyset(&unblock_set);
+    sigaddset(&unblock_set, SIGALRM);
+    pthread_sigmask(SIG_UNBLOCK, &unblock_set, NULL);
     intercept_signal(SIGALRM, alarm_handler, false);
 
     /* Get init thread inside its handler. */
@@ -223,6 +232,18 @@ main(int argc, char **argv)
      * It would be nice to have a guarantee that the signal will come here but
      * that doesn't seem possible.
      */
+
+    /* We block SIGALRM here to avoid a race condition where the helper thread
+     * sends SIGALRM via pthread_kill before this main thread actually enters
+     * sigsuspend. If that happens, the signal is delivered early, and the
+     * subsequent sigsuspend would block indefinitely because no further signals
+     * are sent. Sigsuspend will atomically unblock it (since 'set' is empty
+     * for sigsuspend below).
+     */
+    sigemptyset(&set);
+    sigaddset(&set, SIGALRM);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+
     if (pthread_create(&thread, NULL, test_alarm_signals, (void *)pthread_self()) != 0) {
         perror("failed to create thread");
         exit(1);

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -237,11 +237,11 @@ test_alarm_signals(void *arg)
     signal_cond_var(child_exit);
 
 #ifdef DISABLED_ISSUE_2311
-    /* PR #5482 (i#2311) disabled rerouting of alarm signals while already
+    /* TODO i#2311: PR #5482 disabled rerouting of alarm signals while already
      * in the app signal handler. This was done to avoid problems on large
      * apps where rerouting sent them to other threads instead of dropping
      * if many accumulated. The following check fails when run under DR
-     * but passed otherwise.
+     * but passes otherwise.
      */
     if (alarm_handler_runs_helper_thread == 0) {
         print("ERROR: helper thread did not receive any itimer signals\n");

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -284,12 +284,19 @@ run_alarm_test(bool ensure_pending_sig)
 
     if (ensure_pending_sig) {
         /* Ensure that the SIGALRM is already pending before this thread enters
-         * sigsuspend below.
+         * sigsuspend below. This verifies the case where an eligible signal is
+         * already pending for delivery to the app when the app enters the
+         * sigsuspend, in which case DR should skip the sigsuspend.
          */
         wait_cond_var(initial_sigalrm_sent);
     } else {
-        /* We cannot really guarantee that the delivery of the SIGALRM will be *after*
-         * this thread has entered sigsuspend. This is best effort.
+        /* In native runs, the SIGALRM will be delivered to the app after this
+         * thread unblocks it at the sigsuspend. But in runs under DR, since
+         * SIGALRM is not blocked, it may be delivered to DR and queued up as
+         * pending before this thread enters sigsuspend (same as the
+         * ensure_pending_sig case above).
+         * This is a best effort verification for the case where DR indeed enters
+         * the sigsuspend and gets released by the kernel at the SIGALRM.
          */
     }
 

--- a/suite/tests/linux/sigmask.expect
+++ b/suite/tests/linux/sigmask.expect
@@ -1,3 +1,4 @@
+In run_reroute_test
 sending 10
 in handler for signal 10
 sending 28 with value

--- a/suite/tests/linux/sigmask.expect
+++ b/suite/tests/linux/sigmask.expect
@@ -3,6 +3,10 @@ in handler for signal 10
 sending 28 with value
 in handler for signal 28 from -1 value 0xdeadbeef
 in handler for signal 12
+In run_alarm_test with ensure_pending_sig=0
+init thread now inside handler: setting up itimer
+done with itimer; exiting
+In run_alarm_test with ensure_pending_sig=1
 init thread now inside handler: setting up itimer
 done with itimer; exiting
 all done

--- a/suite/tests/linux/sigmask.expect
+++ b/suite/tests/linux/sigmask.expect
@@ -1,13 +1,13 @@
-In run_reroute_test
+in run_reroute_test
 sending 10
 in handler for signal 10
 sending 28 with value
 in handler for signal 28 from -1 value 0xdeadbeef
 in handler for signal 12
-In run_alarm_test with ensure_pending_sig=0
+in run_alarm_test with ensure_pending_sig=0
 init thread now inside handler: setting up itimer
 done with itimer; exiting
-In run_alarm_test with ensure_pending_sig=1
+in run_alarm_test with ensure_pending_sig=1
 init thread now inside handler: setting up itimer
 done with itimer; exiting
 all done


### PR DESCRIPTION
The sigsuspend syscall allows the app to potentially unblock signals atomically. In the pre-syscall handler for sigsuspend, DR must check if any signal that's eligible for delivery is actually queued up already, and if it is, DR should skip the sigsuspend.

Also modifies the sigmask.c test app to add a scenario where such a signal was already sent by another thread but previously blocked by the receiving thread and unblocked atomically at the sigsuspend. This fails without the new pending signals check added to sigsuspend handling.

For pending signals that might have been delivered to DR before the app could've done the sigsuspend but are currently still queued up by DR: such signals should be delivered and we should execute the sigsuspend anyway. But we skip on adding that complexity for now (RFC); this may create some spurious sigsuspend wake-ups but apps generally execute sigsuspend in a loop anyway.

Also refactors the sigmask.c test app, adding some new checks. This revealed an existing issue (i#2311) where SIGALRMs are not correctly routed to another thread if they are blocked on the main thread already handling one (i#2311, PR #5482). See another RFC on alternate treatment of -reroute_alarm_signals that might be better.

linux.sigmask and linux.sigmask-noalarm pass 100x still.

Issue: #7955, #2311

