### PR TITLE
i#7990: Fix wrong default value for KSTATS_DEFAULT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,19 +408,17 @@ option(TEST_SUITE "we are running a series of builds for official purposes")
 if (INTERNAL OR DEBUG)
   set(KSTATS_DEFAULT ON)
 else (INTERNAL OR DEBUG)
-  set(KSTATS_DEFAULT 0FF)
+  set(KSTATS_DEFAULT OFF)
 endif (INTERNAL OR DEBUG)
 
 # no KSTATS for caller profiling: we want to be as close to release
 # build as we can, but w/o optimizations
 if (CALLPROF)
-  set(KSTATS_DEFAULT 0FF)
+  set(KSTATS_DEFAULT OFF)
 endif (CALLPROF)
 
 set(KSTATS "" CACHE STRING "internal kstat profiling: ON or OFF overrides default")
-# XXX i#170: once CMake 2.8 is released we can detect whether 2.8 is
-# in use, and if so use a value-enum to get drop-down of possible values, like so:
-#   set_property(CACHE KSTATS PROPERTY STRINGS "" "ON" "OFF")
+set_property(CACHE KSTATS PROPERTY STRINGS "" "ON" "OFF")
 if ("${KSTATS}" STREQUAL "")
     set(KSTATS ${KSTATS_DEFAULT})
 endif()

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -100,7 +100,7 @@ static void
 handle_callback_return(dcontext_t *dcontext);
 #endif
 
-#if defined(UNIX) && !defined(X64)
+#if (defined(UNIX) && !defined(X64)) || defined(DEBUG) || defined(KSTATS)
 /* PR 356503: detect clients making syscalls via sysenter */
 static inline void
 found_client_sysenter(void)
@@ -1371,7 +1371,6 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
     if (dcontext->last_exit == get_syscall_linkstub()) {
         LOG(THREAD, LOG_DISPATCH, 2, "Exit from system call\n");
         STATS_INC(num_exits_syscalls);
-#    if defined(UNIX) && !defined(X64)
         /* PR 356503: clients using libraries that make syscalls, invoked from
          * a clean call, will not trigger the whereami check below: so we
          * locate here via mismatching kstat top-of-stack.
@@ -1381,7 +1380,6 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
                 found_client_sysenter();
             }
         });
-#    endif
         KSTOP_NOT_PROPAGATED(syscall_fcache);
         return;
     } else if (dcontext->last_exit == get_selfmod_linkstub()) {

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -100,6 +100,7 @@ static void
 handle_callback_return(dcontext_t *dcontext);
 #endif
 
+#if defined(UNIX) && !defined(X64)
 /* PR 356503: detect clients making syscalls via sysenter */
 static inline void
 found_client_sysenter(void)
@@ -109,6 +110,7 @@ found_client_sysenter(void)
                   "While such behavior is not recommended and can create problems, "
                   "it may work with the -sysenter_is_int80 runtime option.");
 }
+#endif
 
 static bool
 exited_due_to_ni_syscall(dcontext_t *dcontext)
@@ -1369,6 +1371,7 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
     if (dcontext->last_exit == get_syscall_linkstub()) {
         LOG(THREAD, LOG_DISPATCH, 2, "Exit from system call\n");
         STATS_INC(num_exits_syscalls);
+#    if defined(UNIX) && !defined(X64)
         /* PR 356503: clients using libraries that make syscalls, invoked from
          * a clean call, will not trigger the whereami check below: so we
          * locate here via mismatching kstat top-of-stack.
@@ -1378,6 +1381,7 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
                 found_client_sysenter();
             }
         });
+#    endif
         KSTOP_NOT_PROPAGATED(syscall_fcache);
         return;
     } else if (dcontext->last_exit == get_selfmod_linkstub()) {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2365,14 +2365,18 @@ if (X86) # XXX i#1551, i#1569: port asm to ARM and AArch64
       # sepaparate build.  Until someone really focuses on hybrid mode again
       # (in which case a new build param should be added to re-enable libdl),
       # we leave the tests here as regression tests but w/ private loader in place.
+      set(kstats_flag "")
+      if (KSTATS)
+        set(kstats_flag "-no_kstats")
+      endif()
       torunonly(common.nativeexec_retakeover_opt common.nativeexec common/nativeexec.c
-        "-no_early_inject -native_exec_list ${native_dll_name} -native_exec_retakeover  -native_exec_opt -no_kstats" "")
+        "-no_early_inject -native_exec_list ${native_dll_name} -native_exec_retakeover  -native_exec_opt ${kstats_flag}" "")
       # No swap TLS and no kstats for optimized native_exec
       torunonly(common.nativeexec_exe_opt common.nativeexec common/nativeexec_exenative.c
-        "-no_early_inject -native_exec_list common.nativeexec -native_exec_retakeover -native_exec_opt -no_kstats" "")
+        "-no_early_inject -native_exec_list common.nativeexec -native_exec_retakeover -native_exec_opt ${kstats_flag}" "")
       torunonly(common.nativeexec_bindnow_opt common.nativeexec
         common/nativeexec_exenative.c
-        "-no_early_inject -native_exec_list common.nativeexec -native_exec_retakeover -native_exec_opt -no_kstats" "-bind_now")
+        "-no_early_inject -native_exec_list common.nativeexec -native_exec_retakeover -native_exec_opt ${kstats_flag}" "-bind_now")
     endif ()
   endif ()
 


### PR DESCRIPTION
- Fix typo of KSTATS_DEFAULT: `0FF` => `OFF`
- Remove an outdated XXX comment

Fixes #7990
Issue: #170 