### PR TITLE
i#7970 xl8 prefix: Clean up tag and just-pc translation

### DIFF
--- a/core/lib/dr_events.h
+++ b/core/lib/dr_events.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -685,7 +685,8 @@ typedef struct _dr_fault_fragment_info_t {
     /**
      * The tag of the code fragment inside the code cache at the
      * exception/signal/translation interruption point. NULL for
-     * interruption not in the code cache.
+     * interruption not in the code cache. Use dr_fragment_app_pc() to convert
+     * to an application address.
      */
     void *tag;
     /**

--- a/core/lib/dr_events.h
+++ b/core/lib/dr_events.h
@@ -686,7 +686,7 @@ typedef struct _dr_fault_fragment_info_t {
      * The tag of the code fragment inside the code cache at the
      * exception/signal/translation interruption point. NULL for
      * interruption not in the code cache. Use dr_fragment_app_pc() to convert
-     * to an application address.
+     * to the corresponding application address.
      */
     void *tag;
     /**

--- a/core/translate.c
+++ b/core/translate.c
@@ -119,9 +119,9 @@ instr_is_inline_syscall_jmp(dcontext_t *dcontext, instr_t *inst)
 {
     if (!instr_is_our_mangling(inst))
         return false;
-    /* Not bothering to check whether there's a nearby syscall instr:
-     * any label-targeting short jump should be fine to ignore.
-     */
+        /* Not bothering to check whether there's a nearby syscall instr:
+         * any label-targeting short jump should be fine to ignore.
+         */
 #    ifdef X86
     return (instr_get_opcode(inst) == OP_jmp_short &&
             opnd_is_instr(instr_get_target(inst)));

--- a/core/translate.c
+++ b/core/translate.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -119,9 +119,9 @@ instr_is_inline_syscall_jmp(dcontext_t *dcontext, instr_t *inst)
 {
     if (!instr_is_our_mangling(inst))
         return false;
-        /* Not bothering to check whether there's a nearby syscall instr:
-         * any label-targeting short jump should be fine to ignore.
-         */
+    /* Not bothering to check whether there's a nearby syscall instr:
+     * any label-targeting short jump should be fine to ignore.
+     */
 #    ifdef X86
     return (instr_get_opcode(inst) == OP_jmp_short &&
             opnd_is_instr(instr_get_target(inst)));
@@ -1096,7 +1096,7 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
                     }
                 });
                 if (prev_ok == NULL) {
-                    answer = start_app;
+                    answer = dr_fragment_app_pc(start_app);
                     LOG(THREAD_GET, LOG_INTERP, 2,
                         "recreate_app -- WARNING: guessing start pc " PFX "\n", answer);
                 } else {
@@ -1292,12 +1292,13 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
             /* no translation needed, ignoring sysenter stack hacks */
             LOG(THREAD_GET, LOG_INTERP | LOG_SYNCH, 2,
                 "recreate_app no translation needed (at vsyscall)\n");
-            if (!just_pc)
+            if (!just_pc) {
                 restore_stolen_register(tdcontext, mcontext);
-            if (dr_xl8_hook_exists()) {
-                if (!instrument_restore_nonfcache_state_prealloc(
-                        tdcontext, restore_memory, mcontext, &xl8_mcontext))
-                    return RECREATE_FAILURE;
+                if (dr_xl8_hook_exists()) {
+                    if (!instrument_restore_nonfcache_state_prealloc(
+                            tdcontext, restore_memory, mcontext, &xl8_mcontext))
+                        return RECREATE_FAILURE;
+                }
             }
             return res;
         } else {
@@ -1349,12 +1350,13 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
             mcontext->xdx = tdcontext->app_xdx;
         }
 #    endif
-        if (!just_pc)
+        if (!just_pc) {
             restore_stolen_register(tdcontext, mcontext);
-        if (dr_xl8_hook_exists()) {
-            if (!instrument_restore_nonfcache_state_prealloc(tdcontext, restore_memory,
-                                                             mcontext, &xl8_mcontext))
-                return RECREATE_FAILURE;
+            if (dr_xl8_hook_exists()) {
+                if (!instrument_restore_nonfcache_state_prealloc(
+                        tdcontext, restore_memory, mcontext, &xl8_mcontext))
+                    return RECREATE_FAILURE;
+            }
         }
         return res;
     }
@@ -1393,16 +1395,17 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
 #else
         if (is_after_syscall_that_rets(tdcontext, mcontext->pc + INT_LENGTH)) {
             /* i#1145: preserve syscall re-start point */
-            mcontext->pc = POST_SYSCALL_PC(tdcontext) - INT_LENGTH;
+            mcontext->pc = dr_fragment_app_pc(POST_SYSCALL_PC(tdcontext)) - INT_LENGTH;
         } else
 #endif
-        mcontext->pc = POST_SYSCALL_PC(tdcontext);
-        if (!just_pc)
+        mcontext->pc = dr_fragment_app_pc(POST_SYSCALL_PC(tdcontext));
+        if (!just_pc) {
             restore_stolen_register(tdcontext, mcontext);
-        if (dr_xl8_hook_exists()) {
-            if (!instrument_restore_nonfcache_state_prealloc(tdcontext, restore_memory,
-                                                             mcontext, &xl8_mcontext))
-                return RECREATE_FAILURE;
+            if (dr_xl8_hook_exists()) {
+                if (!instrument_restore_nonfcache_state_prealloc(
+                        tdcontext, restore_memory, mcontext, &xl8_mcontext))
+                    return RECREATE_FAILURE;
+            }
         }
         return res;
     } else if (mcontext->pc == get_reset_exit_stub(tdcontext)) {
@@ -1410,13 +1413,14 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
             "recreate_app at reset exit stub => using next_tag " PFX "\n",
             tdcontext->next_tag);
         /* Context is completely native except the pc and the stolen register. */
-        mcontext->pc = tdcontext->next_tag;
-        if (!just_pc)
+        mcontext->pc = dr_fragment_app_pc(tdcontext->next_tag);
+        if (!just_pc) {
             restore_stolen_register(tdcontext, mcontext);
-        if (dr_xl8_hook_exists()) {
-            if (!instrument_restore_nonfcache_state_prealloc(tdcontext, restore_memory,
-                                                             mcontext, &xl8_mcontext))
-                return RECREATE_FAILURE;
+            if (dr_xl8_hook_exists()) {
+                if (!instrument_restore_nonfcache_state_prealloc(
+                        tdcontext, restore_memory, mcontext, &xl8_mcontext))
+                    return RECREATE_FAILURE;
+            }
         }
         return res;
     } else if (in_generated_routine(tdcontext, mcontext->pc)) {
@@ -1853,8 +1857,9 @@ record_translation_info(dcontext_t *dcontext, fragment_t *f, instrlist_t *existi
     cpc = (byte *)FCACHE_ENTRY_PC(f);
     if (fragment_prefix_size(f->flags) > 0) {
         ASSERT(f->start_pc < cpc);
-        set_translation(dcontext, &entries, &num_entries, i, 0, f->tag,
-                        true /*identical*/, true /*our mangling*/, false /*!call*/);
+        set_translation(dcontext, &entries, &num_entries, i, 0,
+                        dr_fragment_app_pc(f->tag), true /*identical*/,
+                        true /*our mangling*/, false /*!call*/);
         last_translation = f->tag;
         last_contig = false;
         i++;


### PR DESCRIPTION
Cleans up two aspects of state translation noticed via inspection while preparing the #7970 fix:

+ Use dr_fragment_app_pc() on tags, instead of returning raw tags. This is difficult to test since there are few cases where the tag does not equal the app pc, and hitting a tag return case in translation requires hitting a handful of rare points, so we leave this without a targeted regression test. This was tested on a large internal application which translates each PC in each frame of a stack walk in an itimer.

+ Do not call instrument_restore_nonfcache_state_prealloc() for just_pc, since this is only meant for restoring (non-register) state changes and there should not be any such restoration for just_pc=true.  Minimally tested by ensuring the #4197 test drwrap-test-detach still passes. This was also tested on a large internal application which translates each PC in each frame of a stack walk in an itimer.

Issue: #7970