### PR TITLE
Track syscall trace instrs counts in syscall_mix

### DIFF
--- a/clients/drcachesim/tests/burst_syscall_inject.cpp
+++ b/clients/drcachesim/tests/burst_syscall_inject.cpp
@@ -146,10 +146,6 @@ check_syscall_stats(syscall_mix_t::statistics_t &syscall_stats)
     assert(syscall_stats.syscall_errno_counts[SYS_rt_sigaction].size() == 2);
     assert(syscall_stats.syscall_errno_counts[SYS_rt_sigaction][EINVAL] == 2);
     assert(syscall_stats.syscall_errno_counts[SYS_rt_sigaction][EFAULT] == 1);
-    assert(syscall_stats.syscall_instrs[SYS_membarrier] > 0);
-    assert(syscall_stats.syscall_instrs[SYS_gettid] > 0);
-    assert(syscall_stats.syscall_instrs[SYS_getpid] > 0);
-    assert(syscall_stats.syscall_instrs[SYS_rt_sigaction] > 0);
 }
 
 static void

--- a/clients/drcachesim/tests/burst_syscall_inject.cpp
+++ b/clients/drcachesim/tests/burst_syscall_inject.cpp
@@ -146,6 +146,10 @@ check_syscall_stats(syscall_mix_t::statistics_t &syscall_stats)
     assert(syscall_stats.syscall_errno_counts[SYS_rt_sigaction].size() == 2);
     assert(syscall_stats.syscall_errno_counts[SYS_rt_sigaction][EINVAL] == 2);
     assert(syscall_stats.syscall_errno_counts[SYS_rt_sigaction][EFAULT] == 1);
+    assert(syscall_stats.syscall_instrs[SYS_membarrier] > 0);
+    assert(syscall_stats.syscall_instrs[SYS_gettid] > 0);
+    assert(syscall_stats.syscall_instrs[SYS_getpid] > 0);
+    assert(syscall_stats.syscall_instrs[SYS_rt_sigaction] > 0);
 }
 
 static void
@@ -700,6 +704,9 @@ test_template_with_repstr(void *dr_context)
     syscall_mix_t::statistics_t syscall_stats;
     basic_counts_t::counters_t template_counts;
     get_tool_results(syscall_trace_template, template_counts, syscall_stats);
