### PR TITLE
i#4474 client.drcallstack-test failing on CentOS 9

### DIFF
--- a/suite/tests/client-interface/drcallstack-test.templatex
+++ b/suite/tests/client-interface/drcallstack-test.templatex
@@ -8,7 +8,6 @@ client.drcallstack-test!bar
 client.drcallstack-test!foo
 client.drcallstack-test!main
 libc.so.6!.*
-client.drcallstack-test!<unknown>
 in qux
 #else
 #endif


### PR DESCRIPTION
CentOS 9 now supports libunwind-1.8.0-4.el9.aarch64 (previously it was libunwind-1.6.2-1.el9.aarch64). This new version of libunwind gives a different stack trace (which looks more correct to me.)

Previously the stack trace was:
```
client.drcallstack-test!qux
client.drcallstack-test!baz
client.drcallstack-test!bar
client.drcallstack-test!foo
client.drcallstack-test!main
libc.so.6!<unknown>
libc.so.6!<unknown>
client.drcallstack-test!<unknown>
```
Now it is:
```
client.drcallstack-test!qux
client.drcallstack-test!baz
client.drcallstack-test!bar
client.drcallstack-test!foo
client.drcallstack-test!main
libc.so.6!<unknown>
libc.so.6!<unknown>
```
It seems that the stack without `client.drcallstack-test!<unknown>` is more correct.

Updated the expectation file to not expect that line.

Issue: #4474