### PR TITLE
i#6672 Remove deprecated `register` keyword in `burst_traceopts.cpp`

### DIFF
--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -141,7 +141,7 @@ test_arrays()
     // test suite builds).  The code below does trigger i#4403 on my machine
     // and contains further patterns which hopefully gives more confidence to
     // our optimizations.
-    register int *ptr = array + 1;
+    int *ptr = array + 1;
     for (int i = 1; i < size - 1; ++i) {
         *ptr += *(ptr - 1) + *(ptr + 1);
         ptr++;


### PR DESCRIPTION
Remove a drprecated `register` storage-class specifier in `burst_traceopts.cpp`

The `register` storage-class specifier was removed in C++17, causing a `-Wregister` warning during build. Compilers have ignored the `register` keyword since long ago, so dropping it is a no-op change.

[Example of the warning in the log](https://github.com/DynamoRIO/dynamorio/actions/runs/28974846363/job/85979335958?pr=7984#step:7:4184)

Issue: #6672 