### PR TITLE
i#7993: Mark actual selfmod PC writable in detach_state test

### DIFF
--- a/suite/tests/api/detach_state_shared.c
+++ b/suite/tests/api/detach_state_shared.c
@@ -525,7 +525,8 @@ check_xsp(ptr_uint_t *xsp)
 #    endif
 
 /* This needs to be larger than the distance from the PC of the call to
- * MAKE_WRITEABLE to the selfmod-modified PC.
+ * MAKE_WRITEABLE to the selfmod-modified PC in SELFMOD, whereever those
+ * macros are instantiated.
  * Currently AArch64's distance is 1316.
  */
 #    define CODE_SIZE_MAKE_WRITABLE_TO_SELFMOD 2048

--- a/suite/tests/api/detach_state_shared.c
+++ b/suite/tests/api/detach_state_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2025 Arm Limited  All rights reserved.
  * **********************************************************/
 
@@ -524,10 +524,17 @@ check_xsp(ptr_uint_t *xsp)
 }
 #    endif
 
+/* This needs to be larger than the distance from the PC of the call to
+ * MAKE_WRITEABLE to the selfmod-modified PC.
+ * Currently AArch64's distance is 1316.
+ */
+#    define CODE_SIZE_MAKE_WRITABLE_TO_SELFMOD 2048
+
 void
 make_mem_writable(ptr_uint_t pc)
 {
-    protect_mem((void *)pc, 1024, ALLOW_READ | ALLOW_WRITE | ALLOW_EXEC);
+    protect_mem((void *)pc, CODE_SIZE_MAKE_WRITABLE_TO_SELFMOD,
+                ALLOW_READ | ALLOW_WRITE | ALLOW_EXEC);
 }
 
 void
@@ -536,7 +543,7 @@ make_mem_non_writeable(ptr_uint_t pc)
     /* Reset self-modifying test page permissions so later non-self-modifying
      * fragment cache tests do not inherit RWX, violating DR's ASSERT() checks.
      */
-    protect_mem((void *)pc, 1024, ALLOW_READ | ALLOW_EXEC);
+    protect_mem((void *)pc, CODE_SIZE_MAKE_WRITABLE_TO_SELFMOD, ALLOW_READ | ALLOW_EXEC);
 }
 
 #else /* asm code *************************************************************/

--- a/suite/tests/api/detach_state_shared.c
+++ b/suite/tests/api/detach_state_shared.c
@@ -524,7 +524,7 @@ check_xsp(ptr_uint_t *xsp)
 }
 #    endif
 
-/* This needs to be larger than the distance from the PC of the call to
+/* This needs to be larger than the distance from the PC of the call in
  * MAKE_WRITEABLE to the selfmod-modified PC in SELFMOD, whereever those
  * macros are instantiated.
  * Currently AArch64's distance is 1316.


### PR DESCRIPTION
Fixes a bug where the detach_state test did not mark a large enough region writable and so left the selfmod PC read-only, causing failure when code layout split the range across two pages.

Tested with the PR #7982 where detach_state fails every time on the aarch64-sve-precommit-* runners: with this change added the failure goes away.

Fixes #7993