### PR TITLE
i#8016: Refactor noinline attributes to the double-underscore variant

### DIFF
--- a/api/docs/annotations.dox
+++ b/api/docs/annotations.dox
@@ -67,7 +67,7 @@ invoked anyway.
 #define ANNOTATION_FUNCTION_CLOBBER_LIST "%rax","%rcx","%rdx","%rsi","%rdi","%r8","%r9"
 #define _CALL_TYPE
 #define DR_ANNOTATION_ATTRIBUTES \
-    __attribute__((noinline, visibility("hidden") _CALL_TYPE))
+    __attribute__((__noinline__, visibility("hidden") _CALL_TYPE))
 #define DR_DEFINE_ANNOTATION(return_type, annotation, parameters, body) \
     const char *annotation##_label = "dynamorio-annotation:"#annotation; \
     DR_ANNOTATION_ATTRIBUTES return_type annotation parameters \

--- a/core/io.c
+++ b/core/io.c
@@ -922,13 +922,13 @@ typedef void (*memset_t)(void *dst, int src, size_t n);
 
 /* Force compiler to not optimize away our own memcpy and memset.
  */
-__attribute__((noinline)) static void *
+static NOINLINE void *
 our_memcpy(void *dst, const void *src, size_t n)
 {
     return memcpy(dst, src, n);
 }
 
-__attribute__((noinline)) static void *
+static NOINLINE void *
 our_memset(void *dst, int src, size_t n)
 {
     return memset(dst, src, n);

--- a/core/lib/dr_annotations_asm.h
+++ b/core/lib/dr_annotations_asm.h
@@ -242,7 +242,7 @@
 #        define ANNOT_LBL(annot, base) #annot "_label@GOT(%" base ")"
 #    endif
 #    define DR_ANNOTATION_ATTRIBUTES \
-        __attribute__((noinline, visibility("hidden") _CALL_TYPE))
+        __attribute__((__noinline__, visibility("hidden") _CALL_TYPE))
 #    define DR_WEAK_DECLARATION __attribute__((weak))
 /* GCC extension "__label__" confines the named label to the block scope. */
 #    define DR_ANNOTATION_OR_NATIVE(annotation, native_version, ...) \

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -169,7 +169,7 @@ typedef _Bool bool;
 #    define ALIGN_VAR(x) __attribute__((aligned(x)))
 #    define INLINE_FORCED inline
 #    define WEAK __attribute__((weak))
-#    define NOINLINE __attribute__((noinline))
+#    define NOINLINE __attribute__((__noinline__))
 #endif
 
 /* Annotates intentional switch case fallthroughs to satisfy

--- a/suite/tests/client-interface/drcallstack-test.c
+++ b/suite/tests/client-interface/drcallstack-test.c
@@ -33,7 +33,7 @@
 #include "tools.h"
 
 #ifdef LINUX
-#    define NOINLINE __attribute__((noinline))
+#    define NOINLINE __attribute__((__noinline__))
 #else
 #    error NYI
 #endif

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -291,7 +291,7 @@ page_size(void)
 #else /* UNIX */
 #    define EXPORT __attribute__((visibility("default")))
 #    define IMPORT extern
-#    define NOINLINE __attribute__((noinline))
+#    define NOINLINE __attribute__((__noinline__))
 #endif
 
 /* convenience macros for secure string buffer operations */


### PR DESCRIPTION
Refactor `noinline` attributes to the double-underscore variant to avoid conflicts with a macro with the same name in the linux kernel. Some of these changes may not be necessary, like the ones in the tests folder, but for consistency I changed them as well.

Fixes #8016 