### PR TITLE
i#7793 kernel filter: add option to keep syscalls

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -287,6 +287,9 @@ Further non-compatibility-affecting changes include:
    instruction ISA_FEAT_ constant.
  - Added instr_get_isa_feature_name() which returns the string name of an ISA_FEAT_
    constant.
+ - Added -filter_kernel and -filter_kernel_except_syscalls to the drmemtrace
+   analyzer that invokes #dynamorio::drmemtrace::kernel_filter_t to remove kernel
+   content from a trace.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -417,6 +417,7 @@ install_client_nonDR_header(drmemtrace tools/view_create.h)
 install_client_nonDR_header(drmemtrace tools/func_view_create.h)
 install_client_nonDR_header(drmemtrace tools/filter/record_filter_create.h)
 install_client_nonDR_header(drmemtrace tools/filter/record_filter.h)
+install_client_nonDR_header(drmemtrace tools/filter/kernel_filter.h)
 # TODO i#6412: Create a separate directory for non-tracer headers so that
 # we can more cleanly separate tracer and raw2trace code.
 install_client_nonDR_header(drmemtrace tracer/raw2trace.h)

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -345,6 +345,12 @@ record_analysis_tool_t *
 record_analyzer_multi_t::create_analysis_tool_from_options(const std::string &tool)
 {
     if (tool == RECORD_FILTER) {
+        if (op_filter_kernel.get_value() &&
+            op_filter_kernel_except_syscalls.get_value()) {
+            ERRMSG("Usage error: cannot specify both -filter_kernel and "
+                   "-filter_kernel_except_syscalls.\n");
+            return nullptr;
+        }
         return record_filter_tool_create(
             op_outdir.get_value(), op_filter_stop_timestamp.get_value(),
             op_filter_cache_size.get_value(), op_filter_trace_types.get_value(),
@@ -352,7 +358,8 @@ record_analyzer_multi_t::create_analysis_tool_from_options(const std::string &to
             op_trim_after_timestamp.get_value(), op_trim_before_instr.get_value(),
             op_trim_after_instr.get_value(), op_encodings2regdeps.get_value(),
             op_filter_func_ids.get_value(), op_modify_marker_value.get_value(),
-            op_filter_kernel.get_value(), op_verbose.get_value());
+            op_filter_kernel.get_value(), op_filter_kernel_except_syscalls.get_value(),
+            op_verbose.get_value());
     } else if (tool == SCHEDULE_STATS) {
         return record_schedule_stats_tool_create(
             op_schedule_stats_print_every.get_value(), op_verbose.get_value());

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -345,12 +345,6 @@ record_analysis_tool_t *
 record_analyzer_multi_t::create_analysis_tool_from_options(const std::string &tool)
 {
     if (tool == RECORD_FILTER) {
-        if (op_filter_kernel.get_value() &&
-            op_filter_kernel_except_syscalls.get_value()) {
-            ERRMSG("Usage error: cannot specify both -filter_kernel and "
-                   "-filter_kernel_except_syscalls.\n");
-            return nullptr;
-        }
         return record_filter_tool_create(
             op_outdir.get_value(), op_filter_stop_timestamp.get_value(),
             op_filter_cache_size.get_value(), op_filter_trace_types.get_value(),

--- a/clients/drcachesim/common/kernel_tracker.h
+++ b/clients/drcachesim/common/kernel_tracker.h
@@ -67,6 +67,16 @@ public:
     }
 
     /**
+     * Returns whether the current point in the trace is inside a system call trace
+     * region.
+     */
+    bool
+    in_syscall_trace() const
+    {
+        return in_syscall_ || last_update_was_syscall_end_marker_;
+    }
+
+    /**
      * Updates the kernel tracking state based on the provided trace \p record.
      */
     void
@@ -86,6 +96,7 @@ private:
         case TRACE_MARKER_TYPE_SYSCALL_TRACE_END:
             in_syscall_ = false;
             last_update_was_end_marker_ = true;
+            last_update_was_syscall_end_marker_ = true;
             break;
         case TRACE_MARKER_TYPE_CONTEXT_SWITCH_END:
             in_context_switch_ = false;
@@ -106,6 +117,7 @@ private:
     update_internal(const memref_t &record)
     {
         last_update_was_end_marker_ = false;
+        last_update_was_syscall_end_marker_ = false;
         if (record.marker.type == TRACE_TYPE_MARKER) {
             update_for_marker(
                 static_cast<trace_marker_type_t>(record.marker.marker_type));
@@ -116,6 +128,7 @@ private:
     update_internal(const trace_entry_t &record)
     {
         last_update_was_end_marker_ = false;
+        last_update_was_syscall_end_marker_ = false;
         if (record.type == TRACE_TYPE_MARKER) {
             update_for_marker(static_cast<trace_marker_type_t>(record.size));
         }
@@ -125,6 +138,7 @@ private:
     bool in_context_switch_ = false;
     int hardware_event_depth_ = 0;
     bool last_update_was_end_marker_ = false;
+    bool last_update_was_syscall_end_marker_ = false;
 };
 
 /**

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1310,13 +1310,28 @@ droption_t<uint64_t> op_trim_after_instr(
 
 droption_t<bool> op_filter_kernel(
     DROPTION_SCOPE_FRONTEND, "filter_kernel", false,
-    "Removes the kernel system call and context switch content from the trace.",
+    "Removes the kernel system call, context switch, and hardware event content from the "
+    "trace.",
     "This option is for -tool " RECORD_FILTER ". When present, it removes the kernel "
     "system call trace content between TRACE_MARKER_TYPE_SYSCALL_TRACE_START and "
     "TRACE_MARKER_TYPE_SYSCALL_TRACE_END, the kernel context switch trace content "
     "between TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and "
-    "TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, and also updates the trace file type to "
-    "remove the OFFLINE_FILE_TYPE_KERNEL_SYSCALLS bit.");
+    "TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, and the kernel content between "
+    "TRACE_MARKER_TYPE_HARDWARE_EVENT and TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN "
+    "markers. It also updates the trace file type to remove the "
+    "OFFLINE_FILE_TYPE_KERNEL_SYSCALLS bit.");
+
+droption_t<bool> op_filter_kernel_except_syscalls(
+    DROPTION_SCOPE_FRONTEND, "filter_kernel_except_syscalls", false,
+    "Removes the kernel context switch and hardware event content from the trace while "
+    "keeping system call content.",
+    "This option is for -tool " RECORD_FILTER ". When present, it removes kernel trace "
+    "content except system call trace content between "
+    "TRACE_MARKER_TYPE_SYSCALL_TRACE_START and TRACE_MARKER_TYPE_SYSCALL_TRACE_END. It "
+    "removes the kernel context switch trace content between "
+    "TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and TRACE_MARKER_TYPE_CONTEXT_SWITCH_END "
+    "and the kernel content between TRACE_MARKER_TYPE_HARDWARE_EVENT and "
+    "TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers.");
 
 droption_t<bool> op_abort_on_invariant_error(
     DROPTION_SCOPE_ALL, "abort_on_invariant_error", true,

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1331,8 +1331,8 @@ droption_t<bool> op_filter_kernel_except_syscalls(
     "removes the kernel context switch trace content between "
     "TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and TRACE_MARKER_TYPE_CONTEXT_SWITCH_END "
     "and the kernel content between TRACE_MARKER_TYPE_HARDWARE_EVENT and "
-    "TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers unless nested within a system call "
-    "trace.");
+    "TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers unless nested within a system "
+    "call trace.");
 
 droption_t<bool> op_abort_on_invariant_error(
     DROPTION_SCOPE_ALL, "abort_on_invariant_error", true,

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1331,7 +1331,8 @@ droption_t<bool> op_filter_kernel_except_syscalls(
     "removes the kernel context switch trace content between "
     "TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and TRACE_MARKER_TYPE_CONTEXT_SWITCH_END "
     "and the kernel content between TRACE_MARKER_TYPE_HARDWARE_EVENT and "
-    "TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers.");
+    "TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers unless nested within a system call "
+    "trace.");
 
 droption_t<bool> op_abort_on_invariant_error(
     DROPTION_SCOPE_ALL, "abort_on_invariant_error", true,

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -253,6 +253,7 @@ extern dynamorio::droption::droption_t<uint64_t> op_trim_after_timestamp;
 extern dynamorio::droption::droption_t<uint64_t> op_trim_before_instr;
 extern dynamorio::droption::droption_t<uint64_t> op_trim_after_instr;
 extern dynamorio::droption::droption_t<bool> op_filter_kernel;
+extern dynamorio::droption::droption_t<bool> op_filter_kernel_except_syscalls;
 extern dynamorio::droption::droption_t<bool> op_abort_on_invariant_error;
 extern dynamorio::droption::droption_t<bool> op_pt2ir_best_effort;
 extern dynamorio::droption::droption_t<int> op_scale_timers;

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -1973,6 +1973,8 @@ test_kernel_filter_except_syscalls()
 
         // Kernel trace between syscall markers and nested hardware_event markers -
         // preserved.
+        // This is the only nesting of kernel trace marker pairs that's currently
+        // expected.
         { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, { 1 } },
           true,
           { true } },

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -1906,6 +1906,101 @@ test_kernel_filter()
     return true;
 }
 
+static bool
+test_kernel_filter_except_syscalls()
+{
+    // Test keeping syscall content while removing other kernel content.
+    constexpr addr_t TID = 5;
+    constexpr addr_t PC_A = 0x1234;
+    constexpr addr_t ENCODING_A = 0x4321;
+    constexpr addr_t PC_B = 0xabcd;
+    constexpr addr_t ENCODING_B = 0xdbca;
+    std::vector<test_case_t> entries = {
+        { { TRACE_TYPE_HEADER, 0, { 0x1 } }, true, { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION, { 0x2 } }, true, { true } },
+        { { TRACE_TYPE_MARKER,
+            TRACE_MARKER_TYPE_FILETYPE,
+            { OFFLINE_FILE_TYPE_ARCH_X86_64 | OFFLINE_FILE_TYPE_ENCODINGS |
+              OFFLINE_FILE_TYPE_KERNEL_SYSCALLS } },
+          true,
+          { true } },
+        { { TRACE_TYPE_THREAD, 0, { TID } }, true, { true } },
+        { { TRACE_TYPE_PID, 0, { 0x5 } }, true, { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, { 0x6 } },
+          true,
+          { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 100 } }, true, { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 0 } }, true, { true } },
+        { { TRACE_TYPE_ENCODING, 2, { ENCODING_A } }, true, { true } },
+        { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
+
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL, { 1 } }, true, { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, { 1 } },
+          true,
+          { true } },
+        { { TRACE_TYPE_ENCODING, 2, { ENCODING_B } }, true, { true } },
+        { { TRACE_TYPE_INSTR, 2, { PC_B } }, true, { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, { 1 } },
+          true,
+          { true } },
+
+        { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
+
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, { 1 } },
+          true,
+          { false } },
+        { { TRACE_TYPE_ENCODING, 2, { ENCODING_B } }, true, { false } },
+        { { TRACE_TYPE_INSTR, 2, { PC_B } }, true, { false } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, { 1 } },
+          true,
+          { false } },
+        { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
+
+        // Kernel trace between hardware_event and hardware_context_return markers.
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_HARDWARE_EVENT, { 1 } },
+          true,
+          { false } },
+        { { TRACE_TYPE_ENCODING, 2, { ENCODING_B } }, true, { false } },
+        { { TRACE_TYPE_INSTR, 2, { PC_B } }, true, { false } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, { 1 } },
+          true,
+          { false } },
+
+        { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
+
+        // Kernel trace between syscall markers and nested hardware_event markers.
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, { 1 } },
+          true,
+          { true } },
+        { { TRACE_TYPE_INSTR, 2, { PC_B } }, true, { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_HARDWARE_EVENT, { 1 } },
+          true,
+          { true } },
+        { { TRACE_TYPE_INSTR, 2, { PC_B } }, true, { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, { 1 } },
+          true,
+          { true } },
+        { { TRACE_TYPE_INSTR, 2, { PC_B } }, true, { true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, { 1 } },
+          true,
+          { true } },
+
+        { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
+        { { TRACE_TYPE_THREAD_EXIT, 0, { TID } }, true, { true } },
+        { { TRACE_TYPE_FOOTER, 0, { 0xa2 } }, true, { true } },
+    };
+    std::vector<std::unique_ptr<record_filter_func_t>> filters;
+    auto kernel_filter = std::unique_ptr<record_filter_func_t>(
+        new dynamorio::drmemtrace::kernel_filter_t(/*keep_syscalls=*/true));
+    filters.push_back(std::move(kernel_filter));
+    auto record_filter = std::unique_ptr<test_record_filter_t>(
+        new test_record_filter_t(std::move(filters), 0, /*write_archive=*/true));
+    if (!process_entries_and_check_result(record_filter.get(), entries, 0).empty())
+        return false;
+    fprintf(stderr, "test_kernel_filter_except_syscalls passed\n");
+    return true;
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -1920,7 +2015,7 @@ test_main(int argc, const char *argv[])
     if (!test_cache_and_type_filter() || !test_chunk_update() || !test_trim_filter() ||
         !test_null_filter() || !test_wait_filter() || !test_encodings2regdeps_filter() ||
         !test_func_id_filter() || !test_modify_marker_value_filter() ||
-        !test_kernel_filter())
+        !test_kernel_filter() || !test_kernel_filter_except_syscalls())
         return 1;
     fprintf(stderr, "All done!\n");
     dr_standalone_exit();

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -1935,6 +1935,7 @@ test_kernel_filter_except_syscalls()
         { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
 
         { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL, { 1 } }, true, { true } },
+        // Syscall trace - preserved.
         { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, { 1 } },
           true,
           { true } },
@@ -1946,6 +1947,7 @@ test_kernel_filter_except_syscalls()
 
         { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
 
+        // Context switch trace - removed.
         { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, { 1 } },
           true,
           { false } },
@@ -1956,7 +1958,8 @@ test_kernel_filter_except_syscalls()
           { false } },
         { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
 
-        // Kernel trace between hardware_event and hardware_context_return markers.
+        // Kernel trace between hardware_event and hardware_context_return markers -
+        // removed.
         { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_HARDWARE_EVENT, { 1 } },
           true,
           { false } },
@@ -1968,7 +1971,8 @@ test_kernel_filter_except_syscalls()
 
         { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
 
-        // Kernel trace between syscall markers and nested hardware_event markers.
+        // Kernel trace between syscall markers and nested hardware_event markers -
+        // preserved.
         { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, { 1 } },
           true,
           { true } },

--- a/clients/drcachesim/tools/filter/kernel_filter.h
+++ b/clients/drcachesim/tools/filter/kernel_filter.h
@@ -38,11 +38,16 @@
 namespace dynamorio {
 namespace drmemtrace {
 
-// Removes all entries between and including the pairs of markers representing
-// kernel execution: for syscalls (TRACE_MARKER_TYPE_SYSCALL_TRACE_START,
-// TRACE_MARKER_TYPE_SYSCALL_TRACE_END), and context switches
-// (TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and TRACE_MARKER_TYPE_CONTEXT_SWITCH_END).
-// If keep_syscalls is true, removes kernel execution entries except system call entries.
+/**
+ * Removes all entries between and including the pairs of markers representing
+ * kernel execution: for syscalls (#TRACE_MARKER_TYPE_SYSCALL_TRACE_START and
+ * #TRACE_MARKER_TYPE_SYSCALL_TRACE_END), context switches
+ * (#TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and #TRACE_MARKER_TYPE_CONTEXT_SWITCH_END),
+ * and hardware events (#TRACE_MARKER_TYPE_HARDWARE_EVENT and
+ * #TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN).
+ * If keep_syscalls is true, removes kernel execution entries except system call
+ * entries (including the other kernel execution nested within it).
+ */
 class kernel_filter_t : public record_filter_t::record_filter_func_t {
 public:
     kernel_filter_t(bool keep_syscalls = false)

--- a/clients/drcachesim/tools/filter/kernel_filter.h
+++ b/clients/drcachesim/tools/filter/kernel_filter.h
@@ -42,8 +42,14 @@ namespace drmemtrace {
 // kernel execution: for syscalls (TRACE_MARKER_TYPE_SYSCALL_TRACE_START,
 // TRACE_MARKER_TYPE_SYSCALL_TRACE_END), and context switches
 // (TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and TRACE_MARKER_TYPE_CONTEXT_SWITCH_END).
+// If keep_syscalls is true, removes kernel execution entries except system call entries.
 class kernel_filter_t : public record_filter_t::record_filter_func_t {
 public:
+    kernel_filter_t(bool keep_syscalls = false)
+        : keep_syscalls_(keep_syscalls)
+    {
+    }
+
     struct shard_data_t {
         kernel_tracker_tmpl_t<trace_entry_t> kernel_tracker;
     };
@@ -61,6 +67,10 @@ public:
     {
         shard_data_t *data = reinterpret_cast<shard_data_t *>(shard_data);
         data->kernel_tracker.update(entry);
+        if (keep_syscalls_) {
+            return !data->kernel_tracker.in_kernel_trace() ||
+                data->kernel_tracker.in_syscall_trace();
+        }
         return !data->kernel_tracker.in_kernel_trace();
     }
     bool
@@ -72,9 +82,13 @@ public:
     uint64_t
     update_filetype(uint64_t filetype) override
     {
-        filetype &= ~OFFLINE_FILE_TYPE_KERNEL_SYSCALLS;
+        if (!keep_syscalls_)
+            filetype &= ~OFFLINE_FILE_TYPE_KERNEL_SYSCALLS;
         return filetype;
     }
+
+private:
+    bool keep_syscalls_ = false;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -127,6 +127,11 @@ record_filter_tool_create(const std::string &output_dir, uint64_t stop_timestamp
                           const std::string &modify_marker_value, bool filter_kernel,
                           bool filter_kernel_except_syscalls, unsigned int verbose)
 {
+    if (filter_kernel && filter_kernel_except_syscalls) {
+        ERRMSG("Usage error: cannot specify both -filter_kernel and "
+               "-filter_kernel_except_syscalls.\n");
+        return nullptr;
+    }
     std::vector<
         std::unique_ptr<dynamorio::drmemtrace::record_filter_t::record_filter_func_t>>
         filter_funcs;

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -125,7 +125,7 @@ record_filter_tool_create(const std::string &output_dir, uint64_t stop_timestamp
                           uint64_t trim_before_instr, uint64_t trim_after_instr,
                           bool encodings2regdeps, const std::string &keep_func_ids,
                           const std::string &modify_marker_value, bool filter_kernel,
-                          unsigned int verbose)
+                          bool filter_kernel_except_syscalls, unsigned int verbose)
 {
     std::vector<
         std::unique_ptr<dynamorio::drmemtrace::record_filter_t::record_filter_func_t>>
@@ -176,10 +176,11 @@ record_filter_tool_create(const std::string &output_dir, uint64_t stop_timestamp
                 new dynamorio::drmemtrace::modify_marker_value_filter_t(
                     modify_marker_value_pairs_list)));
     }
-    if (filter_kernel) {
+    if (filter_kernel || filter_kernel_except_syscalls) {
         filter_funcs.emplace_back(
             std::unique_ptr<dynamorio::drmemtrace::record_filter_t::record_filter_func_t>(
-                new dynamorio::drmemtrace::kernel_filter_t()));
+                new dynamorio::drmemtrace::kernel_filter_t(
+                    /*keep_syscalls=*/filter_kernel_except_syscalls)));
     }
     // TODO i#5675: Add other filters.
 

--- a/clients/drcachesim/tools/filter/record_filter_create.h
+++ b/clients/drcachesim/tools/filter/record_filter_create.h
@@ -78,7 +78,11 @@ namespace drmemtrace {
  *  content between TRACE_MARKER_TYPE_SYSCALL_TRACE_START and
  *  TRACE_MARKER_TYPE_SYSCALL_TRACE_END, the kernel context switch trace content between
  *  TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, and
- *  also update the trace file type to remove the OFFLINE_FILE_TYPE_KERNEL_SYSCALLS bit.
+ *  the kernel content between TRACE_MARKER_TYPE_HARDWARE_EVENT and
+ *  TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers, and also update the trace file type
+ *  to remove the OFFLINE_FILE_TYPE_KERNEL_SYSCALLS bit.
+ * @param[in] filter_kernel_except_syscalls A bool denoting whether to filter out kernel
+ *  trace content except system call trace content.
  * @param[in] verbose  Verbosity level for notifications.
  */
 record_analysis_tool_t *
@@ -89,7 +93,7 @@ record_filter_tool_create(const std::string &output_dir, uint64_t stop_timestamp
                           uint64_t trim_before_instr, uint64_t trim_after_instr,
                           bool encodings2regdeps, const std::string &keep_func_ids,
                           const std::string &modify_marker_value, bool filter_kernel,
-                          unsigned int verbose);
+                          bool filter_kernel_except_syscalls, unsigned int verbose);
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/tools/filter/record_filter_create.h
+++ b/clients/drcachesim/tools/filter/record_filter_create.h
@@ -82,7 +82,8 @@ namespace drmemtrace {
  *  TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers, and also update the trace file type
  *  to remove the OFFLINE_FILE_TYPE_KERNEL_SYSCALLS bit.
  * @param[in] filter_kernel_except_syscalls A bool denoting whether to filter out kernel
- *  trace content except system call trace content.
+ *  trace content except system call trace content and any hardware events nested within
+ *  system calls.
  * @param[in] verbose  Verbosity level for notifications.
  */
 record_analysis_tool_t *

--- a/clients/drcachesim/tools/record_filter_launcher.cpp
+++ b/clients/drcachesim/tools/record_filter_launcher.cpp
@@ -162,13 +162,28 @@ droption_t<std::string> op_modify_marker_value(
 
 droption_t<bool> op_filter_kernel(
     DROPTION_SCOPE_FRONTEND, "filter_kernel", false,
-    "Removes the kernel system call and context switch content from the trace.",
+    "Removes the kernel system call, context switch, and hardware event content from the "
+    "trace.",
     "This option is for -tool record_filter. When present, it removes the kernel "
     "system call trace content between TRACE_MARKER_TYPE_SYSCALL_TRACE_START and "
     "TRACE_MARKER_TYPE_SYSCALL_TRACE_END, the kernel context switch trace content "
     "between TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and "
-    "TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, and also updates the trace file type to "
-    "remove the OFFLINE_FILE_TYPE_KERNEL_SYSCALLS bit.");
+    "TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, and the kernel content between "
+    "TRACE_MARKER_TYPE_HARDWARE_EVENT and TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN "
+    "markers. It also updates the trace file type to remove the "
+    "OFFLINE_FILE_TYPE_KERNEL_SYSCALLS bit.");
+
+droption_t<bool> op_filter_kernel_except_syscalls(
+    DROPTION_SCOPE_FRONTEND, "filter_kernel_except_syscalls", false,
+    "Removes the kernel context switch and hardware event content from the trace while "
+    "keeping system call content.",
+    "This option is for -tool record_filter. When present, it removes kernel trace "
+    "content except system call trace content between "
+    "TRACE_MARKER_TYPE_SYSCALL_TRACE_START and TRACE_MARKER_TYPE_SYSCALL_TRACE_END. It "
+    "removes the kernel context switch trace content between "
+    "TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and TRACE_MARKER_TYPE_CONTEXT_SWITCH_END "
+    "and the kernel content between TRACE_MARKER_TYPE_HARDWARE_EVENT and "
+    "TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers.");
 
 } // namespace
 
@@ -193,6 +208,10 @@ _tmain(int argc, const TCHAR *targv[])
         FATAL_ERROR("Usage error: %s\nUsage:\n%s", parse_err.c_str(),
                     droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     }
+    if (op_filter_kernel.get_value() && op_filter_kernel_except_syscalls.get_value()) {
+        FATAL_ERROR("Usage error: cannot specify both -filter_kernel and "
+                    "-filter_kernel_except_syscalls.");
+    }
 
     auto record_filter = std::unique_ptr<record_analysis_tool_t>(
         dynamorio::drmemtrace::record_filter_tool_create(
@@ -202,7 +221,8 @@ _tmain(int argc, const TCHAR *targv[])
             op_trim_after_timestamp.get_value(), op_trim_before_instr.get_value(),
             op_trim_after_instr.get_value(), op_encodings2regdeps.get_value(),
             op_filter_func_ids.get_value(), op_modify_marker_value.get_value(),
-            op_filter_kernel.get_value(), op_verbose.get_value()));
+            op_filter_kernel.get_value(), op_filter_kernel_except_syscalls.get_value(),
+            op_verbose.get_value()));
     std::vector<record_analysis_tool_t *> tools;
     tools.push_back(record_filter.get());
 

--- a/clients/drcachesim/tools/record_filter_launcher.cpp
+++ b/clients/drcachesim/tools/record_filter_launcher.cpp
@@ -209,10 +209,6 @@ _tmain(int argc, const TCHAR *targv[])
         FATAL_ERROR("Usage error: %s\nUsage:\n%s", parse_err.c_str(),
                     droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     }
-    if (op_filter_kernel.get_value() && op_filter_kernel_except_syscalls.get_value()) {
-        FATAL_ERROR("Usage error: cannot specify both -filter_kernel and "
-                    "-filter_kernel_except_syscalls.");
-    }
 
     auto record_filter = std::unique_ptr<record_analysis_tool_t>(
         dynamorio::drmemtrace::record_filter_tool_create(

--- a/clients/drcachesim/tools/record_filter_launcher.cpp
+++ b/clients/drcachesim/tools/record_filter_launcher.cpp
@@ -183,7 +183,8 @@ droption_t<bool> op_filter_kernel_except_syscalls(
     "removes the kernel context switch trace content between "
     "TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and TRACE_MARKER_TYPE_CONTEXT_SWITCH_END "
     "and the kernel content between TRACE_MARKER_TYPE_HARDWARE_EVENT and "
-    "TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers.");
+    "TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers unless nested within a system "
+    "call trace.");
 
 } // namespace
 


### PR DESCRIPTION
Adds keep_syscalls mode to kernel_filter_t and -filter_kernel_except_syscalls option to filter out kernel trace content (context switches and hardware events) while preserving system calls.

Adds kernel_tracker_t::in_syscall_trace to share logic to detect whether we're specifically inside a syscall trace.

Note that whole-system traces may have the hardware_event and hardware_context_return marker pair nested inside syscalls; we preserve those under the new keep_syscalls mode, because that execution was observed as part of a system call.

Issue: #7793