### PR TITLE
i#8026 histogram cleanup: Add reduce guard

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -1106,6 +1106,8 @@ if (BUILD_TESTS)
       tools/histogram.cpp tests/histogram_test.cpp)
     target_link_libraries(tool.drcachesim.histogram_test
       drmemtrace_static drmemtrace_analyzer test_helpers)
+    # Ensure we have /std:c++17 for std::optional.
+    restore_nonclient_flags(tool.drcachesim.histogram_test OFF)
     add_win32_flags(tool.drcachesim.histogram_test ON)
     add_test(NAME tool.drcachesim.histogram_test
              COMMAND tool.drcachesim.histogram_test)

--- a/clients/drcachesim/tests/histogram_test.cpp
+++ b/clients/drcachesim/tests/histogram_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2023 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2026 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,7 @@
  */
 
 #include <iostream>
+#include <optional>
 #include <vector>
 
 #include "../tools/histogram.h"
@@ -50,7 +51,7 @@ bool
 check_cross_line()
 {
     static constexpr unsigned int LINE_SIZE = 64;
-    histogram_t tool(LINE_SIZE, 0, 0);
+    histogram_t tool(LINE_SIZE, 5, 0);
     std::vector<memref_t> memrefs = {
         gen_instr(1, 20 * LINE_SIZE),
         gen_data(1, /*load=*/true, 10 * LINE_SIZE, 8),
@@ -79,10 +80,72 @@ check_cross_line()
     return true;
 }
 
+bool
+check_parallel_reduce()
+{
+    static constexpr unsigned int LINE_SIZE = 64;
+    // XXX i#8026: Remove this shift to simplify storage.
+    static constexpr unsigned int LINE_SHIFT = 6;
+    histogram_t tool(LINE_SIZE, 5, 0);
+    std::vector<memref_t> memrefs = {
+        gen_instr(1, 20 * LINE_SIZE),
+        gen_data(1, /*load=*/true, 10 * LINE_SIZE, 8),
+        gen_instr(1, 21 * LINE_SIZE),
+        gen_data(1, /*load=*/true, 11 * LINE_SIZE, 8),
+        gen_instr(1, 22 * LINE_SIZE),
+        gen_data(1, /*load=*/true, 12 * LINE_SIZE, 8),
+        // Test repeated lines: should not affect unique.
+        gen_instr(1, 20 * LINE_SIZE),
+        gen_data(1, /*load=*/true, 10 * LINE_SIZE, 8),
+        // Test crossing a cache line.
+        gen_data(1, /*load=*/false, 30 * LINE_SIZE - 4, 8),
+        gen_data(1, /*load=*/false, 40 * LINE_SIZE - 4, LINE_SIZE + 5),
+        gen_instr(1, 50 * LINE_SIZE - 3, 4),
+    };
+    void *worker_data = tool.parallel_worker_init(0);
+    void *shard_data = tool.parallel_shard_init(0, worker_data);
+    for (const auto &memref : memrefs) {
+        if (!tool.parallel_shard_memref(shard_data, memref)) {
+            std::cerr << "parallel_shard_memref failed\n";
+            return false;
+        }
+    }
+    tool.parallel_shard_exit(shard_data);
+    tool.parallel_worker_exit(worker_data);
+
+    auto check_icache = [&tool]() {
+        std::optional<std::unordered_map<addr_t, uint64_t>> icache_res =
+            tool.get_icache_counts();
+        if (!icache_res.has_value()) {
+            std::cerr << "failed to obtain icache counts\n";
+            return false;
+        }
+        // XXX i#8026: Remove this shift to simplify storage.
+        if ((*icache_res)[(20 * LINE_SIZE) >> LINE_SHIFT] != 2 ||
+            (*icache_res)[(21 * LINE_SIZE) >> LINE_SHIFT] != 1) {
+            std::cerr << "incorrect icache counts: got "
+                      << (*icache_res)[(20 * LINE_SIZE) >> LINE_SHIFT] << ","
+                      << (*icache_res)[(21 * LINE_SIZE) >> LINE_SHIFT]
+                      << " instead of 2,1\n";
+            return false;
+        }
+        return true;
+    };
+    if (!check_icache())
+        return false;
+    // Do another reduce inside print_results, testing that multiple reduces
+    // do not change the result. The get_icache_counts() will also do another
+    // reduce.
+    tool.print_results();
+    if (!check_icache())
+        return false;
+    return true;
+}
+
 int
 test_main(int argc, const char *argv[])
 {
-    if (check_cross_line()) {
+    if (check_cross_line() && check_parallel_reduce()) {
         std::cerr << "histogram_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tests/histogram_test.cpp
+++ b/clients/drcachesim/tests/histogram_test.cpp
@@ -51,7 +51,7 @@ bool
 check_cross_line()
 {
     static constexpr unsigned int LINE_SIZE = 64;
-    histogram_t tool(LINE_SIZE, 5, 0);
+    histogram_t tool(LINE_SIZE, /*report_top=*/0, /*verbose=*/0);
     std::vector<memref_t> memrefs = {
         gen_instr(1, 20 * LINE_SIZE),
         gen_data(1, /*load=*/true, 10 * LINE_SIZE, 8),
@@ -86,7 +86,7 @@ check_parallel_reduce()
     static constexpr unsigned int LINE_SIZE = 64;
     // XXX i#8026: Remove this shift to simplify storage.
     static constexpr unsigned int LINE_SHIFT = 6;
-    histogram_t tool(LINE_SIZE, 5, 0);
+    histogram_t tool(LINE_SIZE, /*report_top=*/5, /*verbose=*/0);
     std::vector<memref_t> memrefs = {
         gen_instr(1, 20 * LINE_SIZE),
         gen_data(1, /*load=*/true, 10 * LINE_SIZE, 8),

--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -177,7 +177,6 @@ histogram_t::reduce_results(uint64_t *unique_icache_lines, uint64_t *unique_dcac
     // not need a lock.
     if (results_are_reduced_)
         return true;
-    results_are_reduced_ = true;
 
     if (shard_map_.empty()) {
         reduced_ = serial_shard_;
@@ -195,6 +194,8 @@ histogram_t::reduce_results(uint64_t *unique_icache_lines, uint64_t *unique_dcac
         *unique_icache_lines = reduced_.icache_map.size();
     if (unique_dcache_lines != nullptr)
         *unique_dcache_lines = reduced_.dcache_map.size();
+
+    results_are_reduced_ = true;
     return true;
 }
 

--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -172,6 +172,12 @@ cmp(const std::pair<addr_t, uint64_t> &l, const std::pair<addr_t, uint64_t> &r)
 bool
 histogram_t::reduce_results(uint64_t *unique_icache_lines, uint64_t *unique_dcache_lines)
 {
+    // This is called from a single thread in the analyzer infrastructure, so we do
+    // not need a lock.
+    if (results_are_reduced_)
+        return true;
+    results_are_reduced_ = true;
+
     if (shard_map_.empty()) {
         reduced_ = serial_shard_;
     } else {
@@ -189,6 +195,22 @@ histogram_t::reduce_results(uint64_t *unique_icache_lines, uint64_t *unique_dcac
     if (unique_dcache_lines != nullptr)
         *unique_dcache_lines = reduced_.dcache_map.size();
     return true;
+}
+
+std::optional<std::unordered_map<addr_t, uint64_t>>
+histogram_t::get_icache_counts()
+{
+    if (!reduce_results(nullptr, nullptr))
+        return std::nullopt;
+    return reduced_.icache_map;
+}
+
+std::optional<std::unordered_map<addr_t, uint64_t>>
+histogram_t::get_dcache_counts()
+{
+    if (!reduce_results(nullptr, nullptr))
+        return std::nullopt;
+    return reduced_.dcache_map;
 }
 
 bool

--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -141,6 +141,7 @@ histogram_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     for (addr_t addr = back_align(start_addr, knob_line_size_);
          addr < start_addr + size && addr < addr + knob_line_size_ /* overflow */;
          addr += knob_line_size_) {
+        // XXX i#8026: Remove this shift to simplify storage.
         ++(*cache_map)[addr >> line_size_bits_];
     }
     return true;

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,7 @@
 #include <stdint.h>
 
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -78,6 +79,12 @@ public:
     reduce_results(uint64_t *unique_icache_lines = nullptr,
                    uint64_t *unique_dcache_lines = nullptr);
 
+    virtual std::optional<std::unordered_map<addr_t, uint64_t>>
+    get_icache_counts();
+
+    virtual std::optional<std::unordered_map<addr_t, uint64_t>>
+    get_dcache_counts();
+
 protected:
     struct shard_data_t {
         std::unordered_map<addr_t, uint64_t> icache_map;
@@ -96,6 +103,7 @@ protected:
     shard_data_t serial_shard_;
     // The combined data from all the shards.
     shard_data_t reduced_;
+    bool results_are_reduced_ = false;
 };
 
 } // namespace drmemtrace


### PR DESCRIPTION
Adds a guard on reducing results, to avoid incorrectly re-accumulating on additional parallel reductions.

Adds a unit test of parallel reduction. Adds an export of the count map, which is used in the test to ensure counts are not overly accumulating. Tested without the fix and confirmed the test fails.

Issue: #8026