### PR TITLE
i#8028: Fix clang-format-diff result in CI

### DIFF
--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -112,9 +112,6 @@ found_client_sysenter(void)
 }
 #endif
 
-
-
-
 static bool
 exited_due_to_ni_syscall(dcontext_t *dcontext)
 {

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -112,6 +112,9 @@ found_client_sysenter(void)
 }
 #endif
 
+
+
+
 static bool
 exited_due_to_ni_syscall(dcontext_t *dcontext)
 {

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -277,7 +277,7 @@ else ()
       RESULT_VARIABLE format_result
       ERROR_VARIABLE format_err
       OUTPUT_VARIABLE format_out)
-    if (format_result OR format_err)
+    if (format_err)
       message(FATAL_ERROR
         "Error (${format_result}) running clang-format-diff: ${format_err}")
     endif ()
@@ -288,6 +288,9 @@ else ()
         "Changes are not formatted properly:\n${format_out}")
       message(FATAL_ERROR
         "FATAL ERROR: Changes are not formatted properly (see diff above)!")
+    elseif (format_result)
+      message(FATAL_ERROR
+        "Error (${format_result}) running clang-format-diff")
     else ()
       message("clang-format check passed")
     endif ()


### PR DESCRIPTION
#### Bug

Older versions of `clang-format-diff` returned exit status 0 regardless of whether formatting diffs were found. Newer versions exit with status 1 when formatting diffs are detected and write the diff to `stdout` (`format_out`).

Because `runsuite.cmake` previously checked `if (format_result OR format_err)` immediately after execution, the new non-zero exit status (1) caused CMake to abort with a generic process execution error before reaching `if (format_out)`, hiding the actual formatting diff from developers.

#### Fix

In `runsuite.cmake`:

- Changed `if (format_result OR format_err)` to `if (format_err)` so non-zero exit codes don't abort before reaching the `if (format_out)` block that prints the diff.
- Added `elseif (format_result)` to report exit errors when `clang-format-diff` fails with a non-zero status but produces no stderr and stdout.

Fixes #8028 