### PR TITLE
i#8014: Rename local variables named fallthrough

### DIFF
--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -6906,7 +6906,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
 {
     instr_t *inst, *next_inst, *start_instr, *jmp;
     uint blk, num_exits_deleted;
-    app_pc fallthrough = NULL;
+    app_pc fallthrough_pc = NULL;
     bool found_syscall = false, found_int = false;
 
     /* We don't assert that mangle_trace_at_end() is true b/c the client
@@ -6974,7 +6974,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
             /* Do not call instr_length() on this inst: use length
              * of translation! (i#509)
              */
-            fallthrough = decode_next_pc(dcontext, xl8);
+            fallthrough_pc = decode_next_pc(dcontext, xl8);
         }
 
         /* PR 299808: identify bb boundaries.  We can't go by translations alone, as
@@ -7056,7 +7056,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
             return false;
         }
         /* must have been no final exit cti: add final fall-through jmp */
-        jmp = create_exit_jmp(dcontext, fallthrough, fallthrough, 0);
+        jmp = create_exit_jmp(dcontext, fallthrough_pc, fallthrough_pc, 0);
         /* XXX PR 307284: support client modifying, replacing, or adding
          * syscalls and ints: need to re-analyze.  Then we wouldn't
          * need the md->final_exit_flags field anymore.

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6201,10 +6201,10 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
 
     app_flags_ok = instr_get_prev(instr);
     if (has_fallthrough) {
-        ptr_uint_t fallthrough = address + instr_length(drcontext, instr);
+        ptr_uint_t fallthrough_addr = address + instr_length(drcontext, instr);
         CLIENT_ASSERT(!opnd_uses_reg(user_data, DR_REG_XBX),
                       "register ebx should not be used");
-        CLIENT_ASSERT(fallthrough > address, "wrong fallthrough address");
+        CLIENT_ASSERT(fallthrough_addr > address, "wrong fallthrough address");
         dr_insert_clean_call_ex(
             drcontext, ilist, instr, callee,
             /* Many users will ask for mcontexts; some will set; it doesn't seem worth
@@ -6217,7 +6217,7 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
             /* target is 2nd parameter */
             OPND_CREATE_INTPTR(target),
             /* fall-throug is 3rd parameter */
-            OPND_CREATE_INTPTR(fallthrough),
+            OPND_CREATE_INTPTR(fallthrough_addr),
             /* branch direction (put in ebx below) is 4th parameter */
             opnd_create_reg(REG_XBX),
             /* user defined data is 5th parameter */
@@ -6503,8 +6503,8 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
     }
 
     if (has_fallthrough) {
-        ptr_uint_t fallthrough = address + instr_length(drcontext, instr);
-        CLIENT_ASSERT(fallthrough > address, "wrong fallthrough address");
+        ptr_uint_t fallthrough_addr = address + instr_length(drcontext, instr);
+        CLIENT_ASSERT(fallthrough_addr > address, "wrong fallthrough address");
         dr_insert_clean_call_ex(
             drcontext, ilist, instr, callee,
             /* Many users will ask for mcontexts; some will set; it doesn't seem worth
@@ -6517,7 +6517,7 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
             /* Target is 2nd parameter. */
             OPND_CREATE_INTPTR(target),
             /* Fall-through is 3rd parameter. */
-            OPND_CREATE_INTPTR(fallthrough),
+            OPND_CREATE_INTPTR(fallthrough_addr),
             /* Branch direction is 4th parameter. */
             opnd_create_reg(dir),
             /* User defined data is 5th parameter. */


### PR DESCRIPTION
Renamed local variables named fallthrough in two places:
1. `mangle_trace()` in `core/arch/interp.c`: `fallthrough` -> `fallthrough_pc`
2. `dr_insert_cbr_instrumentation_help()` in `core/lib/instrument.c`: `fallthrough` -> `fallthrough_addr`

Fixes #8014 