### PR TITLE
i#8008 format: Remove non-UTF8 characters

### DIFF
--- a/suite/tests/security-win32/sd_tester.c
+++ b/suite/tests/security-win32/sd_tester.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2004 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -129,7 +129,7 @@ main(int argc, char **argv)
         buffer_test("heap");
         buffer_test("newheap");
 #ifndef X64
-        /* disabling b/c messes up the print: "success" comes out as "Ðuccess" */
+        /* disabling b/c messes up the print: "success" has 's' as a non-utf8 char */
         buffer_test("crtheap");
 #endif
         buffer_test("virtual");

--- a/tools/DRinstall/ShellInterface.cpp
+++ b/tools/DRinstall/ShellInterface.cpp
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -218,7 +219,7 @@ HRESULT CreateShortCut::CreateIt (LPCSTR pszShortcutFile, LPSTR pszLink,
             hres = ppf->Save (wsz, TRUE);
 
             if (! SUCCEEDED (hres))
-                AfxMessageBox (“Save failed!”);
+                AfxMessageBox ("Save failed!");
 
             // Release the pointer to IPersistFile.
             ppf->Release ();

--- a/tools/runjob.c
+++ b/tools/runjob.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -121,10 +122,10 @@ StartRestrictedProcess(LPTSTR app_name, LPTSTR app_cmdline, SIZE_T pagefile_limi
     // Second, set some UI restrictions
     jobuir.UIRestrictionsClass = JOB_OBJECT_UILIMIT_NONE; // A fancy 0
 
-    // The process can’t logoff the system
+    // The process can't logoff the system
     jobuir.UIRestrictionsClass |= JOB_OBJECT_UILIMIT_EXITWINDOWS;
 
-    // The process can’t access USER object (like other windows) in the system
+    // The process can't access USER object (like other windows) in the system
     jobuir.UIRestrictionsClass |= JOB_OBJECT_UILIMIT_HANDLES;
 
     ok = SetInformationJobObject(hjob, JobObjectBasicUIRestrictions, &jobuir,
@@ -158,11 +159,11 @@ StartRestrictedProcess(LPTSTR app_name, LPTSTR app_cmdline, SIZE_T pagefile_limi
     //        automatically associated with the same job
     AssignProcessToJobObject(hjob, pi.hProcess);
 
-    // Now, we can allow the child process’s thread to execute code.
+    // Now, we can allow the child process's thread to execute code.
     ResumeThread(pi.hThread);
     CloseHandle(pi.hThread);
 
-    // Wait for the process to terminate or for all the job’s allotted CPU time to be used
+    // Wait for the process to terminate or for all the job's allotted CPU time to be used
     {
         DWORD dw;
         HANDLE h[2];


### PR DESCRIPTION
Removes non-UTF8 characters from tools/runjob.c.
These crash clang-format-diff and are blocking PR #8009.
Also fixes non-UTF8 characters found in two other files while at it.

Issue: #8008