### PR TITLE
i#2884: Add O_CLOEXEC to prevent fd leakage in injector

### DIFF
--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -1926,7 +1926,7 @@ inject_ptrace(dr_inject_info_t *info, const char *library_path)
     }
 
     /* Open libdynamorio.so as readonly in the child. */
-    dr_fd = injectee_open(info, library_path, O_RDONLY, 0);
+    dr_fd = injectee_open(info, library_path, O_RDONLY | O_CLOEXEC, 0);
     if (dr_fd < 0) {
         if (verbose) {
             fprintf(stderr, "Unable to open %s in injectee (%d): %s\n ", library_path,

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -1925,7 +1925,9 @@ inject_ptrace(dr_inject_info_t *info, const char *library_path)
         }
     }
 
-    /* Open libdynamorio.so as readonly in the child. */
+    /* Open libdynamorio.so as readonly in the child.
+     * Use O_CLOEXEC so the fd does not leak to the app on exec.
+     */
     dr_fd = injectee_open(info, library_path, O_RDONLY | O_CLOEXEC, 0);
     if (dr_fd < 0) {
         if (verbose) {


### PR DESCRIPTION
When drrun injects libdynamorio.so into a child process, the file descriptor used to open the library was not marked close-on-exec. This caused the fd to leak into the target program, which could be exploited by malware to detect DynamoRIO or alter behavior.

Added O_CLOEXEC flag to the injectee_open call in core/unix/injector.c.

Reproduction:
1. Run: drrun -- target_program
2. Check /proc/<target_pid>/fd before fix - fd 3 points to libdynamorio.so
3. After fix - fd is closed on exec

Fixed #2884