+    assert(syscall_stats.syscall_instrs[SYS_gettid] == SYSCALL_INSTR_COUNT);
+    assert(syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM] ==
+           DEFAULT_INSTR_COUNT);
     int distinct_instrs_in_tmpl = SYSCALL_INSTR_COUNT + DEFAULT_INSTR_COUNT;
     if (!(template_counts.instrs == distinct_instrs_in_tmpl &&
           template_counts.instrs_nofetch == REP_MOVS_COUNT - 1 &&
@@ -747,6 +754,10 @@ test_trace_templates(void *dr_context)
     syscall_mix_t::statistics_t syscall_stats;
     basic_counts_t::counters_t template_counts;
     get_tool_results(syscall_trace_template, template_counts, syscall_stats);
+    assert(syscall_stats.syscall_instrs[SYS_membarrier] == SYSCALL_INSTR_COUNT);
+    assert(syscall_stats.syscall_instrs[SYS_gettid] == SYSCALL_INSTR_COUNT);
+    assert(syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM] ==
+           DEFAULT_INSTR_COUNT);
 
     // We have two templates of two instrs each, and one default template with
     // just one instr.

--- a/clients/drcachesim/tests/burst_syscall_inject.cpp
+++ b/clients/drcachesim/tests/burst_syscall_inject.cpp
@@ -704,9 +704,18 @@ test_template_with_repstr(void *dr_context)
     syscall_mix_t::statistics_t syscall_stats;
     basic_counts_t::counters_t template_counts;
     get_tool_results(syscall_trace_template, template_counts, syscall_stats);
-    assert(syscall_stats.syscall_instrs[SYS_gettid] == SYSCALL_INSTR_COUNT);
-    assert(syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM] ==
-           DEFAULT_INSTR_COUNT);
+    if (syscall_stats.syscall_instrs[SYS_gettid] != SYSCALL_INSTR_COUNT) {
+        std::cerr << "SYS_gettid instr count " << syscall_stats.syscall_instrs[SYS_gettid]
+                  << " != " << SYSCALL_INSTR_COUNT << "\n";
+        return 1;
+    }
+    if (syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM] !=
+        DEFAULT_INSTR_COUNT) {
+        std::cerr << "Default template instr count "
+                  << syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM]
+                  << " != " << DEFAULT_INSTR_COUNT << "\n";
+        return 1;
+    }
     int distinct_instrs_in_tmpl = SYSCALL_INSTR_COUNT + DEFAULT_INSTR_COUNT;
     if (!(template_counts.instrs == distinct_instrs_in_tmpl &&
           template_counts.instrs_nofetch == REP_MOVS_COUNT - 1 &&
@@ -754,10 +763,24 @@ test_trace_templates(void *dr_context)
     syscall_mix_t::statistics_t syscall_stats;
     basic_counts_t::counters_t template_counts;
     get_tool_results(syscall_trace_template, template_counts, syscall_stats);
-    assert(syscall_stats.syscall_instrs[SYS_membarrier] == SYSCALL_INSTR_COUNT);
-    assert(syscall_stats.syscall_instrs[SYS_gettid] == SYSCALL_INSTR_COUNT);
-    assert(syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM] ==
-           DEFAULT_INSTR_COUNT);
+    if (syscall_stats.syscall_instrs[SYS_membarrier] != SYSCALL_INSTR_COUNT) {
+        std::cerr << "SYS_membarrier instr count "
+                  << syscall_stats.syscall_instrs[SYS_membarrier]
+                  << " != " << SYSCALL_INSTR_COUNT << "\n";
+        return 1;
+    }
+    if (syscall_stats.syscall_instrs[SYS_gettid] != SYSCALL_INSTR_COUNT) {
+        std::cerr << "SYS_gettid instr count " << syscall_stats.syscall_instrs[SYS_gettid]
+                  << " != " << SYSCALL_INSTR_COUNT << "\n";
+        return 1;
+    }
+    if (syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM] !=
+        DEFAULT_INSTR_COUNT) {
+        std::cerr << "Default template instr count "
+                  << syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM]
+                  << " != " << DEFAULT_INSTR_COUNT << "\n";
+        return 1;
+    }
 
     // We have two templates of two instrs each, and one default template with
     // just one instr.

--- a/clients/drcachesim/tools/syscall_mix.cpp
+++ b/clients/drcachesim/tools/syscall_mix.cpp
@@ -197,9 +197,8 @@ syscall_mix_t::print_results()
             int64_t instrs = total.syscall_instrs[keyvals.first];
             // XXX: It would be nicer to print the system call name string instead
             // of its number.
