### PR TITLE
Rename symbolic constant for default syscall tmpl sysnum

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -156,6 +156,8 @@ changes:
  - Added #drvector_t.config field which contains additional configuration parameters for
    a #drvector_t. It currently contains #drvector_config_t.zero_alloc that when set to
    true sets every entry pointer of the drvector's storage to 0 using memset().
+ - Renamed DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM in trace_entry.h to
+   #dynamorio::drmemtrace::DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM.
 
 The changes between version \DR_VERSION and 11.3.0 include the following minor
 compatibility changes:

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -156,8 +156,6 @@ changes:
  - Added #drvector_t.config field which contains additional configuration parameters for
    a #drvector_t. It currently contains #drvector_config_t.zero_alloc that when set to
    true sets every entry pointer of the drvector's storage to 0 using memset().
- - Renamed DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM in trace_entry.h to
-   #dynamorio::drmemtrace::DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM.
 
 The changes between version \DR_VERSION and 11.3.0 include the following minor
 compatibility changes:

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1238,7 +1238,7 @@ typedef enum {
      *
      * The file may also include a "default" trace that can be used for system calls that
      * do not have any trace specified in this file. The default trace has the sysnum
-     * set to #DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM in the enclosing markers in the
+     * set to #DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM in the enclosing markers in the
      * trace template file. When this trace is injected by the scheduler for some
      * syscall, the value in the enclosing markers will be changed to that syscall num.
      *
@@ -1728,7 +1728,7 @@ typedef struct _pt_data_buf_t pt_data_buf_t;
  * on any platform, and also differ from other possible sentinels
  * like -1 on 32-bit.
  */
-constexpr int DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM = 0x0fffffff;
+constexpr int DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM = 0x0fffffff;
 
 /**
  * The name of the file in -offline mode where module data is written.

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -1723,7 +1723,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::read_syscall_sequences()
     if (status != sched_type_t::STATUS_SUCCESS) {
         return status;
     }
-    auto default_seq_it = syscall_sequence_.find(DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM);
+    auto default_seq_it = syscall_sequence_.find(DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM);
     if (default_seq_it != syscall_sequence_.end()) {
         default_syscall_sequence_ = std::move(default_seq_it->second);
         syscall_sequence_.erase(default_seq_it);
@@ -2120,7 +2120,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_kernel_sequence(
         if (record_type_is_marker(record, marker_type, marker_value) &&
             (marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_START ||
              marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_END) &&
-            marker_value == DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM) {
+            marker_value == DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM) {
             record_type_set_marker_value(record, input->to_inject_syscall);
         }
         // TODO i#7495: Add invariant checks that ensure these are equal to the

--- a/clients/drcachesim/tests/burst_syscall_inject.cpp
+++ b/clients/drcachesim/tests/burst_syscall_inject.cpp
@@ -215,7 +215,7 @@ write_default_syscall_trace(void *dr_context, std::unique_ptr<std::ostream> &wri
 {
     write_trace_entry(writer,
                       test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL_TRACE_START,
-                                             DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM));
+                                             DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM));
 #ifdef X86
     instr_t *instr = INSTR_CREATE_sysret(dr_context);
 #elif defined(AARCHXX)
@@ -229,7 +229,7 @@ write_default_syscall_trace(void *dr_context, std::unique_ptr<std::ostream> &wri
                       TRACE_TYPE_INSTR_INDIRECT_JUMP);
     write_trace_entry(writer,
                       test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
-                                             DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM));
+                                             DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM));
     return instr;
 }
 
@@ -705,10 +705,10 @@ test_template_with_repstr(void *dr_context)
                   << " != " << SYSCALL_INSTR_COUNT << "\n";
         return 1;
     }
-    if (syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM] !=
+    if (syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM] !=
         DEFAULT_INSTR_COUNT) {
         std::cerr << "Default template instr count "
-                  << syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM]
+                  << syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM]
                   << " != " << DEFAULT_INSTR_COUNT << "\n";
         return 1;
     }
@@ -770,10 +770,10 @@ test_trace_templates(void *dr_context)
                   << " != " << SYSCALL_INSTR_COUNT << "\n";
         return 1;
     }
-    if (syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM] !=
+    if (syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM] !=
         DEFAULT_INSTR_COUNT) {
         std::cerr << "Default template instr count "
-                  << syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM]
+                  << syscall_stats.syscall_instrs[DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM]
                   << " != " << DEFAULT_INSTR_COUNT << "\n";
         return 1;
     }

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -4473,7 +4473,7 @@ check_kernel_syscall_trace(void)
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 42), nullptr },
             // Second template.
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START,
-                         DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM),
+                         DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM),
               nullptr },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), load },
             { gen_instr(TID_A), move },
@@ -4483,7 +4483,7 @@ check_kernel_syscall_trace(void)
             { gen_marker(TID_A, TRACE_MARKER_TYPE_BRANCH_TARGET, 0), nullptr },
             { gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A), sys_return },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
-                         DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM),
+                         DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM),
               nullptr },
             { gen_exit(TID_A), nullptr }
         };
@@ -4531,14 +4531,14 @@ check_kernel_syscall_trace(void)
             { gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 0), nullptr },
             // Syscall template.
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START,
-                         DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM),
+                         DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM),
               nullptr },
             { gen_instr(TID_A), load },
             { gen_data(TID_A, /*load=*/true, /*addr=*/0x1234, /*size=*/4), nullptr },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_BRANCH_TARGET, 0), nullptr },
             { gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A), sys_return },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
