### PR TITLE
Preserve syscall results during application invocation

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5932,7 +5932,9 @@ dr_invoke_syscall_as_app(void *drcontext, int sysnum, int arg_count, ...)
     } else {
         res = dynamorio_syscall(sysnum, arg_count, args[0], args[1], args[2], args[3],
                                 args[4], args[5]);
+        MCXT_SYSCALL_RES(mc) = res;
         post_system_call(dcontext);
+        res = MCXT_SYSCALL_RES(mc);
     }
     dcontext->client_data->skip_client_syscall_events = false;
     /* Restore app registers. */

--- a/suite/tests/client-interface/strace.dll.c
+++ b/suite/tests/client-interface/strace.dll.c
@@ -48,6 +48,7 @@
 #ifdef UNIX
 #    ifdef LINUX
 #        include <syscall.h>
+#        include <sys/mman.h>
 #        define SYSNUM_SIGPROCMASK SYS_rt_sigprocmask
 #    else
 #        include <sys/syscall.h>
@@ -167,6 +168,21 @@ dr_init(client_id_t id)
         dr_fprintf(STDERR, "dr_invoke_syscall_as_app failed with %d\n", res);
     if (rlim_raw.rlim_cur == rlim_dr.rlim_cur)
         dr_fprintf(STDERR, "dr_invoke_syscall_as_app failed to go through DR\n");
+
+    /* Exercise post-syscall memory bookkeeping with the actual kernel result. */
+    reg_t map = dr_invoke_syscall_as_app(
+        dr_get_current_drcontext(), SYS_mmap, 6, (reg_t)NULL, (reg_t)4096,
+        (reg_t)(PROT_READ | PROT_WRITE), (reg_t)(MAP_PRIVATE | MAP_ANONYMOUS), (reg_t)-1,
+        (reg_t)0);
+    if ((ptr_int_t)map < 0)
+        dr_fprintf(STDERR, "dr_invoke_syscall_as_app mmap failed with " PFX "\n", map);
+    else {
+        *(volatile byte *)map = 1;
+        res = dr_invoke_syscall_as_app(dr_get_current_drcontext(), SYS_munmap, 2,
+                                       (reg_t)map, (reg_t)4096);
+        if (res < 0)
+            dr_fprintf(STDERR, "dr_invoke_syscall_as_app munmap failed with %d\n", res);
+    }
 #endif
 }
 


### PR DESCRIPTION
dr_invoke_syscall_as_app() ran post_system_call() without first publishing the raw kernel return value in the saved machine context. Post-syscall handlers therefore observed the stale syscall-number register; for SYS_mmap on x86-64 this is 9 instead of the returned mapping address and can corrupt DynamoRIO memory bookkeeping or crash the guest.\n\nStore the raw return value before post_system_call(), then return the possibly adjusted result. Extend client.strace with an anonymous mmap/munmap invocation to exercise post-syscall memory bookkeeping.\n\nDownstream reproducer: a DynamoRIO client that forwards application mmap through dr_invoke_syscall_as_app caused /usr/bin/sort and /usr/bin/md5sum to SIGSEGV before guest output.