-            std::cerr << std::setw(20) << keyvals.second << " : "
-                      << std::setw(20) << instrs << " : "
-                      << std::setw(9) << keyvals.first << "\n";
+            std::cerr << std::setw(20) << keyvals.second << " : " << std::setw(20)
+                      << instrs << " : " << std::setw(9) << keyvals.first << "\n";
         }
     }
     if (!total.syscall_errno_counts.empty()) {

--- a/clients/drcachesim/tools/syscall_mix.cpp
+++ b/clients/drcachesim/tools/syscall_mix.cpp
@@ -39,6 +39,7 @@
 #include <iomanip>
 #include <iostream>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -112,8 +113,8 @@ syscall_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
     shard_data_t *shard = reinterpret_cast<shard_data_t *>(shard_data);
     if (type_is_instr(memref.instr.type)) {
-        if (shard->current_syscall_trace_num != -1) {
-            ++shard->stats.syscall_instrs[shard->current_syscall_trace_num];
+        if (shard->current_syscall_trace_sysnum.has_value()) {
+            ++shard->stats.syscall_instrs[*shard->current_syscall_trace_sysnum];
         }
         return true;
     }
@@ -135,11 +136,11 @@ syscall_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         assert(static_cast<uintptr_t>(syscall_num) == memref.marker.marker_value);
 #endif
         ++shard->stats.syscall_trace_counts[syscall_num];
-        shard->current_syscall_trace_num = syscall_num;
+        shard->current_syscall_trace_sysnum = syscall_num;
         break;
     }
     case TRACE_MARKER_TYPE_SYSCALL_TRACE_END:
-        shard->current_syscall_trace_num = -1;
+        shard->current_syscall_trace_sysnum = std::nullopt;
         break;
     case TRACE_MARKER_TYPE_SYSCALL_FAILED:
         ++shard->stats.syscall_errno_counts[shard->last_sysnum]
@@ -193,7 +194,7 @@ syscall_mix_t::print_results()
     }
     if (!total.syscall_trace_counts.empty()) {
         std::cerr << std::setw(20) << "syscall trace count"
-                  << " : " << std::setw(20) << "instr count"
+                  << " : " << std::setw(20) << "total instr count"
                   << " : " << std::setw(9) << "syscall_num\n";
         std::vector<std::pair<int, int64_t>> sorted_trace(
             total.syscall_trace_counts.begin(), total.syscall_trace_counts.end());

--- a/clients/drcachesim/tools/syscall_mix.cpp
+++ b/clients/drcachesim/tools/syscall_mix.cpp
@@ -199,12 +199,12 @@ syscall_mix_t::print_results()
         std::vector<std::pair<int, int64_t>> sorted_trace(
             total.syscall_trace_counts.begin(), total.syscall_trace_counts.end());
         std::sort(sorted_trace.begin(), sorted_trace.end(), cmp_second_val);
-        for (const auto &keyvals : sorted_trace) {
-            int64_t instrs = total.syscall_instrs[keyvals.first];
+        for (const auto &[sysnum, syscall_count] : sorted_trace) {
+            int64_t instrs = total.syscall_instrs[sysnum];
             // XXX: It would be nicer to print the system call name string instead
             // of its number.
-            std::cerr << std::setw(20) << keyvals.second << " : " << std::setw(20)
-                      << instrs << " : " << std::setw(9) << keyvals.first << "\n";
+            std::cerr << std::setw(20) << syscall_count << " : " << std::setw(20)
+                      << instrs << " : " << std::setw(9) << sysnum << "\n";
         }
     }
     if (!total.syscall_errno_counts.empty()) {

--- a/clients/drcachesim/tools/syscall_mix.cpp
+++ b/clients/drcachesim/tools/syscall_mix.cpp
@@ -112,7 +112,9 @@ syscall_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
     shard_data_t *shard = reinterpret_cast<shard_data_t *>(shard_data);
     if (type_is_instr(memref.instr.type)) {
-        ++shard->stats.syscall_instrs[shard->last_sysnum];
+        if (shard->current_syscall_trace_num != -1) {
+            ++shard->stats.syscall_instrs[shard->current_syscall_trace_num];
+        }
         return true;
     }
     if (memref.marker.type != TRACE_TYPE_MARKER)
@@ -133,9 +135,12 @@ syscall_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         assert(static_cast<uintptr_t>(syscall_num) == memref.marker.marker_value);
 #endif
         ++shard->stats.syscall_trace_counts[syscall_num];
-        shard->last_sysnum = syscall_num;
+        shard->current_syscall_trace_num = syscall_num;
         break;
     }
+    case TRACE_MARKER_TYPE_SYSCALL_TRACE_END:
+        shard->current_syscall_trace_num = -1;
+        break;
     case TRACE_MARKER_TYPE_SYSCALL_FAILED:
         ++shard->stats.syscall_errno_counts[shard->last_sysnum]
                                            [static_cast<int>(memref.marker.marker_value)];

--- a/clients/drcachesim/tools/syscall_mix.cpp
+++ b/clients/drcachesim/tools/syscall_mix.cpp
@@ -111,6 +111,10 @@ bool
 syscall_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
     shard_data_t *shard = reinterpret_cast<shard_data_t *>(shard_data);
+    if (type_is_instr(memref.instr.type)) {
+        ++shard->stats.syscall_instrs[shard->last_sysnum];
+        return true;
+    }
     if (memref.marker.type != TRACE_TYPE_MARKER)
         return true;
     switch (memref.marker.marker_type) {
@@ -129,6 +133,7 @@ syscall_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         assert(static_cast<uintptr_t>(syscall_num) == memref.marker.marker_value);
 #endif
         ++shard->stats.syscall_trace_counts[syscall_num];
+        shard->last_sysnum = syscall_num;
         break;
     }
     case TRACE_MARKER_TYPE_SYSCALL_FAILED:
@@ -183,15 +188,18 @@ syscall_mix_t::print_results()
     }
     if (!total.syscall_trace_counts.empty()) {
         std::cerr << std::setw(20) << "syscall trace count"
+                  << " : " << std::setw(20) << "instr count"
                   << " : " << std::setw(9) << "syscall_num\n";
         std::vector<std::pair<int, int64_t>> sorted_trace(
             total.syscall_trace_counts.begin(), total.syscall_trace_counts.end());
         std::sort(sorted_trace.begin(), sorted_trace.end(), cmp_second_val);
         for (const auto &keyvals : sorted_trace) {
+            int64_t instrs = total.syscall_instrs[keyvals.first];
             // XXX: It would be nicer to print the system call name string instead
             // of its number.
-            std::cerr << std::setw(20) << keyvals.second << " : " << std::setw(9)
-                      << keyvals.first << "\n";
+            std::cerr << std::setw(20) << keyvals.second << " : "
+                      << std::setw(20) << instrs << " : "
+                      << std::setw(9) << keyvals.first << "\n";
         }
     }
     if (!total.syscall_errno_counts.empty()) {
@@ -225,6 +233,9 @@ syscall_mix_t::get_total_statistics() const
             }
             for (const auto &keyvals : shard.second->stats.syscall_trace_counts) {
                 total.syscall_trace_counts[keyvals.first] += keyvals.second;
+            }
+            for (const auto &[sysnum, instrs] : shard.second->stats.syscall_instrs) {
+                total.syscall_instrs[sysnum] += instrs;
             }
             for (const auto &keyvals : shard.second->stats.syscall_errno_counts) {
                 for (const auto &keyvals2 : keyvals.second) {

--- a/clients/drcachesim/tools/syscall_mix.h
+++ b/clients/drcachesim/tools/syscall_mix.h
@@ -36,6 +36,7 @@
 #include <stdint.h>
 
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -90,7 +91,7 @@ protected:
         statistics_t stats;
         std::string error;
         int last_sysnum = -1;
-        int current_syscall_trace_num = -1;
+        std::optional<int> current_syscall_trace_sysnum = std::nullopt;
     };
 
     std::unordered_map<int, shard_data_t *> shard_map_;

--- a/clients/drcachesim/tools/syscall_mix.h
+++ b/clients/drcachesim/tools/syscall_mix.h
@@ -90,6 +90,7 @@ protected:
         statistics_t stats;
         std::string error;
         int last_sysnum = -1;
+        int current_syscall_trace_num = -1;
     };
 
     std::unordered_map<int, shard_data_t *> shard_map_;

--- a/clients/drcachesim/tools/syscall_mix.h
+++ b/clients/drcachesim/tools/syscall_mix.h
@@ -71,6 +71,7 @@ public:
     struct statistics_t {
         std::unordered_map<int, int64_t> syscall_counts;
         std::unordered_map<int, int64_t> syscall_trace_counts;
+        std::unordered_map<int, int64_t> syscall_instrs;
         // First map translates syscall number to a map that translates
         // failure codes to counts. This is only tracked for system calls traced
         // with -record_syscall where TRACE_MARKER_TYPE_SYSCALL_FAILED


### PR DESCRIPTION
Adds tracking for total instrs seen for each syscall across the whole trace in the syscall mix drmemtrace analyzer tool.

For backward compatibility of syscall_mix_t::statistics_t, this PR doesn't group the syscall count, trace count, error count, and the new instr count into one struct. Some syscall errno checks are also simpler if the syscall error counts are in a separate map.