### PR TITLE
i#2440 AArch64 IR: Add INSTR_CREATE_lsl

### DIFF
--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -701,6 +701,26 @@
 #define INSTR_CREATE_ubfm(dc, rd, rn, immr, imms) \
     instr_create_1dst_3src(dc, OP_ubfm, rd, rn, immr, imms)
 
+/**
+ * Creates a LSL (immediate) instruction with one output and two inputs.
+ *
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param rd    The output register.
+ * \param rn    The input register.
+ * \param shift The left-shift immediate.
+ */
+static inline instr_t *
+INSTR_CREATE_lsl(void *dc, opnd_t rd, opnd_t rn, opnd_t shift)
+{
+    const ptr_int_t shift_amount = opnd_get_immed_int(shift);
+    const bool is_32bit = reg_is_32bit(opnd_get_reg(rd));
+    const opnd_t immr = opnd_create_immed_int(
+        is_32bit ? (32 - shift_amount) & 31 : (64 - shift_amount) & 63, OPSZ_6b);
+    const opnd_t imms =
+        opnd_create_immed_int((is_32bit ? 31 : 63) - shift_amount, OPSZ_6b);
+    return INSTR_CREATE_ubfm(dc, rd, rn, immr, imms);
+}
+
 #define INSTR_CREATE_ldp(dc, rt1, rt2, mem) \
     instr_create_2dst_1src(dc, OP_ldp, rt1, rt2, mem)
 #define INSTR_CREATE_ldr(dc, Rd, mem) instr_create_1dst_1src((dc), OP_ldr, (Rd), (mem))

--- a/suite/tests/api/ir_aarch64_v80.c
+++ b/suite/tests/api/ir_aarch64_v80.c
@@ -740,6 +740,52 @@ TEST_INSTR(prfum)
         });
 }
 
+TEST_INSTR(lsl)
+{
+    /* Testing LSL Xd, Xn, #shift */
+    static const uint shift64[6] = {
+        0, 7, 16, 36, 45, 63,
+    };
+    /* lsl is an alias of ubfm:
+     *      lsl Xd, Xn, #shift
+     * maps to
+     *      ubfm Xd, Xn, #(-shift % 64), #(63-shift).
+     */
+    TEST_LOOP_EXPECT(ubfm, 6,
+                     INSTR_CREATE_lsl(dc, opnd_create_reg(Xn_six_offset_0[i]),
+                                      opnd_create_reg(Xn_six_offset_1[i]),
+                                      OPND_CREATE_INT(shift64[i])),
+                     {
+                         EXPECT_DISASSEMBLY("ubfm   %x0 $0x00 $0x3f -> %x0",
+                                            "ubfm   %x6 $0x39 $0x38 -> %x5",
+                                            "ubfm   %x11 $0x30 $0x2f -> %x10",
+                                            "ubfm   %x16 $0x1c $0x1b -> %x15",
+                                            "ubfm   %x21 $0x13 $0x12 -> %x20",
+                                            "ubfm   %x30 $0x01 $0x00 -> %x30", );
+                     });
+
+    static const uint shift32[6] = {
+        0, 7, 16, 24, 27, 31,
+    };
+    /* lsl is an alias of ubfm:
+     *      lsl Wd, Wn, #shift
+     * maps to
+     *      ubfm Wd, Wn, #(-shift % 32), #(31-shift).
+     */
+    TEST_LOOP_EXPECT(ubfm, 6,
+                     INSTR_CREATE_lsl(dc, opnd_create_reg(Wn_six_offset_0[i]),
+                                      opnd_create_reg(Wn_six_offset_1[i]),
+                                      OPND_CREATE_INT(shift32[i])),
+                     {
+                         EXPECT_DISASSEMBLY("ubfm   %w0 $0x00 $0x1f -> %w0",
+                                            "ubfm   %w6 $0x19 $0x18 -> %w5",
+                                            "ubfm   %w11 $0x10 $0x0f -> %w10",
+                                            "ubfm   %w16 $0x08 $0x07 -> %w15",
+                                            "ubfm   %w21 $0x05 $0x04 -> %w20",
+                                            "ubfm   %w30 $0x01 $0x00 -> %w30", );
+                     });
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -769,6 +815,8 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(prfm);
     RUN_INSTR_TEST(prfum);
+
+    RUN_INSTR_TEST(lsl);
 
     print("All v8.0 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
Add an INSTR_CREATE function for the instruction alias
    lsl, Rd, Rn, #shift
and related tests.

Issue: #2440