-                         DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM),
+                         DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM),
               nullptr },
             // Switch template.
             { gen_marker(TID_A, TRACE_MARKER_TYPE_CONTEXT_SWITCH_START,
@@ -4575,14 +4575,14 @@ check_kernel_syscall_trace(void)
             { gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 0), nullptr },
             // Only one template, which has a PC discontinuity.
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START,
-                         DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM),
+                         DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM),
               nullptr },
             { gen_instr(TID_A), move },
             // Missing load instruction from the PC order in setup 'ilist' above.
             { gen_marker(TID_A, TRACE_MARKER_TYPE_BRANCH_TARGET, 0), nullptr },
             { gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A), sys_return },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
-                         DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM),
+                         DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM),
               nullptr },
             { gen_exit(TID_A), nullptr }
         };

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -492,11 +492,12 @@ get_mock_syscall_sequence(int syscall_base, addr_t syscall_pc_start = 0xfeed101)
                 TRACE_MARKER_TYPE_SYSCALL_TRACE_END, syscall_base + 1),
             test_util::make_marker(
                 TRACE_MARKER_TYPE_SYSCALL_TRACE_START,
-                DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM),
+                DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM),
             test_util::make_marker(TRACE_MARKER_TYPE_BRANCH_TARGET, DONT_CARE),
             test_util::make_instr(syscall_pc_start + 20, TRACE_TYPE_INSTR_INDIRECT_JUMP),
             test_util::make_marker(
-                TRACE_MARKER_TYPE_SYSCALL_TRACE_END, DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM),
+                TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
+                DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM),
             test_util::make_exit(TID_IN_SYSCALLS),
             test_util::make_footer(),
         /* clang-format on */

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -194,7 +194,7 @@ invariant_checker_t::parallel_shard_exit(void *shard_data)
         bool has_switch_templates = !shard->saw_switch_trace_.empty();
         bool has_syscall_templates = !shard->saw_syscall_trace_.empty();
         bool has_default_syscall_template =
-            shard->saw_syscall_trace_.find(DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM) !=
+            shard->saw_syscall_trace_.find(DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM) !=
             shard->saw_syscall_trace_.end();
         report_if_false(shard,
                         (!has_switch_templates && has_syscall_templates) ||

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -211,7 +211,7 @@ raw2trace_t::get_syscall_template(int syscall_num)
     if (it != syscall_trace_templates_.end()) {
         return &it->second;
     }
-    it = syscall_trace_templates_.find(DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM);
+    it = syscall_trace_templates_.find(DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM);
     if (it != syscall_trace_templates_.end())
         return &it->second;
     return nullptr;


### PR DESCRIPTION
Renames DEFAULT_SYSCALL_TRACE_TEMPLATE_NUM in trace_entry.h to DEFAULT_SYSCALL_TRACE_TEMPLATE_SYSNUM to show more clearly that it is sentinel for the syscall number field.