### PR TITLE
i#7854 wholesys traces: fix is_record_kernel stream inv check

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -964,6 +964,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
 #endif
     }
     if (!is_a_unit_test(shard)) {
+        // TODO i#7854: Run the invariant checker on a checked-in whole_system
+        // trace for coverage of the hardware_event related conditions below.
         report_if_false(shard,
                         (shard->between_kernel_syscall_trace_markers_ ||
                          shard->between_kernel_context_switch_markers_ ||

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -836,7 +836,21 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
 
     bool at_syscall_trace_end = false;
     bool at_context_switch_trace_end = false;
-
+    bool at_outermost_hardware_event_trace_end = false;
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT) {
+        ++shard->hardware_event_context_depth_;
+    }
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) {
+        --shard->hardware_event_context_depth_;
+        if (shard->hardware_event_context_depth_ < 0) {
+            // Allow the trace to start in the middle of an interrupt handler.
+            shard->hardware_event_context_depth_ = 0;
+        } else if (shard->hardware_event_context_depth_ == 0) {
+            at_outermost_hardware_event_trace_end = true;
+        }
+    }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_END) {
         shard->expect_syscall_trace_ = false;
@@ -953,7 +967,9 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         report_if_false(shard,
                         (shard->between_kernel_syscall_trace_markers_ ||
                          shard->between_kernel_context_switch_markers_ ||
-                         at_syscall_trace_end || at_context_switch_trace_end) ==
+                         shard->hardware_event_context_depth_ > 0 ||
+                         at_syscall_trace_end || at_context_switch_trace_end ||
+                         at_outermost_hardware_event_trace_end) ==
                             shard->stream->is_record_kernel(),
                         "Stream is_record_kernel() inaccurate");
     }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -840,6 +840,10 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT) {
         ++shard->hardware_event_context_depth_;
+        // Sanity check to ensure we catch missing endpoints.
+        assert(shard->hardware_event_context_depth_ < 30);
+        report_if_false(shard, shard->hardware_event_context_depth_ < 30,
+                        "Possibly missing hardware_context_return markers.");
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) {

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -186,6 +186,7 @@ protected:
         };
         // We only support sigreturn-using handlers so we have pairing: no longjmp.
         std::stack<signal_context> context_stack_;
+        int hardware_event_context_depth_ = 0;
 
         // When we see a context return marker (TRACE_MARKER_TYPE_KERNEL_XFER or
         // TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) we pop the top entry from

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -186,7 +186,6 @@ protected:
         };
         // We only support sigreturn-using handlers so we have pairing: no longjmp.
         std::stack<signal_context> context_stack_;
-        int hardware_event_context_depth_ = 0;
 
         // When we see a context return marker (TRACE_MARKER_TYPE_KERNEL_XFER or
         // TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) we pop the top entry from
@@ -252,6 +251,7 @@ protected:
         int expected_write_records_ = 0;
         bool between_kernel_syscall_trace_markers_ = false;
         bool between_kernel_context_switch_markers_ = false;
+        int hardware_event_context_depth_ = 0;
         // The kernel-trace-end branch target marker may have a zero value if it's at the
         // end of some thread's trace. If we find a zero-value branch_target marker, we
         // set this flag to verify that there's a thread exit next.


### PR DESCRIPTION
Handles the hardware_event and hardware_context_return markers in the drmemtrace invariant checker is_record_kernel stream invariant check.

Verified that this fixes those invariant errors on an internal trace. Added a TODO to check-in a whole_system trace and run the invariant checker on it for test coverage.

Issue: #7854