### PR TITLE
i#8001 shared defs: Use TESTANY instead of TEST

### DIFF
--- a/api/docs/code_style.dox
+++ b/api/docs/code_style.dox
@@ -189,7 +189,7 @@ warn you if you use assignment rather than equality.
 
 -# Use the `TEST` and related macros for testing bits.
 
-  \b GOOD: `if (TEST(BITMASK, x))`
+  \b GOOD: `if (TESTANY(BITMASK, x))`
 
   \e BAD:  `if ((x & BITMASK) != 0)`
 

--- a/clients/common/utils.h
+++ b/clients/common/utils.h
@@ -50,7 +50,6 @@
 #define BUFFER_LAST_ELEMENT(buf) (buf)[BUFFER_SIZE_ELEMENTS(buf) - 1]
 #define NULL_TERMINATE_BUFFER(buf) BUFFER_LAST_ELEMENT(buf) = 0
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
-#define TEST TESTANY
 
 #ifdef WINDOWS
 #    define IF_WINDOWS(x) x

--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -573,7 +573,7 @@ bb_bitmap_lookup(module_table_t *table, uint addr)
 {
     byte *bm = table->bb_table.bitmap;
     if (bm[BITMAP_INDEX(addr)] == 0xff ||
-        TEST(BITMAP_MASK(BITMAP_OFFSET(addr)), bm[BITMAP_INDEX(addr)]))
+        TESTANY(BITMAP_MASK(BITMAP_OFFSET(addr)), bm[BITMAP_INDEX(addr)]))
         return BB_TABLE_ENTRY_SET;
     return BB_TABLE_ENTRY_CLEAR;
 }
@@ -589,7 +589,7 @@ bb_bitmap_add(module_table_t *table, bb_entry_t *entry)
     if (bm[idx] == BB_TABLE_RANGE_SET)
         return false;
     offs = BITMAP_OFFSET(entry->start);
-    if (TEST(BITMAP_MASK(offs), bm[idx]))
+    if (TESTANY(BITMAP_MASK(offs), bm[idx]))
         return false;
     /* now we add a new bb */
     PRINT(6, "Add 0x%x-0x%x in table " PFX "\n", entry->start, entry->start + entry->size,

--- a/clients/drcpusim/tests/cpuid.c
+++ b/clients/drcpusim/tests/cpuid.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -148,20 +148,20 @@ main(int argc, char **argv)
     print("  ext_edx = 0x%08x\n  ext_ecx = 0x%08x\n", ext_edx, ext_ecx);
     print("  sext_ebx = 0x%08x\n", sext_ebx);
     print("Major ISA features:\n");
-    if (TEST(FEAT_EDX_MMX, feat_edx))
+    if (TESTANY(FEAT_EDX_MMX, feat_edx))
         print("  MMX\n");
-    if (TEST(FEAT_EDX_SSE, feat_edx))
+    if (TESTANY(FEAT_EDX_SSE, feat_edx))
         print("  SSE\n");
-    if (TEST(FEAT_EDX_SSE2, feat_edx))
+    if (TESTANY(FEAT_EDX_SSE2, feat_edx))
         print("  SSE2\n");
-    if (TEST(FEAT_ECX_SSE3, feat_ecx))
+    if (TESTANY(FEAT_ECX_SSE3, feat_ecx))
         print("  SSE3\n");
-    if (TEST(FEAT_ECX_SSSE3, feat_ecx))
+    if (TESTANY(FEAT_ECX_SSSE3, feat_ecx))
         print("  SSSE3\n");
-    if (TEST(FEAT_ECX_SSE41, feat_ecx))
+    if (TESTANY(FEAT_ECX_SSE41, feat_ecx))
         print("  SSE41\n");
-    if (TEST(FEAT_ECX_SSE42, feat_ecx))
+    if (TESTANY(FEAT_ECX_SSE42, feat_ecx))
         print("  SSE42\n");
-    if (TEST(FEAT_ECX_AVX, feat_ecx))
+    if (TESTANY(FEAT_ECX_AVX, feat_ecx))
         print("  AVX\n");
 }

--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -178,7 +178,7 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
     uint *pc = write_stub_pc;
     uint num_nops_needed = 0;
     /* TODO i#1575: coarse-grain NYI on ARM */
-    ASSERT_NOT_IMPLEMENTED(!TEST(FRAG_COARSE_GRAIN, f->flags));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(FRAG_COARSE_GRAIN, f->flags));
     if (LINKSTUB_DIRECT(l_flags)) {
         /* stp x0, x1, [x(stolen), #(offs)] */
         *pc++ = (0xa9000000 | 0 | 1 << 10 | (dr_reg_stolen - DR_REG_X0) << 5 |
@@ -461,7 +461,7 @@ unlink_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     ASSERT(LINKSTUB_INDIRECT(l->flags));
     /* Target is always the same, so if it's already unlinked, this is a nop. */
-    if (!TEST(LINK_LINKED, l->flags))
+    if (!TESTANY(LINK_LINKED, l->flags))
         return;
     ibl_code = get_ibl_routine_code(dcontext, extract_branchtype(l->flags), f->flags);
     exit_target = ibl_code->unlinked_ibl_entry;
@@ -643,7 +643,7 @@ append_restore_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
     int i;
 
     /* TODO i#1573: NYI on ARM with SELFPROT_DCONTEXT */
-    ASSERT_NOT_IMPLEMENTED(!TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
     ASSERT(dr_reg_stolen != SCRATCH_REG0);
     /* Store stolen reg value into TLS slot. */
     APP(ilist, RESTORE_FROM_DC(dcontext, SCRATCH_REG0, REG_OFFSET(dr_reg_stolen)));

--- a/core/arch/aarchxx/emit_utils.c
+++ b/core/arch/aarchxx/emit_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -87,7 +87,7 @@ append_fcache_enter_prologue(dcontext_t *dcontext, instrlist_t *ilist, bool abso
                           opnd_create_reg(REG_DCXT)));
 #endif
     ASSERT_NOT_IMPLEMENTED(!absolute &&
-                           !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
+                           !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
     /* grab gen routine's parameter dcontext and put it into REG_DCXT */
     APP(ilist, XINST_CREATE_move(dcontext, opnd_create_reg(REG_DCXT), OPND_ARG1));
 #ifdef UNIX

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1688,7 +1688,7 @@ mangle_indirect_jump(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         instr_set_src(instr, 0, memop);
         instr_set_dst(instr, 0, opnd_create_reg(IBL_TARGET_REG));
         /* We target only the typical return instructions: multi-pop here */
-        if (TEST(INSTR_CLOBBER_RETADDR, instr->flags) && opc == OP_ldmia) {
+        if (TESTANY(INSTR_CLOBBER_RETADDR, instr->flags) && opc == OP_ldmia) {
             bool writeback = instr_num_srcs(instr) > 1;
             if (writeback) {
                 opnd_set_disp(&memop, -sizeof(void *));
@@ -1823,7 +1823,7 @@ mangle_indirect_jump(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             mangle_stolen_reg(dcontext, ilist, instr, immed_next, remove_instr);
         }
         /* We target only the typical return instructions: single pop here */
-        if (TEST(INSTR_CLOBBER_RETADDR, instr->flags) && opc == OP_ldr) {
+        if (TESTANY(INSTR_CLOBBER_RETADDR, instr->flags) && opc == OP_ldr) {
             bool writeback = instr_num_srcs(instr) > 1;
             if (writeback && opnd_is_immed_int(instr_get_src(instr, 1))) {
                 opnd_t memop = instr_get_src(instr, 0);
@@ -2047,7 +2047,7 @@ mangle_rel_addr(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
      * has no analogue with a non-PC base.
      */
     if (instr_get_isa_mode(instr) == DR_ISA_ARM_THUMB &&
-        TEST(DR_OPND_NEGATED, opnd_get_flags(mem_op)) && disp >= 256) {
+        TESTANY(DR_OPND_NEGATED, opnd_get_flags(mem_op)) && disp >= 256) {
         /* Apply the disp now */
         r15 -= disp;
         disp = 0;
@@ -2769,7 +2769,7 @@ normalize_ldm_instr(dcontext_t *dcontext, instr_t *instr, /* ldm */
         }
         instr_set_predicate(*ldr_pc, pred);
         instr_set_translation(*ldr_pc, pc);
-        if (TEST(INSTR_CLOBBER_RETADDR, instr->flags))
+        if (TESTANY(INSTR_CLOBBER_RETADDR, instr->flags))
             (*ldr_pc)->flags |= INSTR_CLOBBER_RETADDR;
     }
 }

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -1464,7 +1464,7 @@ arch_thread_exit(dcontext_t *dcontext _IF_WINDOWS(bool detach_stacked_callbacks)
     if (!detach_stacked_callbacks && !DYNAMO_OPTION(thin_client)) {
 #endif
         /* ensure we didn't miss the init patch and leave it writable! */
-        ASSERT(!TEST(SELFPROT_GENCODE, DYNAMO_OPTION(protect_mask)) ||
+        ASSERT(!TESTANY(SELFPROT_GENCODE, DYNAMO_OPTION(protect_mask)) ||
                !((generated_code_t *)dcontext->private_code)->writable);
 #ifdef WINDOWS
     }
@@ -1487,7 +1487,8 @@ arch_patch_syscall_common(dcontext_t *dcontext, byte *target _IF_X64(gencode_mod
     generated_code_t *code = get_emitted_routines_code(dcontext _IF_X86_64(mode));
     if (code != NULL && (!is_shared_gencode(code) || dcontext == GLOBAL_DCONTEXT)) {
         /* ensure we didn't miss the init patch and leave it writable! */
-        ASSERT(!TEST(SELFPROT_GENCODE, DYNAMO_OPTION(protect_mask)) || !code->writable);
+        ASSERT(!TESTANY(SELFPROT_GENCODE, DYNAMO_OPTION(protect_mask)) ||
+               !code->writable);
         /* this is only done for detach, so no need to re-protect */
         protect_generated_code(code, WRITABLE);
         emit_patch_syscall(dcontext, target _IF_X64(mode));
@@ -1520,7 +1521,7 @@ protect_generated_code(generated_code_t *code_in, bool writable)
      */
     volatile generated_code_t *code =
         (generated_code_t *)vmcode_get_writable_addr((byte *)code_in);
-    if (TEST(SELFPROT_GENCODE, DYNAMO_OPTION(protect_mask)) &&
+    if (TESTANY(SELFPROT_GENCODE, DYNAMO_OPTION(protect_mask)) &&
         code->writable != writable) {
         byte *genstart = (byte *)PAGE_START(code->gen_start_pc);
         if (!writable) {
@@ -1540,13 +1541,14 @@ protect_generated_code(generated_code_t *code_in, bool writable)
 ibl_source_fragment_type_t
 get_source_fragment_type(dcontext_t *dcontext, uint fragment_flags)
 {
-    if (TEST(FRAG_IS_TRACE, fragment_flags)) {
-        return (TEST(FRAG_SHARED, fragment_flags)) ? IBL_TRACE_SHARED : IBL_TRACE_PRIVATE;
-    } else if (TEST(FRAG_COARSE_GRAIN, fragment_flags)) {
-        ASSERT(TEST(FRAG_SHARED, fragment_flags));
+    if (TESTANY(FRAG_IS_TRACE, fragment_flags)) {
+        return (TESTANY(FRAG_SHARED, fragment_flags)) ? IBL_TRACE_SHARED
+                                                      : IBL_TRACE_PRIVATE;
+    } else if (TESTANY(FRAG_COARSE_GRAIN, fragment_flags)) {
+        ASSERT(TESTANY(FRAG_SHARED, fragment_flags));
         return IBL_COARSE_SHARED;
     } else {
-        return (TEST(FRAG_SHARED, fragment_flags)) ? IBL_BB_SHARED : IBL_BB_PRIVATE;
+        return (TESTANY(FRAG_SHARED, fragment_flags)) ? IBL_BB_SHARED : IBL_BB_PRIVATE;
     }
 }
 
@@ -2470,9 +2472,9 @@ static inline uint
 table_flags_to_frag_flags(dcontext_t *dcontext, ibl_table_t *table)
 {
     uint flags = 0;
-    if (TEST(FRAG_TABLE_TARGET_SHARED, table->table_flags))
+    if (TESTANY(FRAG_TABLE_TARGET_SHARED, table->table_flags))
         flags |= FRAG_SHARED;
-    if (TEST(FRAG_TABLE_TRACE, table->table_flags))
+    if (TESTANY(FRAG_TABLE_TRACE, table->table_flags))
         flags |= FRAG_IS_TRACE;
     /* We want to make sure that any updates to FRAG_TABLE_* flags
      * are reflected in this routine. */
@@ -3037,7 +3039,7 @@ hook_vsyscall(dcontext_t *dcontext, bool method_changing)
             "vsyscall page %p is not the base of its area %p\n",
             vsyscall_sysenter_return_pc, base_pc);
     }
-    if (!TEST(MEMPROT_WRITE, prot)) {
+    if (!TESTANY(MEMPROT_WRITE, prot)) {
         res = set_protection(vsyscall_page_start, vsyscall_size, prot | MEMPROT_WRITE);
         if (!res) {
             LOG(GLOBAL, LOG_SYSCALLS | LOG_VMAREAS, 1,
@@ -3103,7 +3105,7 @@ hook_vsyscall(dcontext_t *dcontext, bool method_changing)
                          /* we require a thread-shared fcache_return */
                          after_do_shared_syscall_addr(dcontext), NOT_HOT_PATCHABLE);
 
-    if (!TEST(MEMPROT_WRITE, prot)) {
+    if (!TESTANY(MEMPROT_WRITE, prot)) {
         /* we don't override res here since not much point in not using the
          * hook once its in if we failed to re-protect: we're going to have to
          * trust the app code here anyway */
@@ -3147,7 +3149,7 @@ unhook_vsyscall(void)
             vsyscall_sysenter_return_pc, base_pc);
         return false;
     }
-    if (!TEST(MEMPROT_WRITE, prot)) {
+    if (!TESTANY(MEMPROT_WRITE, prot)) {
         res = set_protection(vsyscall_page_start, vsyscall_size, prot | MEMPROT_WRITE);
         if (!res)
             return false;
@@ -3156,7 +3158,7 @@ unhook_vsyscall(void)
     /* we do not restore the 5th (junk/nop) byte (we never copied it) */
     if (vsyscall_sysenter_displaced_pc == vsyscall_syscall_end_pc) /* <4.4.8 */
         memset(vmcode_get_writable_addr(vsyscall_syscall_end_pc), RAW_OPCODE_nop, len);
-    if (!TEST(MEMPROT_WRITE, prot)) {
+    if (!TESTANY(MEMPROT_WRITE, prot)) {
         res = set_protection(vsyscall_page_start, vsyscall_size, prot);
         ASSERT(res);
     }
@@ -3458,7 +3460,7 @@ dr_mcontext_to_priv_mcontext(priv_mcontext_t *dst, dr_mcontext_t *src)
     if (TESTALL(DR_MC_ALL, src->flags) && src->size == sizeof(dr_mcontext_t)) {
         *dst = *(priv_mcontext_t *)(&MCXT_FIRST_REG_FIELD(src));
     } else {
-        if (TEST(DR_MC_INTEGER, src->flags)) {
+        if (TESTANY(DR_MC_INTEGER, src->flags)) {
             /* xsp is in the middle of the mcxt, so we save dst->xsp here and
              * restore it later so we can use one memcpy for DR_MC_INTEGER.
              */
@@ -3471,7 +3473,7 @@ dr_mcontext_to_priv_mcontext(priv_mcontext_t *dst, dr_mcontext_t *src)
                 return false;
             dst->xsp = save_xsp;
         }
-        if (TEST(DR_MC_CONTROL, src->flags)) {
+        if (TESTANY(DR_MC_CONTROL, src->flags)) {
             /* XXX i#2710: mc->lr should be under DR_MC_CONTROL */
             dst->xsp = src->xsp;
 #if defined(RISCV64)
@@ -3489,7 +3491,7 @@ dr_mcontext_to_priv_mcontext(priv_mcontext_t *dst, dr_mcontext_t *src)
             else
                 return false;
         }
-        if (TEST(DR_MC_MULTIMEDIA, src->flags)) {
+        if (TESTANY(DR_MC_MULTIMEDIA, src->flags)) {
 #ifdef X86
             if (src->size > offsetof(dr_mcontext_t, simd)) {
                 if (MCXT_NUM_SIMD_SLOTS > MCXT_NUM_SIMD_SSE_AVX_SLOTS &&
@@ -3562,7 +3564,7 @@ priv_mcontext_to_dr_mcontext(dr_mcontext_t *dst, priv_mcontext_t *src)
      * user set-size field. But currently do not, preferring to detect
      * incompatibility and asserting or returning false.
      */
-    if (TEST(DR_MC_MULTIMEDIA, dst->flags) && dst->size != sizeof(dr_mcontext_t)) {
+    if (TESTANY(DR_MC_MULTIMEDIA, dst->flags) && dst->size != sizeof(dr_mcontext_t)) {
         CLIENT_ASSERT(
             false, "A pre-SVE client is running on an Arm AArch64 SVE DynamoRIO build!");
         return false;
@@ -3571,7 +3573,7 @@ priv_mcontext_to_dr_mcontext(dr_mcontext_t *dst, priv_mcontext_t *src)
     if (TESTALL(DR_MC_ALL, dst->flags) && dst->size == sizeof(dr_mcontext_t)) {
         *(priv_mcontext_t *)(&MCXT_FIRST_REG_FIELD(dst)) = *src;
     } else {
-        if (TEST(DR_MC_INTEGER, dst->flags)) {
+        if (TESTANY(DR_MC_INTEGER, dst->flags)) {
             /* xsp is in the middle of the mcxt, so we save dst->xsp here and
              * restore it later so we can use one memcpy for DR_MC_INTEGER.
              */
@@ -3584,7 +3586,7 @@ priv_mcontext_to_dr_mcontext(dr_mcontext_t *dst, priv_mcontext_t *src)
                 return false;
             dst->xsp = save_xsp;
         }
-        if (TEST(DR_MC_CONTROL, dst->flags)) {
+        if (TESTANY(DR_MC_CONTROL, dst->flags)) {
             dst->xsp = src->xsp;
 #if defined(RISCV64)
             if (dst->size > offsetof(dr_mcontext_t, fcsr))
@@ -3601,7 +3603,7 @@ priv_mcontext_to_dr_mcontext(dr_mcontext_t *dst, priv_mcontext_t *src)
             else
                 return false;
         }
-        if (TEST(DR_MC_MULTIMEDIA, dst->flags)) {
+        if (TESTANY(DR_MC_MULTIMEDIA, dst->flags)) {
 #ifdef X86
             if (dst->size > offsetof(dr_mcontext_t, simd)) {
                 if (MCXT_NUM_SIMD_SLOTS > MCXT_NUM_SIMD_SSE_AVX_SLOTS &&

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -389,10 +389,10 @@ static inline ibl_entry_point_type_t
 get_ibl_entry_type(uint link_or_instr_flags)
 {
 #if defined(X86) && defined(X64)
-    if (TEST(LINK_TRACE_CMP, link_or_instr_flags))
+    if (TESTANY(LINK_TRACE_CMP, link_or_instr_flags))
         return IBL_TRACE_CMP;
 #endif
-    if (TEST(LINK_FAR, link_or_instr_flags))
+    if (TESTANY(LINK_FAR, link_or_instr_flags))
         return IBL_FAR;
     else
         return IBL_LINKED;
@@ -1650,7 +1650,7 @@ special_ibl_xfer_tgt(dcontext_t *dcontext, generated_code_t *code,
  */
 #    define FRAG_DB_SHARED(flags) true
 #else
-#    define FRAG_DB_SHARED(flags) (TEST(FRAG_SHARED, (flags)))
+#    define FRAG_DB_SHARED(flags) (TESTANY(FRAG_SHARED, (flags)))
 #endif
 
 /* fragment_t fields */
@@ -1682,7 +1682,7 @@ use_ibt_prefix(uint flags)
      */
     return (IS_IBL_TARGET(flags) &&
             /* coarse bbs (and fine in presence of coarse) do not support prefixes */
-            !(DYNAMO_OPTION(coarse_units) && !TEST(FRAG_IS_TRACE, flags) &&
+            !(DYNAMO_OPTION(coarse_units) && !TESTANY(FRAG_IS_TRACE, flags) &&
               DYNAMO_OPTION(bb_ibl_targets)));
 }
 

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * Copyright (c) 2025 Foundation of Research and Technology, Hellas.
  * **********************************************************/
@@ -921,8 +921,8 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 #    define SIZE32_MOV_PTR_IMM_TO_TLS 10
 
 #    ifdef X64
-#        define FRAG_IS_32(flags) (TEST(FRAG_32_BIT, (flags)))
-#        define FRAG_IS_X86_TO_X64(flags) (TEST(FRAG_X86_TO_X64, (flags)))
+#        define FRAG_IS_32(flags) (TESTANY(FRAG_32_BIT, (flags)))
+#        define FRAG_IS_X86_TO_X64(flags) (TESTANY(FRAG_X86_TO_X64, (flags)))
 #    else
 #        define FRAG_IS_32(flags) true
 #        define FRAG_IS_X86_TO_X64(flags) false
@@ -947,7 +947,7 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 
 /* size of restore ecx prefix */
 #    define XCX_IN_TLS(flags) \
-        (DYNAMO_OPTION(private_ib_in_tls) || TEST(FRAG_SHARED, (flags)))
+        (DYNAMO_OPTION(private_ib_in_tls) || TESTANY(FRAG_SHARED, (flags)))
 #    define FRAGMENT_BASE_PREFIX_SIZE(flags)                          \
         ((FRAG_IS_X86_TO_X64(flags) &&                                \
           IF_X64_ELSE(DYNAMO_OPTION(x86_to_x64_ibl_opt), false))      \
@@ -1015,7 +1015,7 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 #        define FRAG_IS_THUMB(flags) false
 #        define FRAG_IS_32(flags) false
 #    else
-#        define FRAG_IS_THUMB(flags) (TEST(FRAG_THUMB, (flags)))
+#        define FRAG_IS_THUMB(flags) (TESTANY(FRAG_THUMB, (flags)))
 #        define FRAG_IS_32(flags) true
 #    endif
 
@@ -1152,14 +1152,14 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 
 #define STATS_PAD_JMPS_ADD(flags, stat, val)                  \
     DOSTATS({                                                 \
-        if (TEST(FRAG_SHARED, (flags))) {                     \
-            if (TEST(FRAG_IS_TRACE, (flags)))                 \
+        if (TESTANY(FRAG_SHARED, (flags))) {                  \
+            if (TESTANY(FRAG_IS_TRACE, (flags)))              \
                 STATS_ADD(pad_jmps_shared_trace_##stat, val); \
             else                                              \
                 STATS_ADD(pad_jmps_shared_bb_##stat, val);    \
-        } else if (TEST(FRAG_IS_TRACE, (flags)))              \
+        } else if (TESTANY(FRAG_IS_TRACE, (flags)))           \
             STATS_ADD(pad_jmps_trace_##stat, val);            \
-        else if (TEST(FRAG_TEMP_PRIVATE, (flags)))            \
+        else if (TESTANY(FRAG_TEMP_PRIVATE, (flags)))         \
             STATS_ADD(pad_jmps_temp_##stat, val);             \
         else                                                  \
             STATS_ADD(pad_jmps_bb_##stat, val);               \
@@ -1596,11 +1596,11 @@ print_optimization_stats(void);
 static inline ibl_branch_type_t
 extract_branchtype(ushort linkstub_flags)
 {
-    if (TEST(LINK_RETURN, linkstub_flags))
+    if (TESTANY(LINK_RETURN, linkstub_flags))
         return IBL_RETURN;
     if (EXIT_IS_CALL(linkstub_flags))
         return IBL_INDCALL;
-    if (TEST(LINK_JMP, linkstub_flags)) /* plain JMP or IND_JMP_PLT */
+    if (TESTANY(LINK_JMP, linkstub_flags)) /* plain JMP or IND_JMP_PLT */
         return IBL_INDJMP;
     ASSERT_NOT_REACHED();
     return IBL_GENERIC;

--- a/core/arch/arm/emit_utils.c
+++ b/core/arch/arm/emit_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -194,7 +194,7 @@ static size_t
 get_fcache_return_tls_offs(dcontext_t *dcontext, uint flags)
 {
     /* ARM always uses shared gencode so we ignore FRAG_DB_SHARED(flags) */
-    if (TEST(FRAG_COARSE_GRAIN, flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, flags)) {
         /* TODO i#1575: coarse-grain NYI on ARM */
         ASSERT_NOT_IMPLEMENTED(false);
         return 0;
@@ -217,7 +217,7 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
 {
     byte *pc = (byte *)stub_pc;
     /* TODO i#1575: coarse-grain NYI on ARM */
-    ASSERT_NOT_IMPLEMENTED(!TEST(FRAG_COARSE_GRAIN, f->flags));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(FRAG_COARSE_GRAIN, f->flags));
     /* XXX: should we use our IR and encoder instead?  Then we could
      * share code with emit_do_syscall(), though at a perf cost.
      */
@@ -510,7 +510,7 @@ unlink_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     ASSERT(LINKSTUB_INDIRECT(l->flags));
     /* target is always the same, so if it's already unlinked, this is a nop */
-    if (!TEST(LINK_LINKED, l->flags))
+    if (!TESTANY(LINK_LINKED, l->flags))
         return;
     ibl_code = get_ibl_routine_code(dcontext, extract_branchtype(l->flags), f->flags);
     exit_target = ibl_code->unlinked_ibl_entry;
@@ -639,7 +639,7 @@ append_restore_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
 {
     dr_isa_mode_t isa_mode = dr_get_isa_mode(dcontext);
     /* TODO i#1573: NYI on ARM with SELFPROT_DCONTEXT */
-    ASSERT_NOT_IMPLEMENTED(!TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
     ASSERT(dr_reg_stolen != SCRATCH_REG0);
     /* store stolen reg value into TLS slot */
     APP(ilist, RESTORE_FROM_DC(dcontext, SCRATCH_REG0, REG_OFFSET(dr_reg_stolen)));
@@ -699,7 +699,7 @@ append_save_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool ibl_end, bool abs
 {
     dr_isa_mode_t isa_mode = dr_get_isa_mode(dcontext);
     ASSERT_NOT_IMPLEMENTED(!absolute &&
-                           !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
+                           !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
     if (R0_OFFSET != 0) {
         APP(ilist,
             INSTR_CREATE_add(dcontext, opnd_create_reg(REG_DCXT),
@@ -822,7 +822,7 @@ insert_mode_change_handling(dcontext_t *dc, instrlist_t *ilist, instr_t *where,
      * Unfortunately it's hard to not do this in the IBL and instead back in DR:
      * what about signal handler, other places who decode?
      */
-    ASSERT_NOT_IMPLEMENTED(!TEST(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)));
     PRE(ilist, where, instr_create_restore_from_tls(dc, scratch2, TLS_DCONTEXT_SLOT));
     /* Get LSB from target address */
     PRE(ilist, where,

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -152,7 +152,7 @@
 int
 exit_stub_size(dcontext_t *dcontext, cache_pc target, uint flags)
 {
-    if (TEST(FRAG_COARSE_GRAIN, flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, flags)) {
         /* For coarse: bb building points at bb ibl, and then insert_exit_stub
          * changes that to the appropriate coarse prefix.  So the emit() calls to
          * this routine pass in a real ibl.  But any later calls, e.g. for
@@ -188,7 +188,7 @@ exit_stub_size(dcontext_t *dcontext, cache_pc target, uint flags)
                            IBL_FRAG_FLAGS(ibl_code)))
             return 0;
 
-        if (TEST(FRAG_COARSE_GRAIN, flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, flags)) {
             IF_WINDOWS(ASSERT(!is_shared_syscall_routine(dcontext, target)));
             /* keep in synch w/ coarse_indirect_stub_size() */
             return (STUB_COARSE_INDIRECT_SIZE(flags));
@@ -207,7 +207,7 @@ exit_stub_size(dcontext_t *dcontext, cache_pc target, uint flags)
             return (STUB_INDIRECT_SIZE(flags));
     } else {
         /* direct branch */
-        if (TEST(FRAG_COARSE_GRAIN, flags))
+        if (TESTANY(FRAG_COARSE_GRAIN, flags))
             return (STUB_COARSE_DIRECT_SIZE(flags));
         else
             return (STUB_DIRECT_SIZE(flags));
@@ -293,7 +293,7 @@ uint
 extend_trace_pad_bytes(fragment_t *add_frag)
 {
     /* To estimate we count the number of exit ctis by counting the linkstubs. */
-    bool inline_ibl_head = TEST(FRAG_IS_TRACE, add_frag->flags)
+    bool inline_ibl_head = TESTANY(FRAG_IS_TRACE, add_frag->flags)
         ? DYNAMO_OPTION(inline_trace_ibl)
         : DYNAMO_OPTION(inline_bb_ibl);
     int num_patchables = 0;
@@ -363,7 +363,7 @@ cache_pc
 get_direct_exit_target(dcontext_t *dcontext, uint flags)
 {
     if (FRAG_DB_SHARED(flags)) {
-        if (TEST(FRAG_COARSE_GRAIN, flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, flags)) {
             /* note that entrance stubs should target their unit's prefix,
              * who will then target this routine
              */
@@ -387,12 +387,12 @@ bool
 is_exit_cti_patchable(dcontext_t *dcontext, instr_t *inst, uint frag_flags)
 {
     app_pc target;
-    if (TEST(FRAG_COARSE_GRAIN, frag_flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, frag_flags)) {
         /* Case 8647: coarse grain fragment bodies always link through stubs
          * until frozen, so their ctis are never patched except at freeze time
          * when we suspend the world.
          */
-        ASSERT(!TEST(FRAG_IS_TRACE, frag_flags));
+        ASSERT(!TESTANY(FRAG_IS_TRACE, frag_flags));
         return false;
     }
     ASSERT(instr_is_exit_cti(inst));
@@ -518,7 +518,7 @@ link_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, bool hot_
      */
     byte *stub_pc = (byte *)EXIT_STUB_PC(dcontext, f, l);
 
-    ASSERT(!TEST(FRAG_COARSE_GRAIN, f->flags));
+    ASSERT(!TESTANY(FRAG_COARSE_GRAIN, f->flags));
 
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     ASSERT(LINKSTUB_INDIRECT(l->flags));
@@ -574,12 +574,12 @@ indirect_linkstub_target(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
          * exit from other indirect exits and from other exits in
          * a fragment containing ignorable or non-ignorable syscalls
          */
-        ASSERT(TEST(FRAG_HAS_SYSCALL, f->flags));
+        ASSERT(TESTANY(FRAG_HAS_SYSCALL, f->flags));
         return shared_syscall_routine_ex(
             dcontext _IF_X86_64(FRAGMENT_GENCODE_MODE(f->flags)));
     }
 #endif
-    if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
         /* Need to target the ibl prefix.  Passing in cti works as well as stub,
          * and avoids a circular dependence where linkstub_unlink_entry_offset()
          * call this routine to get the target and then this routine asks for
@@ -961,7 +961,7 @@ remove_assembled_patch_markers(dcontext_t *dcontext, patch_list_t *patch)
     */
 
     while (j < patch->num_relocations) {
-        if (TEST(PATCH_MARKER, patch->entry[j].patch_flags)) {
+        if (TESTANY(PATCH_MARKER, patch->entry[j].patch_flags)) {
             LOG(THREAD, LOG_EMIT, 4,
                 "remove_assembled_patch_markers: removing marker %d\n", j);
         } else {
@@ -989,9 +989,9 @@ relocate_patch_list(dcontext_t *dcontext, patch_list_t *patch, instrlist_t *ilis
     /* go through the instructions and "relocate" by indirectly using XDI */
     for (inst = instrlist_first(ilist); inst; inst = instr_get_next(inst)) {
         if (cur < patch->num_relocations && inst == patch->entry[cur].where.instr) {
-            ASSERT(!TEST(PATCH_OFFSET_VALID, patch->entry[cur].patch_flags));
+            ASSERT(!TESTANY(PATCH_OFFSET_VALID, patch->entry[cur].patch_flags));
 
-            if (!TEST(PATCH_MARKER, patch->entry[cur].patch_flags)) {
+            if (!TESTANY(PATCH_MARKER, patch->entry[cur].patch_flags)) {
                 opnd_t opnd;
                 ASSERT(instr_num_srcs(inst) > 0);
                 opnd = instr_get_src(inst, 0);
@@ -1071,7 +1071,7 @@ encode_with_patch_list(dcontext_t *dcontext, patch_list_t *patch, instrlist_t *i
         pc = nxt_pc;
 
         if (cur < patch->num_relocations && inst == patch->entry[cur].where.instr) {
-            ASSERT(!TEST(PATCH_OFFSET_VALID, patch->entry[cur].patch_flags));
+            ASSERT(!TESTANY(PATCH_OFFSET_VALID, patch->entry[cur].patch_flags));
 
             /* support positive offsets from beginning and negative -
              * from end of instruction
@@ -1093,18 +1093,18 @@ encode_with_patch_list(dcontext_t *dcontext, patch_list_t *patch, instrlist_t *i
                 "encode_with_patch_list: patch_entry_t[%d] offset=" PFX "\n", cur,
                 patch->entry[cur].where.offset);
 
-            if (TEST(PATCH_MARKER, patch->entry[cur].patch_flags)) {
+            if (TESTANY(PATCH_MARKER, patch->entry[cur].patch_flags)) {
                 /* treat value_location_offset as an output argument
                    and store there the computed offset,
                 */
                 ptr_uint_t *output_value =
                     (ptr_uint_t *)patch->entry[cur].value_location_offset;
                 ptr_uint_t output_offset = patch->entry[cur].where.offset;
-                if (TEST(PATCH_ASSEMBLE_ABSOLUTE, patch->entry[cur].patch_flags)) {
-                    ASSERT(!TEST(PATCH_UINT_SIZED, patch->entry[cur].patch_flags));
+                if (TESTANY(PATCH_ASSEMBLE_ABSOLUTE, patch->entry[cur].patch_flags)) {
+                    ASSERT(!TESTANY(PATCH_UINT_SIZED, patch->entry[cur].patch_flags));
                     output_offset += (ptr_uint_t)vmcode_get_executable_addr(start_pc);
                 }
-                if (TEST(PATCH_UINT_SIZED, patch->entry[cur].patch_flags)) {
+                if (TESTANY(PATCH_UINT_SIZED, patch->entry[cur].patch_flags)) {
                     IF_X64(ASSERT(CHECK_TRUNCATE_TYPE_uint(output_offset)));
                     *((uint *)output_value) = (uint)output_offset;
                 } else
@@ -1138,7 +1138,7 @@ print_patch_list(patch_list_t *patch)
         patch->num_relocations);
 
     for (i = 0; i < patch->num_relocations; i++) {
-        ASSERT(TEST(PATCH_OFFSET_VALID, patch->entry[i].patch_flags));
+        ASSERT(TESTANY(PATCH_OFFSET_VALID, patch->entry[i].patch_flags));
         LOG(THREAD_GET, LOG_EMIT, 4,
             "patch_list [%d] offset=" PFX " patch_flags=%d value_offset=" PFX "\n", i,
             patch->entry[i].where.offset, patch->entry[i].patch_flags,
@@ -1158,7 +1158,7 @@ disassemble_with_annotations(dcontext_t *dcontext, patch_list_t *patch, byte *st
     do {
         if (cur < patch->num_relocations &&
             pc >= start_pc + patch->entry[cur].where.offset) {
-            ASSERT(TEST(PATCH_OFFSET_VALID, patch->entry[cur].patch_flags));
+            ASSERT(TESTANY(PATCH_OFFSET_VALID, patch->entry[cur].patch_flags));
             /* this is slightly off - we'll mark next instruction,
                but is good enough for this purpose */
             LOG(THREAD, LOG_EMIT, 2, "%d:", cur);
@@ -1199,9 +1199,9 @@ patch_emitted_code(dcontext_t *dcontext, patch_list_t *patch, byte *start_pc)
         /* value address, (think for example of pt->trace.hash_mask) */
         ptr_uint_t value;
         char *vaddr = NULL;
-        if (TEST(PATCH_PER_THREAD, patch->entry[i].patch_flags)) {
+        if (TESTANY(PATCH_PER_THREAD, patch->entry[i].patch_flags)) {
             vaddr = (char *)pt + patch->entry[i].value_location_offset;
-        } else if (TEST(PATCH_UNPROT_STAT, patch->entry[i].patch_flags)) {
+        } else if (TESTANY(PATCH_UNPROT_STAT, patch->entry[i].patch_flags)) {
             /* separate the two parts of the stat */
             uint unprot_offs = (uint)(patch->entry[i].value_location_offset) >> 16;
             uint field_offs = (uint)(patch->entry[i].value_location_offset) & 0xffff;
@@ -1213,17 +1213,17 @@ patch_emitted_code(dcontext_t *dcontext, patch_list_t *patch, byte *start_pc)
                 patch->entry[i].value_location_offset, unprot_offs, field_offs, vaddr);
         } else
             ASSERT_NOT_REACHED();
-        ASSERT(TEST(PATCH_OFFSET_VALID, patch->entry[i].patch_flags));
-        ASSERT(!TEST(PATCH_MARKER, patch->entry[i].patch_flags));
+        ASSERT(TESTANY(PATCH_OFFSET_VALID, patch->entry[i].patch_flags));
+        ASSERT(!TESTANY(PATCH_MARKER, patch->entry[i].patch_flags));
 
-        if (!TEST(PATCH_TAKE_ADDRESS, patch->entry[i].patch_flags)) {
+        if (!TESTANY(PATCH_TAKE_ADDRESS, patch->entry[i].patch_flags)) {
             /* use value pointed by computed address */
-            if (TEST(PATCH_UINT_SIZED, patch->entry[i].patch_flags))
+            if (TESTANY(PATCH_UINT_SIZED, patch->entry[i].patch_flags))
                 value = (ptr_uint_t) * ((uint *)vaddr);
             else
                 value = *(ptr_uint_t *)vaddr;
         } else {
-            ASSERT(!TEST(PATCH_UINT_SIZED, patch->entry[i].patch_flags));
+            ASSERT(!TESTANY(PATCH_UINT_SIZED, patch->entry[i].patch_flags));
             value = (ptr_uint_t)vaddr; /* use computed address */
         }
 
@@ -1232,7 +1232,7 @@ patch_emitted_code(dcontext_t *dcontext, patch_list_t *patch, byte *start_pc)
             " vaddr=" PFX " value=" PFX "\n",
             i, patch->entry[i].where.offset, patch->entry[i].patch_flags,
             patch->entry[i].value_location_offset, vaddr, value);
-        if (TEST(PATCH_UINT_SIZED, patch->entry[i].patch_flags)) {
+        if (TESTANY(PATCH_UINT_SIZED, patch->entry[i].patch_flags)) {
             IF_X64(ASSERT(CHECK_TRUNCATE_TYPE_uint(value)));
             *((uint *)pc) = (uint)value;
         } else
@@ -1266,7 +1266,7 @@ update_indirect_exit_stub(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     ASSERT(LINKSTUB_INDIRECT(l->flags));
     ASSERT(EXIT_HAS_STUB(l->flags, f->flags));
     /* Shared use indirection so no patching needed -- caller should check */
-    ASSERT(!TEST(FRAG_SHARED, f->flags));
+    ASSERT(!TESTANY(FRAG_SHARED, f->flags));
 #ifdef WINDOWS
     /* Do not touch shared_syscall */
     if (EXIT_TARGET_TAG(dcontext, f, l) ==
@@ -1281,7 +1281,7 @@ update_indirect_exit_stub(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
         return;
     }
 
-    if (TEST(FRAG_IS_TRACE, f->flags)) {
+    if (TESTANY(FRAG_IS_TRACE, f->flags)) {
         ASSERT(code->trace_ibl[branch_type].ibl_head_is_inlined);
         patch_emitted_code(dcontext, &code->trace_ibl[branch_type].ibl_stub_patch,
                            start_pc);
@@ -1961,7 +1961,7 @@ append_jmp_to_fcache_target(dcontext_t *dcontext, instrlist_t *ilist,
  *  mov SCRATCH_REG5, xax # save callee-saved reg in case return for signal
  *  if (!absolute)
  *      mov    ARG1, SCRATCH_REG5 # dcontext param
- *    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *      RESTORE_FROM_UPCONTEXT PROT_OFFSET, %xsi
  *    endif
  *  endif
@@ -2097,16 +2097,16 @@ append_jmp_to_fcache_target(dcontext_t *dcontext, instrlist_t *ilist,
  *    RESTORE_FROM_UPCONTEXT xbx_OFFSET,%xbx
  *    RESTORE_FROM_UPCONTEXT xcx_OFFSET,%xcx
  *    RESTORE_FROM_UPCONTEXT xdx_OFFSET,%xdx
- *  if (absolute || !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *  if (absolute || !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *    RESTORE_FROM_UPCONTEXT xsi_OFFSET,%xsi
  *  endif
- *  if (absolute || TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *  if (absolute || TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *    RESTORE_FROM_UPCONTEXT xdi_OFFSET,%xdi
  *  endif
  *    RESTORE_FROM_UPCONTEXT xbp_OFFSET,%xbp
  *    RESTORE_FROM_UPCONTEXT xsp_OFFSET,%xsp
  *  if (!absolute)
- *    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *      RESTORE_FROM_UPCONTEXT xsi_OFFSET,%xsi
  *    else
  *      RESTORE_FROM_UPCONTEXT xdi_OFFSET,%xdi
@@ -2256,7 +2256,7 @@ emit_fcache_enter(dcontext_t *dcontext, generated_code_t *code, byte *pc)
 
     00:   mov xdi, tls_slot_scratch2   64 89 3d 0c 0f 00 00 mov    %edi -> %fs:0xf0c
     07:   mov tls_slot_dcontext, xdi   64 8b 3d 14 0f 00 00 mov    %fs:0xf14 -> %edi
-  if TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)
+  if TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)
      ASSERT_NOT_TESTED
   endif
 */
@@ -2271,7 +2271,7 @@ insert_shared_get_dcontext(dcontext_t *dcontext, instrlist_t *ilist, instr_t *wh
     }
     PRE(ilist, where,
         RESTORE_FROM_TLS(dcontext, SCRATCH_REG5 /*xdi/r5*/, TLS_DCONTEXT_SLOT));
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
 #ifdef X86
         bool absolute = false;
         /* PR 224798: we could avoid extra indirection by storing
@@ -2316,7 +2316,7 @@ insert_shared_restore_dcontext_reg(dcontext_t *dcontext, instrlist_t *ilist,
  *  if (!absolute)
  *    mov  %xdi,fs:xdx_OFFSET
  *    mov  fs:dcontext,%xdi
- *    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *      RESTORE_FROM_DCONTEXT PROT_OFFSET,%xdi
  *      xchg   %xsi,%xdi
  *      SAVE_TO_UPCONTEXT %xdi,xsi_OFFSET
@@ -2357,7 +2357,7 @@ append_prepare_fcache_return(dcontext_t *dcontext, generated_code_t *code,
      */
     APP(ilist, SAVE_TO_TLS(dcontext, REG_DCTXT, DCONTEXT_BASE_SPILL_SLOT));
     APP(ilist, RESTORE_FROM_TLS(dcontext, REG_DCTXT, TLS_DCONTEXT_SLOT));
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
 #ifdef X86
         /* we'd need a 3rd slot in order to nicely get unprot ptr into xsi
          * we can do it w/ only 2 slots by clobbering dcontext ptr
@@ -2437,7 +2437,7 @@ append_call_dispatch(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
  *  if (!absolute)
  *    mov  %xdi,fs:xdx_OFFSET
  *    mov  fs:dcontext,%xdi
- *    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *      RESTORE_FROM_DCONTEXT PROT_OFFSET,%xdi
  *      xchg   %xsi,%xdi
  *      SAVE_TO_UPCONTEXT %xdi,xsi_OFFSET
@@ -2463,7 +2463,7 @@ append_call_dispatch(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
  *  endif
  *    SAVE_TO_UPCONTEXT %xcx,xcx_OFFSET
  *    SAVE_TO_UPCONTEXT %xdx,xdx_OFFSET
- *  if (absolute || !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *  if (absolute || !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *    SAVE_TO_UPCONTEXT %xsi,xsi_OFFSET
  *  endif
  *  if (absolute)
@@ -2874,7 +2874,7 @@ emit_coarse_exit_prefix(dcontext_t *dcontext, byte *pc, coarse_info_t *info)
     APP(&ilist, fcache_ret_prefix);
 
 #if defined(X86) && defined(X64)
-    if (TEST(PERSCACHE_X86_32, info->flags)) {
+    if (TESTANY(PERSCACHE_X86_32, info->flags)) {
         /* XXX: this won't work b/c opnd size will be wrong */
         ASSERT_NOT_IMPLEMENTED(false && "must pass opnd size to SAVE_TO_TLS");
         APP(&ilist, SAVE_TO_TLS(dcontext, REG_ECX, MANGLE_XCX_SPILL_SLOT));
@@ -3501,7 +3501,7 @@ emit_far_ibl(dcontext_t *dcontext, byte *pc, ibl_code_t *ibl_code,
          * and add logic there to set x86_mode based on LINK_FAR.
          * We do not want x86_mode sitting in unprotected_context_t.
          */
-        ASSERT_NOT_IMPLEMENTED(!TEST(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)));
+        ASSERT_NOT_IMPLEMENTED(!TESTANY(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)));
         APP(&ilist,
             XINST_CREATE_store(
                 dcontext,
@@ -4034,7 +4034,7 @@ emit_shared_syscall(dcontext_t *dcontext, generated_code_t *code, byte *pc,
                          1 /* offset of imm field */, (ptr_uint_t *)&after_syscall_ptr);
     }
     /* even if !DYNAMO_OPTION(syscalls_synch_flush) must set for reset */
-    ASSERT(!TEST(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)));
+    ASSERT(!TESTANY(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)));
     if (all_shared) {
         /* readers of at_syscall are ok w/ us not quite having xdi restored yet */
         APP(&ilist,

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -263,7 +263,7 @@ init_build_bb(build_bb_t *bb, app_pc start_pc, bool app_interp, bool for_cache,
     bb->record_translation = record_translation;
     bb->outf = outf;
     bb->overlap_info = overlap_info;
-    bb->follow_direct = !TEST(FRAG_SELFMOD_SANDBOXED, known_flags);
+    bb->follow_direct = !TESTANY(FRAG_SELFMOD_SANDBOXED, known_flags);
     bb->flags = known_flags;
     bb->ibl_branch_type = IBL_GENERIC; /* initialization only */
 #ifdef ARM
@@ -882,7 +882,7 @@ bb_process_invalid_instr(dcontext_t *dcontext, build_bb_t *bb)
          * types of invalid instructions (for ex. STATUS_INVALID_LOCK
          * _SEQUENCE for lock prefix on a jmp instruction).
          */
-        if (TEST(DUMPCORE_FORGE_ILLEGAL_INST, DYNAMO_OPTION(dumpcore_mask)))
+        if (TESTANY(DUMPCORE_FORGE_ILLEGAL_INST, DYNAMO_OPTION(dumpcore_mask)))
             os_dump_core("Warning: Encountered Illegal Instruction");
         os_forge_exception(bb->instr_start, ILLEGAL_INSTRUCTION_EXCEPTION);
         ASSERT_NOT_REACHED();
@@ -1082,7 +1082,7 @@ bb_process_call_direct(dcontext_t *dcontext, build_bb_t *bb)
         return true; /* keep bb going, w/o inlining call */
     } else {
         if (DYNAMO_OPTION(coarse_split_calls) && DYNAMO_OPTION(coarse_units) &&
-            TEST(FRAG_COARSE_GRAIN, bb->flags)) {
+            TESTANY(FRAG_COARSE_GRAIN, bb->flags)) {
             if (instrlist_first(bb->ilist) != bb->instr) {
                 /* have call be in its own bb */
                 bb_stop_prior_to_instr(dcontext, bb, true /*appended already*/);
@@ -1157,7 +1157,7 @@ instr_is_call_sysenter_pattern(instr_t *call, instr_t *mov, instr_t *sysenter)
     /* Did we find a "call (%xdx) or "call %xdx" that's already marked
      * for ind->direct call conversion? */
     instr = call;
-    if (!(instr != NULL && TEST(INSTR_IND_CALL_DIRECT, instr->flags) &&
+    if (!(instr != NULL && TESTANY(INSTR_IND_CALL_DIRECT, instr->flags) &&
           instr_is_call_indirect(instr) &&
           /* The 2nd src operand should always be %xsp. */
           opnd_is_reg(instr_get_src(instr, 1)) &&
@@ -1914,7 +1914,7 @@ bb_process_syscall(dcontext_t *dcontext, build_bb_t *bb)
     if (bb->pass_to_client && !bb->post_client)
         return false;
 #ifdef DGC_DIAGNOSTICS
-    if (TEST(FRAG_DYNGEN, bb->flags) && !is_dyngen_vsyscall(bb->instr_start)) {
+    if (TESTANY(FRAG_DYNGEN, bb->flags) && !is_dyngen_vsyscall(bb->instr_start)) {
         LOG(THREAD, LOG_INTERP, 1, "WARNING: syscall @ " PFX " in dyngen code!\n",
             bb->instr_start);
     }
@@ -2077,7 +2077,7 @@ bb_process_convertible_indcall(dcontext_t *dcontext, build_bb_t *bb)
     /* If there's no CTI in the BB, we can check if there are 5+ preceding
      * bytes and if they could hold a "mov" instruction.
      */
-    if (!TEST(FRAG_HAS_DIRECT_CTI, bb->flags) && bb->instr_start - 5 >= bb->start_pc) {
+    if (!TESTANY(FRAG_HAS_DIRECT_CTI, bb->flags) && bb->instr_start - 5 >= bb->start_pc) {
 
         byte opcode = *((byte *)bb->instr_start - 5);
 
@@ -2217,7 +2217,7 @@ bb_process_convertible_indcall(dcontext_t *dcontext, build_bb_t *bb)
             /* As a flag to allow our xfer from now-non-coarse to coarse
              * (for vsyscall-in-ntdll) we pre-emptively mark as has-syscall.
              */
-            ASSERT(!TEST(FRAG_HAS_SYSCALL, bb->flags));
+            ASSERT(!TESTANY(FRAG_HAS_SYSCALL, bb->flags));
             bb->flags |= FRAG_HAS_SYSCALL;
         }
         if (check_new_page_jmp(dcontext, bb, callee)) {
@@ -2679,7 +2679,7 @@ client_check_syscall(instrlist_t *ilist, instr_t *inst, bool *found_syscall,
          * we assert on ignorable also?  Probably we'd have to have
          * an exception for the middle of a trace?
          */
-        if (IF_UNIX(TEST(INSTR_NI_SYSCALL, inst->flags))
+        if (IF_UNIX(TESTANY(INSTR_NI_SYSCALL, inst->flags))
             /* PR 243391: only block-ending interrupt 2b matters */
             IF_WINDOWS(instr_is_syscall(inst) ||
                        ((instr_get_opcode(inst) == OP_int &&
@@ -2751,7 +2751,7 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
     app_pc tag = bb->pretend_pc == NULL ? bb->start_pc : bb->pretend_pc;
 
 #ifdef LINUX
-    if (TEST(FRAG_STARTS_RSEQ_REGION, bb->flags)) {
+    if (TESTANY(FRAG_STARTS_RSEQ_REGION, bb->flags)) {
         rseq_insert_start_label(dcontext, tag, bb->ilist);
         /* This is a temporary flag, as it overlaps with another used later. */
         bb->flags &= ~FRAG_STARTS_RSEQ_REGION;
@@ -2763,7 +2763,7 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
                                 &emitflags)) {
         /* although no callback was called we must process syscalls/ints (PR 307284) */
     }
-    if (bb->for_cache && TEST(DR_EMIT_GO_NATIVE, emitflags)) {
+    if (bb->for_cache && TESTANY(DR_EMIT_GO_NATIVE, emitflags)) {
         LOG(THREAD, LOG_INTERP, 2, "client requested that we go native\n");
         SYSLOG_INTERNAL_INFO("thread " TIDFMT " is going native at client request",
                              d_r_get_thread_id());
@@ -2922,10 +2922,10 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
                  * xref case 10846 and i#198
                  */
                 CLIENT_ASSERT(
-                    !TEST(~(LINK_DIRECT | LINK_INDIRECT | LINK_CALL | LINK_RETURN |
-                            LINK_JMP | LINK_NI_SYSCALL_ALL |
-                            LINK_SPECIAL_EXIT IF_WINDOWS(| LINK_CALLBACK_RETURN)),
-                          bb->exit_type) &&
+                    !TESTANY(~(LINK_DIRECT | LINK_INDIRECT | LINK_CALL | LINK_RETURN |
+                               LINK_JMP | LINK_NI_SYSCALL_ALL |
+                               LINK_SPECIAL_EXIT IF_WINDOWS(| LINK_CALLBACK_RETURN)),
+                             bb->exit_type) &&
                         !EXIT_IS_IND_JMP_PLT(bb->exit_type),
                     "client unsupported block exit type internal error");
 
@@ -2977,7 +2977,7 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
                  * we can check for post-cti code
                  */
                 if (inst != instrlist_last(bb->ilist)) {
-                    if (TEST(FRAG_COARSE_GRAIN, bb->flags)) {
+                    if (TESTANY(FRAG_COARSE_GRAIN, bb->flags)) {
                         /* PR 213005: coarse can't handle code beyond ctis */
                         bb->flags &= ~FRAG_COARSE_GRAIN;
                         STATS_INC(coarse_prevent_client);
@@ -3006,7 +3006,7 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
                     DYNAMO_OPTION(max_elide_call) == 0)
                     bb->flags |= FRAG_CANNOT_BE_TRACE;
                 /* our cti check above should have already turned off coarse */
-                ASSERT(!TEST(FRAG_COARSE_GRAIN, bb->flags));
+                ASSERT(!TESTANY(FRAG_COARSE_GRAIN, bb->flags));
             }
         }
     }
@@ -3016,9 +3016,9 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
      */
     ASSERT(!DYNAMO_OPTION(inline_ignored_syscalls));
 
-    ASSERT((TEST(FRAG_HAS_SYSCALL, bb->flags) && found_syscall) ||
-           (!TEST(FRAG_HAS_SYSCALL, bb->flags) && !found_syscall));
-    IF_WINDOWS(ASSERT(!TEST(LINK_CALLBACK_RETURN, bb->exit_type) || found_int));
+    ASSERT((TESTANY(FRAG_HAS_SYSCALL, bb->flags) && found_syscall) ||
+           (!TESTANY(FRAG_HAS_SYSCALL, bb->flags) && !found_syscall));
+    IF_WINDOWS(ASSERT(!TESTANY(LINK_CALLBACK_RETURN, bb->exit_type) || found_int));
 
     /* Note that we do NOT remove, or set, FRAG_HAS_DIRECT_CTI based on
      * client modifications: setting it for a selfmod fragment could
@@ -3110,7 +3110,7 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
             forward_eflags_analysis(dcontext, bb->ilist, instrlist_first(bb->ilist));
     }
 
-    if (TEST(DR_EMIT_STORE_TRANSLATIONS, emitflags)) {
+    if (TESTANY(DR_EMIT_STORE_TRANSLATIONS, emitflags)) {
         /* PR 214962: let client request storage instead of recreation */
         bb->flags |= FRAG_HAS_TRANSLATION_INFO;
         /* if we didn't have record on from start, can't store translation info */
@@ -3125,13 +3125,13 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
          * so we avoid undoing savings from -opt_memory with a tool that
          * doesn't support persistence.
          */
-        if (!TEST(DR_EMIT_PERSISTABLE, emitflags)) {
+        if (!TESTANY(DR_EMIT_PERSISTABLE, emitflags)) {
             bb->flags &= ~FRAG_COARSE_GRAIN;
             STATS_INC(coarse_prevent_client);
         }
     }
 
-    if (TEST(DR_EMIT_MUST_END_TRACE, emitflags)) {
+    if (TESTANY(DR_EMIT_MUST_END_TRACE, emitflags)) {
         /* i#848: let client terminate traces */
         bb->flags |= FRAG_MUST_END_TRACE;
     }
@@ -3355,11 +3355,11 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
     /* avoid discrepancy in finding invalid instructions between fast decode
      * and the full decode of sandboxing by doing full decode up front
      */
-    if (TEST(FRAG_SELFMOD_SANDBOXED, bb->flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags)) {
         bb->full_decode = true;
         bb->follow_direct = false;
     }
-    if (TEST(FRAG_HAS_TRANSLATION_INFO, bb->flags)) {
+    if (TESTANY(FRAG_HAS_TRANSLATION_INFO, bb->flags)) {
         bb->full_decode = true;
         bb->record_translation = true;
     }
@@ -3449,8 +3449,8 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                     stop_bb_on_fallthrough = true;
                     break;
                 }
-                if (!TEST(FRAG_SELFMOD_SANDBOXED, old_flags) &&
-                    TEST(FRAG_SELFMOD_SANDBOXED, bb->flags)) {
+                if (!TESTANY(FRAG_SELFMOD_SANDBOXED, old_flags) &&
+                    TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags)) {
                     /* Restart the decode loop with full_decode and
                      * !follow_direct, which are needed for sandboxing.  This
                      * can't happen more than once because sandboxing is now on.
@@ -3597,7 +3597,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                  */
                 bb->follow_direct = false;
                 DOSTATS({
-                    if (TEST(FRAG_HAS_DIRECT_CTI, bb->flags))
+                    if (TESTANY(FRAG_HAS_DIRECT_CTI, bb->flags))
                         STATS_INC(hotp_num_frag_direct_cti);
                 });
             }
@@ -3605,7 +3605,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
 #endif
 
         if (bb->full_decode) {
-            if (TEST(FRAG_SELFMOD_SANDBOXED, bb->flags) && instr_valid(bb->instr) &&
+            if (TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags) && instr_valid(bb->instr) &&
                 instr_writes_memory(bb->instr)) {
                 /* to allow tailing non-writes, end prior to the write beyond the max */
                 total_writes++;
@@ -3747,7 +3747,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
 #ifdef X64
         /* must be prior to mbr check since mbr location could be rip-rel */
         if (DYNAMO_OPTION(coarse_split_riprel) && DYNAMO_OPTION(coarse_units) &&
-            TEST(FRAG_COARSE_GRAIN, bb->flags) &&
+            TESTANY(FRAG_COARSE_GRAIN, bb->flags) &&
             instr_has_rel_addr_reference(bb->instr)) {
             if (instrlist_first(bb->ilist) != bb->instr) {
                 /* have ref be in its own bb */
@@ -3788,7 +3788,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                 STATS_INC(num_indirect_calls);
 
                 if (DYNAMO_OPTION(coarse_split_calls) && DYNAMO_OPTION(coarse_units) &&
-                    TEST(FRAG_COARSE_GRAIN, bb->flags)) {
+                    TESTANY(FRAG_COARSE_GRAIN, bb->flags)) {
                     if (instrlist_first(bb->ilist) != bb->instr) {
                         /* have call be in its own bb */
                         bb_stop_prior_to_instr(dcontext, bb, true /*appended already*/);
@@ -3984,7 +3984,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
     BBPRINT(bb, 3, "end_pc = " PFX "\n\n", bb->end_pc);
 
 #ifdef LINUX
-    if (TEST(FRAG_HAS_RSEQ_ENDPOINT, bb->flags)) {
+    if (TESTANY(FRAG_HAS_RSEQ_ENDPOINT, bb->flags)) {
         instr_t *label = INSTR_CREATE_label(dcontext);
         instr_set_note(label, (void *)DR_NOTE_REG_BARRIER);
         /* We want the label after the final rseq instruction.  We've
@@ -4050,7 +4050,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
 
     STATS_TRACK_MAX(max_instrs_in_a_bb, total_instrs);
 
-    if (stop_bb_on_fallthrough && TEST(FRAG_HAS_DIRECT_CTI, bb->flags)) {
+    if (stop_bb_on_fallthrough && TESTANY(FRAG_HAS_DIRECT_CTI, bb->flags)) {
         /* If we followed a direct cti to an instruction straddling a vmarea
          * boundary, we can't actually do the elision.  See the
          * sandbox_last_byte() test case in security-common/sandbox.c.  Restart
@@ -4085,10 +4085,10 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
         return;
     }
 
-    if (TEST(FRAG_SELFMOD_SANDBOXED, bb->flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags)) {
         ASSERT(bb->full_decode);
         ASSERT(!bb->follow_direct);
-        ASSERT(!TEST(FRAG_HAS_DIRECT_CTI, bb->flags));
+        ASSERT(!TESTANY(FRAG_HAS_DIRECT_CTI, bb->flags));
     }
 
 #ifdef HOT_PATCHING_INTERFACE
@@ -4198,8 +4198,8 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
      * for cache management, both consistency and capacity)
      * bbs injected with hot patches are also not shared (see case 5272).
      */
-    if (DYNAMO_OPTION(shared_bbs) && !TEST(FRAG_SELFMOD_SANDBOXED, bb->flags) &&
-        !TEST(FRAG_TEMP_PRIVATE, bb->flags)
+    if (DYNAMO_OPTION(shared_bbs) && !TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags) &&
+        !TESTANY(FRAG_TEMP_PRIVATE, bb->flags)
 #ifdef HOT_PATCHING_INTERFACE
         && !hotp_injected
 #endif
@@ -4210,21 +4210,21 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
          * We don't support ignorable syscalls in shared fragments, as they
          * don't set at_syscall and so are incompatible w/ -syscalls_synch_flush.
          */
-        if (!TEST(FRAG_HAS_SYSCALL, bb->flags) ||
+        if (!TESTANY(FRAG_HAS_SYSCALL, bb->flags) ||
             TESTANY(LINK_NI_SYSCALL_ALL, bb->exit_type) ||
-            TEST(LINK_SPECIAL_EXIT, bb->exit_type))
+            TESTANY(LINK_SPECIAL_EXIT, bb->exit_type))
             bb->flags |= FRAG_SHARED;
 #ifdef WINDOWS
         /* A fragment can be shared if it contains a syscall that will be
          * executed via the version of shared syscall that can be targetted by
          * shared frags.
          */
-        else if (TEST(FRAG_HAS_SYSCALL, bb->flags) &&
+        else if (TESTANY(FRAG_HAS_SYSCALL, bb->flags) &&
                  DYNAMO_OPTION(shared_fragment_shared_syscalls) &&
                  bb->exit_target == shared_syscall_routine(dcontext))
             bb->flags |= FRAG_SHARED;
         else {
-            ASSERT((TEST(FRAG_HAS_SYSCALL, bb->flags) &&
+            ASSERT((TESTANY(FRAG_HAS_SYSCALL, bb->flags) &&
                     (DYNAMO_OPTION(ignore_syscalls) ||
                      (!DYNAMO_OPTION(shared_fragment_shared_syscalls) &&
                       bb->exit_target == shared_syscall_routine(dcontext)))) &&
@@ -4236,40 +4236,41 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
         bb->exit_type |= LINK_SPECIAL_EXIT;
     }
 
-    if (TEST(FRAG_COARSE_GRAIN, bb->flags) &&
-        (!TEST(FRAG_SHARED, bb->flags) ||
+    if (TESTANY(FRAG_COARSE_GRAIN, bb->flags) &&
+        (!TESTANY(FRAG_SHARED, bb->flags) ||
          /* Ignorable syscalls on linux are mangled w/ intra-fragment jmps, which
           * decode_fragment() cannot handle -- and on win32 this overlaps w/
           * FRAG_MUST_END_TRACE and LINK_NI_SYSCALL
           */
-         TEST(FRAG_HAS_SYSCALL, bb->flags) || TEST(FRAG_MUST_END_TRACE, bb->flags) ||
-         TEST(FRAG_CANNOT_BE_TRACE, bb->flags) ||
-         TEST(FRAG_SELFMOD_SANDBOXED, bb->flags) ||
+         TESTANY(FRAG_HAS_SYSCALL, bb->flags) ||
+         TESTANY(FRAG_MUST_END_TRACE, bb->flags) ||
+         TESTANY(FRAG_CANNOT_BE_TRACE, bb->flags) ||
+         TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags) ||
          /* PR 214142: coarse units does not support storing translations */
-         TEST(FRAG_HAS_TRANSLATION_INFO, bb->flags) ||
+         TESTANY(FRAG_HAS_TRANSLATION_INFO, bb->flags) ||
     /* FRAG_HAS_DIRECT_CTI: we never elide (assert is below);
      * not-inlined call/jmp: we turn off FRAG_COARSE_GRAIN up above
      */
 #ifdef WINDOWS
-         TEST(LINK_CALLBACK_RETURN, bb->exit_type) ||
+         TESTANY(LINK_CALLBACK_RETURN, bb->exit_type) ||
 #endif
          TESTANY(LINK_NI_SYSCALL_ALL, bb->exit_type))) {
         /* Currently not supported in a coarse unit */
         STATS_INC(num_fine_in_coarse);
         DOSTATS({
-            if (!TEST(FRAG_SHARED, bb->flags))
+            if (!TESTANY(FRAG_SHARED, bb->flags))
                 STATS_INC(coarse_prevent_private);
-            else if (TEST(FRAG_HAS_SYSCALL, bb->flags))
+            else if (TESTANY(FRAG_HAS_SYSCALL, bb->flags))
                 STATS_INC(coarse_prevent_syscall);
-            else if (TEST(FRAG_MUST_END_TRACE, bb->flags))
+            else if (TESTANY(FRAG_MUST_END_TRACE, bb->flags))
                 STATS_INC(coarse_prevent_end_trace);
-            else if (TEST(FRAG_CANNOT_BE_TRACE, bb->flags))
+            else if (TESTANY(FRAG_CANNOT_BE_TRACE, bb->flags))
                 STATS_INC(coarse_prevent_no_trace);
-            else if (TEST(FRAG_SELFMOD_SANDBOXED, bb->flags))
+            else if (TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags))
                 STATS_INC(coarse_prevent_selfmod);
-            else if (TEST(FRAG_HAS_TRANSLATION_INFO, bb->flags))
+            else if (TESTANY(FRAG_HAS_TRANSLATION_INFO, bb->flags))
                 STATS_INC(coarse_prevent_translation);
-            else if (IF_WINDOWS_ELSE_0(TEST(LINK_CALLBACK_RETURN, bb->exit_type)))
+            else if (IF_WINDOWS_ELSE_0(TESTANY(LINK_CALLBACK_RETURN, bb->exit_type)))
                 STATS_INC(coarse_prevent_cbret);
             else if (TESTANY(LINK_NI_SYSCALL_ALL, bb->exit_type))
                 STATS_INC(coarse_prevent_syscall);
@@ -4278,10 +4279,11 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
         });
         bb->flags &= ~FRAG_COARSE_GRAIN;
     }
-    ASSERT(!TEST(FRAG_COARSE_GRAIN, bb->flags) || !TEST(FRAG_HAS_DIRECT_CTI, bb->flags));
+    ASSERT(!TESTANY(FRAG_COARSE_GRAIN, bb->flags) ||
+           !TESTANY(FRAG_HAS_DIRECT_CTI, bb->flags));
 
     /* now that we know whether shared, ensure we have the right ibl routine */
-    if (!TEST(FRAG_SHARED, bb->flags) && TEST(LINK_INDIRECT, bb->exit_type)) {
+    if (!TESTANY(FRAG_SHARED, bb->flags) && TESTANY(LINK_INDIRECT, bb->exit_type)) {
         ASSERT(bb->exit_target ==
                get_ibl_routine(dcontext, get_ibl_entry_type(bb->exit_type),
                                DEFAULT_IBL_BB(), bb->ibl_branch_type));
@@ -4348,17 +4350,17 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
     /* set flags */
 #ifdef DGC_DIAGNOSTICS
     /* no traces in dyngen code, that would mess up our exit tracking */
-    if (TEST(FRAG_DYNGEN, bb->flags))
+    if (TESTANY(FRAG_DYNGEN, bb->flags))
         bb->flags |= FRAG_CANNOT_BE_TRACE;
 #endif
     if (!INTERNAL_OPTION(unsafe_ignore_eflags_prefix)
             IF_X64(|| !INTERNAL_OPTION(unsafe_ignore_eflags_trace))) {
         bb->flags |= instr_eflags_to_fragment_eflags(bb->eflags);
-        if (TEST(FRAG_WRITES_EFLAGS_OF, bb->flags)) {
+        if (TESTANY(FRAG_WRITES_EFLAGS_OF, bb->flags)) {
             LOG(THREAD, LOG_INTERP, 4, "fragment writes OF prior to reading it!\n");
             STATS_INC(bbs_eflags_writes_of);
-        } else if (TEST(FRAG_WRITES_EFLAGS_6, bb->flags)) {
-            IF_X86(ASSERT(TEST(FRAG_WRITES_EFLAGS_OF, bb->flags)));
+        } else if (TESTANY(FRAG_WRITES_EFLAGS_6, bb->flags)) {
+            IF_X86(ASSERT(TESTANY(FRAG_WRITES_EFLAGS_OF, bb->flags)));
             LOG(THREAD, LOG_INTERP, 4,
                 "fragment writes all 6 flags prior to reading any\n");
             STATS_INC(bbs_eflags_writes_6);
@@ -4372,7 +4374,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                     STATS_INC(bbs_eflags_reads);
                 } else {
                     STATS_INC(bbs_eflags_writes_none);
-                    if (TEST(LINK_INDIRECT, bb->exit_type))
+                    if (TESTANY(LINK_INDIRECT, bb->exit_type))
                         STATS_INC(bbs_eflags_writes_none_ind);
                 }
             });
@@ -4380,7 +4382,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
     }
 
     /* can only have proactive translation info if flag was set from the beginning */
-    if (TEST(FRAG_HAS_TRANSLATION_INFO, bb->flags) &&
+    if (TESTANY(FRAG_HAS_TRANSLATION_INFO, bb->flags) &&
         (!bb->record_translation || !bb->full_decode))
         bb->flags &= ~FRAG_HAS_TRANSLATION_INFO;
 
@@ -4473,12 +4475,12 @@ static bool
 mangle_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
 {
 #ifdef ARCH_SUPPORTS_HW_CACHE_CONSISTENCY
-    if (TEST(FRAG_SELFMOD_SANDBOXED, bb->flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags)) {
         byte *selfmod_start, *selfmod_end;
         /* sandbox requires that bb have no direct cti followings!
          * check_thread_vm_area should have ensured this for us
          */
-        ASSERT(!TEST(FRAG_HAS_DIRECT_CTI, bb->flags));
+        ASSERT(!TESTANY(FRAG_HAS_DIRECT_CTI, bb->flags));
         LOG(THREAD, LOG_INTERP, 2,
             "fragment overlaps selfmod area, inserting sandboxing\n");
         /* only reason can't be trace is don't have mechanism set up
@@ -4604,7 +4606,7 @@ decode_trace(void *drcontext, void *tag)
     if (get_thread_private_dcontext() != dcontext)
         return NULL;
 
-    if (frag != NULL && TEST(FRAG_IS_TRACE, frag->flags)) {
+    if (frag != NULL && TESTANY(FRAG_IS_TRACE, frag->flags)) {
         instrlist_t *ilist;
         bool alloc_res;
         /* Support being called from bb/trace hook (couldbelinking) or
@@ -4706,7 +4708,7 @@ build_native_exec_bb(dcontext_t *dcontext, build_bb_t *bb)
     ASSERT(bb->start_pc != NULL);
     /* vmlist must start out empty (or N/A).  For clients it may have started early. */
     ASSERT(bb->vmlist == NULL || !bb->record_vmlist || bb->checked_start_vmarea);
-    if (TEST(FRAG_HAS_TRANSLATION_INFO, bb->flags))
+    if (TESTANY(FRAG_HAS_TRANSLATION_INFO, bb->flags))
         bb->flags &= ~FRAG_HAS_TRANSLATION_INFO;
     bb->native_exec = true;
 
@@ -4800,7 +4802,7 @@ build_native_exec_bb(dcontext_t *dcontext, build_bb_t *bb)
     instrlist_append(bb->ilist,
                      XINST_CREATE_jump(dcontext, opnd_create_pc(bb->start_pc)));
 
-    if (DYNAMO_OPTION(shared_bbs) && !TEST(FRAG_TEMP_PRIVATE, bb->flags))
+    if (DYNAMO_OPTION(shared_bbs) && !TESTANY(FRAG_TEMP_PRIVATE, bb->flags))
         bb->flags |= FRAG_SHARED;
 
     /* Can't be coarse-grain since has non-exit cti */
@@ -4824,7 +4826,7 @@ build_native_exec_bb(dcontext_t *dcontext, build_bb_t *bb)
      * happens while native before coming back out.  While the former does not
      * depend on the target at all, unfortunately we cannot verify the latter.
      */
-    if (TEST(FRAG_SELFMOD_SANDBOXED, bb->flags))
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, bb->flags))
         bb->flags &= ~FRAG_SELFMOD_SANDBOXED;
     DEBUG_DECLARE(ok =) mangle_bb_ilist(dcontext, bb);
     ASSERT(ok);
@@ -4875,7 +4877,7 @@ at_native_exec_gateway(dcontext_t *dcontext, app_pc start,
 
     if (DYNAMO_OPTION(native_exec) && !vmvector_empty(native_exec_areas)) {
         /* do we KNOW that we came from an indirect call? */
-        if (TEST(LINK_CALL /*includes IND_JMP_PLT*/, dcontext->last_exit->flags) &&
+        if (TESTANY(LINK_CALL /*includes IND_JMP_PLT*/, dcontext->last_exit->flags) &&
             /* only check direct calls if native_exec_dircalls is on */
             (DYNAMO_OPTION(native_exec_dircalls) ||
              LINKSTUB_INDIRECT(dcontext->last_exit->flags))) {
@@ -4972,7 +4974,7 @@ at_native_exec_gateway(dcontext_t *dcontext, app_pc start,
         /* Is this a return from a non-native module into a native module? */
         if (!native_exec_bb && DYNAMO_OPTION(native_exec_retakeover) &&
             LINKSTUB_INDIRECT(dcontext->last_exit->flags) &&
-            TEST(LINK_RETURN, dcontext->last_exit->flags)) {
+            TESTANY(LINK_RETURN, dcontext->last_exit->flags)) {
             if (is_native_pc(start)) {
                 /* XXX: check that this is the return address of a known native
                  * callsite where we took over on a module transition.
@@ -5023,7 +5025,7 @@ static inline void
 init_interp_build_bb(dcontext_t *dcontext, build_bb_t *bb, app_pc start,
                      uint initial_flags, bool for_trace, instrlist_t **unmangled_ilist)
 {
-    ASSERT_OWN_MUTEX(USE_BB_BUILDING_LOCK() && !TEST(FRAG_TEMP_PRIVATE, initial_flags),
+    ASSERT_OWN_MUTEX(USE_BB_BUILDING_LOCK() && !TESTANY(FRAG_TEMP_PRIVATE, initial_flags),
                      &bb_building_lock);
     /* We need to set up for abort prior to native exec and other checks
      * that can crash */
@@ -5038,7 +5040,7 @@ init_interp_build_bb(dcontext_t *dcontext, build_bb_t *bb, app_pc start,
         initial_flags |
             (INTERNAL_OPTION(store_translations) ? FRAG_HAS_TRANSLATION_INFO : 0),
         NULL /*no overlap*/);
-    if (!TEST(FRAG_TEMP_PRIVATE, initial_flags))
+    if (!TESTANY(FRAG_TEMP_PRIVATE, initial_flags))
         bb->has_bb_building_lock = true;
     /* We avoid races where there is no hook when we start building a
      * bb (and hence we don't record translation or do full decode) yet
@@ -5163,7 +5165,7 @@ build_basic_block_fragment(dcontext_t *dcontext, app_pc start, uint initial_flag
 
     if (DYNAMO_OPTION(opt_jit) && visible && is_jit_managed_area(bb.start_pc)) {
         ASSERT(bb.overlap_info == NULL || bb.overlap_info->contiguous);
-        jitopt_add_dgc_bb(bb.start_pc, bb.end_pc, TEST(FRAG_IS_TRACE_HEAD, bb.flags));
+        jitopt_add_dgc_bb(bb.start_pc, bb.end_pc, TESTANY(FRAG_IS_TRACE_HEAD, bb.flags));
     }
 
     /* emit fragment into fcache */
@@ -5186,7 +5188,7 @@ build_basic_block_fragment(dcontext_t *dcontext, app_pc start, uint initial_flag
     DOLOG(2, LOG_INTERP,
           { disassemble_fragment(dcontext, f, d_r_stats->loglevel <= 3); });
     DOLOG(4, LOG_INTERP, {
-        if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags)) {
+        if (TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)) {
             LOG(THREAD, LOG_INTERP, 4, "\nXXXX sandboxed fragment!  original code:\n");
             disassemble_app_bb(dcontext, f->tag, THREAD);
             LOG(THREAD, LOG_INTERP, 4, "code cache code:\n");
@@ -5354,7 +5356,7 @@ recreate_fragment_ilist(dcontext_t *dcontext, byte *pc,
          * the memory might have changed.  caller should use the stored
          * translation info instead.
          */
-        if (f == NULL || TEST(FRAG_WAS_DELETED, f->flags)) {
+        if (f == NULL || TESTANY(FRAG_WAS_DELETED, f->flags)) {
             ASSERT(f != NULL || !alloc); /* alloc shouldn't be set if no f */
             ilist = NULL;
             goto recreate_fragment_done;
@@ -5501,7 +5503,7 @@ recreate_fragment_ilist(dcontext_t *dcontext, byte *pc,
                     f->id);
 #    ifdef SIDELINE
                 if (dynamo_options.sideline) {
-                    if (!TEST(FRAG_DO_NOT_SIDELINE, f->flags))
+                    if (!TESTANY(FRAG_DO_NOT_SIDELINE, f->flags))
                         optimize_trace(dcontext, f->tag, ilist);
                     /* else, never optimized */
                 } else
@@ -6173,9 +6175,9 @@ mangle_indirect_branch_in_trace(dcontext_t *dcontext, instrlist_t *trace,
 #    ifdef X64
     if (X64_CACHE_MODE_DC(dcontext)) {
         LOG(THREAD, LOG_INTERP, 4, "next_flags for post-ibl-cmp: 0x%x\n", next_flags);
-        if (!TEST(FRAG_WRITES_EFLAGS_6, next_flags) &&
+        if (!TESTANY(FRAG_WRITES_EFLAGS_6, next_flags) &&
             !INTERNAL_OPTION(unsafe_ignore_eflags_trace)) {
-            if (!TEST(FRAG_WRITES_EFLAGS_OF, next_flags) && /* OF was saved */
+            if (!TESTANY(FRAG_WRITES_EFLAGS_OF, next_flags) && /* OF was saved */
                 !INTERNAL_OPTION(unsafe_ignore_overflow)) {
                 /* restore OF using add that overflows if OF was on when we did seto */
                 added_size +=
@@ -6791,7 +6793,7 @@ extend_trace(dcontext_t *dcontext, fragment_t *f, linkstub_t *prev_l)
     /* if you want to re-add the ability to add traces, revive
      * CUSTOM_TRACES_ADD_TRACE from the attic
      */
-    ASSERT(!TEST(FRAG_IS_TRACE, f->flags)); /* expecting block fragments */
+    ASSERT(!TESTANY(FRAG_IS_TRACE, f->flags)); /* expecting block fragments */
 
     if (prev_l != NULL) {
         ASSERT(!LINKSTUB_FAKE(prev_l) ||
@@ -7069,14 +7071,14 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
              * survives to here if the instr is not clobbered,
              * and does not come from md->final_exit_flags
              */
-            if (TEST(INSTR_SHARED_SYSCALL, instrlist_last(ilist)->flags)) {
+            if (TESTANY(INSTR_SHARED_SYSCALL, instrlist_last(ilist)->flags)) {
                 instr_set_target(jmp, opnd_create_pc(shared_syscall_routine(dcontext)));
                 instr_set_our_mangling(jmp, true); /* undone by target set */
             }
             /* XXX: test for linux too, but allowing ignorable syscalls */
             if (!TESTANY(LINK_NI_SYSCALL_ALL IF_WINDOWS(| LINK_CALLBACK_RETURN),
                          md->final_exit_flags) &&
-                !TEST(INSTR_SHARED_SYSCALL, instrlist_last(ilist)->flags)) {
+                !TESTANY(INSTR_SHARED_SYSCALL, instrlist_last(ilist)->flags)) {
                 CLIENT_ASSERT(false,
                               "client modified or added a syscall or int: unsupported");
                 return false;
@@ -7089,7 +7091,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
         CLIENT_ASSERT((!found_syscall && !found_int)
                       /* On linux we allow ignorable syscalls in middle.
                        * XXX PR 307284: see notes above. */
-                      IF_UNIX(|| !TEST(LINK_NI_SYSCALL, md->final_exit_flags)),
+                      IF_UNIX(|| !TESTANY(LINK_NI_SYSCALL, md->final_exit_flags)),
                       "client changed exit target where unsupported\n"
                       "check if trace ends in a syscall or int");
     }
@@ -7107,7 +7109,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
     /* We do not need to remove nops since we never emitted */
     d_r_mangle(dcontext, ilist, &md->trace_flags, true /*mangle calls*/,
                /* we're post-client so we don't need translations unless storing */
-               TEST(FRAG_HAS_TRANSLATION_INFO, md->trace_flags));
+               TESTANY(FRAG_HAS_TRANSLATION_INFO, md->trace_flags));
     DOLOG(4, LOG_INTERP, {
         LOG(THREAD, LOG_INTERP, 4, "trace ilist after mangling:\n");
         instrlist_disassemble(dcontext, md->trace_tag, ilist, THREAD);
@@ -7133,7 +7135,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
                     next_flags);
                 fixup_last_cti(dcontext, ilist, md->blk_info[blk + 1].info.tag,
                                next_flags, md->trace_flags, NULL, NULL,
-                               TEST(FRAG_HAS_TRANSLATION_INFO, md->trace_flags),
+                               TESTANY(FRAG_HAS_TRANSLATION_INFO, md->trace_flags),
                                &num_exits_deleted,
                                /* Only walk ilist between these instrs */
                                start_instr, inst);
@@ -7266,13 +7268,13 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
     uint num_dir = 0, num_indir = 0;
     bool tls_to_dc;
     bool shared_to_private =
-        TEST(FRAG_SHARED, f->flags) && !TEST(FRAG_SHARED, target_flags);
+        TESTANY(FRAG_SHARED, f->flags) && !TESTANY(FRAG_SHARED, target_flags);
 #ifdef WINDOWS
     /* The fragment could contain an ignorable sysenter instruction if
      * the following conditions are satisfied. */
     bool possible_ignorable_sysenter = DYNAMO_OPTION(ignore_syscalls) &&
         (get_syscall_method() == SYSCALL_METHOD_SYSENTER) &&
-        TEST(FRAG_HAS_SYSCALL, f->flags);
+        TESTANY(FRAG_HAS_SYSCALL, f->flags);
 #endif
     instrlist_t intra_ctis;
     coarse_info_t *info = NULL;
@@ -7308,12 +7310,12 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
      * Handle coarse-grain fake fragment_t by discovering exits as we go, with
      * l being NULL the whole time.
      */
-    if (TEST(FRAG_FAKE, f->flags)) {
-        ASSERT(TEST(FRAG_COARSE_GRAIN, f->flags));
+    if (TESTANY(FRAG_FAKE, f->flags)) {
+        ASSERT(TESTANY(FRAG_COARSE_GRAIN, f->flags));
         info = get_fragment_coarse_info(f);
         ASSERT(info != NULL);
         coarse_elided_ubrs =
-            (info->persisted && TEST(PERSCACHE_ELIDED_UBR, info->flags)) ||
+            (info->persisted && TESTANY(PERSCACHE_ELIDED_UBR, info->flags)) ||
             (!info->persisted && DYNAMO_OPTION(coarse_freeze_elide_ubr));
         /* Assumption: coarse-grain fragments have no ctis w/ off-fragment targets
          * that are not exit ctis
@@ -7326,7 +7328,7 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
         cti = NULL;
         if (l != NULL) {
             stop_pc = EXIT_CTI_PC(f, l);
-        } else if (TEST(FRAG_FAKE, f->flags)) {
+        } else if (TESTANY(FRAG_FAKE, f->flags)) {
             /* we don't know the size of f */
             stop_pc = (cache_pc)UNIVERSAL_REGION_END;
         } else {
@@ -7346,14 +7348,14 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                 stop_pc = raw_start_pc;
             }
         }
-        IF_X64(ASSERT(TEST(FRAG_FAKE, f->flags) /* no copy made */ ||
+        IF_X64(ASSERT(TESTANY(FRAG_FAKE, f->flags) /* no copy made */ ||
                       CHECK_TRUNCATE_TYPE_uint((stop_pc - raw_start_pc))));
         num_bytes = (uint)(stop_pc - raw_start_pc);
         LOG(THREAD, LOG_MONITOR, DF_LOGLEVEL(dcontext),
             "decoding fragment from " PFX " to " PFX "\n", raw_start_pc, stop_pc);
         if (num_bytes > 0) {
             if (buf != NULL) {
-                if (TEST(FRAG_FAKE, f->flags)) {
+                if (TESTANY(FRAG_FAKE, f->flags)) {
                     /* we don't know the size of f, so we copy later, though
                      * we do point instrs into buf before we copy!
                      */
@@ -7531,7 +7533,7 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                         d_r_loginst(dcontext, 4, instr,
                                     "decode_fragment: found non-exit cti");
                     });
-                    if (TEST(FRAG_FAKE, f->flags)) {
+                    if (TESTANY(FRAG_FAKE, f->flags)) {
                         /* Case 8711: we don't know the size so we can't even
                          * distinguish off-fragment from intra-fragment targets.
                          * Thus we have to assume that any cti is an exit cti, and
@@ -7720,7 +7722,7 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
             });
             ASSERT(pc == stop_pc);
             cache_pc next_pc = pc;
-            if (l != NULL && TEST(LINK_PADDED, l->flags) && instr_is_nop(instr)) {
+            if (l != NULL && TESTANY(LINK_PADDED, l->flags) && instr_is_nop(instr)) {
                 /* Throw away our padding nop. */
                 LOG(THREAD, LOG_MONITOR, DF_LOGLEVEL(dcontext) - 1,
                     "%s: removing padding nop @" PFX "\n", __FUNCTION__, prev_pc);
@@ -7738,7 +7740,7 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                     instrlist_append(ilist, instr);
                     cur_buf += offset;
                 }
-                if (buf != NULL && TEST(FRAG_FAKE, f->flags)) {
+                if (buf != NULL && TESTANY(FRAG_FAKE, f->flags)) {
                     /* Now that we know the size we can copy into buf.
                      * We have been incrementing cur_buf all along, though
                      * we didn't have contents there.
@@ -7765,7 +7767,7 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
             pc = next_pc;
         }
 
-        if (l == NULL && !TEST(FRAG_FAKE, f->flags))
+        if (l == NULL && !TESTANY(FRAG_FAKE, f->flags))
             break;
 
         /* decode the exit branch */
@@ -7788,7 +7790,7 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
             if (instr_is_cti_short_rewrite(instr, stop_pc))
                 remangle_short_rewrite(dcontext, instr, stop_pc, 0 /*same target*/);
             instr_tgt = opnd_get_pc(instr_get_target(instr));
-            ASSERT(TEST(FRAG_COARSE_GRAIN, f->flags));
+            ASSERT(TESTANY(FRAG_COARSE_GRAIN, f->flags));
             if (cti == NULL && coarse_is_entrance_stub(instr_tgt)) {
                 target_tag = entrance_stub_target_tag(instr_tgt, info);
                 l_flags = LINK_DIRECT;
@@ -7861,15 +7863,15 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                 DODEBUG({
                     LOG(THREAD, LOG_MONITOR, DF_LOGLEVEL(dcontext) - 1,
                         "%s: %s ibl_routine " PFX " with %s_target=" PFX "\n",
-                        TEST(FRAG_IS_TRACE, target_flags) ? "extend_trace"
-                                                          : "decode_fragment",
+                        TESTANY(FRAG_IS_TRACE, target_flags) ? "extend_trace"
+                                                             : "decode_fragment",
                         new_target == old_target ? "maintaining" : "replacing",
                         old_target, new_target == old_target ? "old" : "new", new_target);
                     STATS_INC(num_traces_ibl_extended);
                 });
 #ifdef WINDOWS
                 DOSTATS({
-                    if (TEST(FRAG_IS_TRACE, target_flags) &&
+                    if (TESTANY(FRAG_IS_TRACE, target_flags) &&
                         old_target == shared_syscall_routine(dcontext))
                         STATS_INC(num_traces_shared_syscall_extended);
                 });
@@ -7887,7 +7889,7 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
         }
         instrlist_append(ilist, instr);
 
-        if (TEST(FRAG_FAKE, f->flags)) {
+        if (TESTANY(FRAG_FAKE, f->flags)) {
             /* Assumption: coarse-grain bbs have 1 ind exit or 2 direct,
              * and no code beyond the last exit!  Of course frozen bbs
              * can have their final jmp elided, which we handle above.
@@ -8047,7 +8049,7 @@ copy_fragment(dcontext_t *dcontext, fragment_t *f, bool replace)
 
     /* emit as invisible fragment */
     /* We don't support shared fragments, where vm_area_add_to_list can fail */
-    ASSERT_NOT_IMPLEMENTED(!TEST(FRAG_SHARED, f->flags));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(FRAG_SHARED, f->flags));
     DEBUG_DECLARE(ok =)
     vm_area_add_to_list(dcontext, f->tag, &vmlist, f->flags, f, false /*no locks*/);
     ASSERT(ok); /* should never fail for private fragments */
@@ -8108,7 +8110,7 @@ shift_ctis_in_fragment(dcontext_t *dcontext, fragment_t *f, ssize_t shift,
         (get_syscall_method() == SYSCALL_METHOD_SYSENTER) &&
         /* XXX Traces don't have FRAG_HAS_SYSCALL set so we can't filter on
          * that flag for all fragments. */
-        (TEST(FRAG_HAS_SYSCALL, f->flags) || TEST(FRAG_IS_TRACE, f->flags));
+        (TESTANY(FRAG_HAS_SYSCALL, f->flags) || TESTANY(FRAG_IS_TRACE, f->flags));
 #endif
     instr_t instr;
     instr_init(dcontext, &instr);
@@ -8262,7 +8264,7 @@ d_r_emulate_instr(dcontext_t *dcontext, instr_t *inst, priv_mcontext_t *mc)
         DOCHECK(1, {
             uint prot = 0;
             ASSERT(get_memory_info((app_pc)target, NULL, NULL, &prot));
-            ASSERT(TEST(MEMPROT_WRITE, prot));
+            ASSERT(TESTANY(MEMPROT_WRITE, prot));
         });
         LOG(THREAD, LOG_INTERP, 2, "\temulating store by writing " PFX " to " PFX "\n",
             val, target);
@@ -8286,7 +8288,7 @@ d_r_emulate_instr(dcontext_t *dcontext, instr_t *inst, priv_mcontext_t *mc)
         DOCHECK(1, {
             uint prot = 0;
             ASSERT(get_memory_info((app_pc)target, NULL, NULL, &prot));
-            ASSERT(TEST(MEMPROT_WRITE, prot));
+            ASSERT(TESTANY(MEMPROT_WRITE, prot));
         });
         LOG(THREAD, LOG_INTERP, 2, "\temulating %s to " PFX "\n",
             opc == IF_X86_ELSE(OP_inc, OP_add) ? "inc" : "dec", target);

--- a/core/arch/loadtoconst.c
+++ b/core/arch/loadtoconst.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1303,9 +1303,10 @@ save_eflags_list(dcontext_t *dcontext, fragment_t *frag)
         instrlist_append(ilist, INSTR_CREATE_lahf(dcontext));
     }
 
-    if (!TEST(FRAG_WRITES_EFLAGS_OF, frag->flags) || dynamo_options.safe_loads_to_const) {
+    if (!TESTANY(FRAG_WRITES_EFLAGS_OF, frag->flags) ||
+        dynamo_options.safe_loads_to_const) {
         /* must have saved eax */
-        ASSERT(!TEST(FRAG_WRITES_EFLAGS_6, frag->flags) ||
+        ASSERT(!TESTANY(FRAG_WRITES_EFLAGS_6, frag->flags) ||
                dynamo_options.safe_loads_to_const);
         instrlist_append(ilist,
                          INSTR_CREATE_setcc(dcontext, OP_seto, opnd_create_reg(REG_AL)));

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -121,7 +121,7 @@ insert_get_mcontext_base(dcontext_t *dcontext, instrlist_t *ilist, instr_t *wher
     PRE(ilist, where, instr_create_restore_from_tls(dcontext, reg, TLS_DCONTEXT_SLOT));
 
     /* An extra level of indirection with SELFPROT_DCONTEXT */
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         ASSERT_NOT_TESTED();
         PRE(ilist, where,
             XINST_CREATE_load(dcontext, opnd_create_reg(reg),
@@ -234,7 +234,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
         /* DSTACK_OFFSET isn't within the upcontext so if it's separate this won't
          * work right.  XXX - the dcontext accessing routines are a mess of shared
          * vs. no shared support, separate context vs. no separate context support etc. */
-        ASSERT_NOT_IMPLEMENTED(!TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
+        ASSERT_NOT_IMPLEMENTED(!TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
 
 #ifdef WINDOWS
         /* i#249: swap PEB pointers while we have dcxt in reg.  We risk "silent
@@ -751,10 +751,10 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     instr_t *in = (instr == NULL) ? instrlist_last(ilist) : instr_get_prev(instr);
     bool direct;
     uint stack_for_params = insert_parameter_preparation(
-        dcontext, ilist, instr, TEST(META_CALL_CLEAN, flags), num_args, args);
+        dcontext, ilist, instr, TESTANY(META_CALL_CLEAN, flags), num_args, args);
     ASSERT(ALIGNED(stack_for_params, get_ABI_stack_alignment()));
 
-    if (TEST(META_CALL_CLEAN, flags) && should_track_where_am_i()) {
+    if (TESTANY(META_CALL_CLEAN, flags) && should_track_where_am_i()) {
         if (SCRATCH_ALWAYS_TLS()) {
 #if defined(AARCHXX) || defined(RISCV64)
             int link_reg = IF_RISCV64_ELSE(DR_REG_RA, DR_REG_LR);
@@ -803,7 +803,7 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
      * We document this to clients using dr_insert_call_ex() or DR_CLEANCALL_INDIRECT.
      */
     direct = insert_reachable_cti(dcontext, ilist, instr, encode_pc, (byte *)callee,
-                                  false /*call*/, TEST(META_CALL_RETURNS, flags),
+                                  false /*call*/, TESTANY(META_CALL_RETURNS, flags),
                                   false /*!precise*/, CALL_SCRATCH_REG, NULL);
     if (stack_for_params > 0) {
         /* XXX PR 245936: let user decide whether to clean up?
@@ -816,10 +816,10 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                              OPND_CREATE_INT32(stack_for_params)));
     }
 
-    if (TEST(META_CALL_CLEAN, flags) && should_track_where_am_i()) {
+    if (TESTANY(META_CALL_CLEAN, flags) && should_track_where_am_i()) {
         uint whereami;
 
-        if (TEST(META_CALL_RETURNS_TO_NATIVE, flags))
+        if (TESTANY(META_CALL_RETURNS_TO_NATIVE, flags))
             whereami = (uint)DR_WHERE_APP;
         else
             whereami = (uint)DR_WHERE_FCACHE;
@@ -1451,10 +1451,10 @@ mangle_rseq_insert_native_sequence(dcontext_t *dcontext, instrlist_t *ilist,
              * the target part of the sequence, leading to app errors.
              */
             uint exit_type = instr_branch_type(copy);
-            byte *pc = get_ibl_routine(dcontext, get_ibl_entry_type(exit_type),
-                                       TEST(FRAG_IS_TRACE, *flags) ? DEFAULT_IBL_TRACE()
-                                                                   : DEFAULT_IBL_BB(),
-                                       get_ibl_branch_type(copy));
+            byte *pc = get_ibl_routine(
+                dcontext, get_ibl_entry_type(exit_type),
+                TESTANY(FRAG_IS_TRACE, *flags) ? DEFAULT_IBL_TRACE() : DEFAULT_IBL_BB(),
+                get_ibl_branch_type(copy));
             instr_t *exit = XINST_CREATE_jump(dcontext, opnd_create_pc(pc));
             instr_exit_branch_set_type(exit, exit_type);
             instrlist_preinsert(ilist, insert_at, exit);
@@ -1700,7 +1700,7 @@ mangle_rseq(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     if (pc + len >= end) {
         ilist->flags |= INSTR_RSEQ_ENDPOINT;
         /* We should already have this flag set by the bb builder. */
-        ASSERT(TEST(FRAG_HAS_RSEQ_ENDPOINT, *flags));
+        ASSERT(TESTANY(FRAG_HAS_RSEQ_ENDPOINT, *flags));
         if (pc + len != end) {
             REPORT_FATAL_ERROR_AND_EXIT(
                 RSEQ_BEHAVIOR_UNSUPPORTED, 3, get_application_name(),
@@ -1844,7 +1844,7 @@ d_r_mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags DR_PARAM_INOUT,
     bool ignorable_sysenter = DYNAMO_OPTION(ignore_syscalls) &&
         DYNAMO_OPTION(ignore_syscalls_follow_sysenter) &&
         (get_syscall_method() == SYSCALL_METHOD_SYSENTER) &&
-        TEST(FRAG_HAS_SYSCALL, *flags);
+        TESTANY(FRAG_HAS_SYSCALL, *flags);
 #endif
 
     /* Walk through instr list:
@@ -2103,7 +2103,7 @@ d_r_mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags DR_PARAM_INOUT,
 #endif
 
         if (!instr_is_cti(instr) || instr_is_meta(instr)) {
-            if (TEST(INSTR_CLOBBER_RETADDR, instr->flags) && instr_is_label(instr)) {
+            if (TESTANY(INSTR_CLOBBER_RETADDR, instr->flags) && instr_is_label(instr)) {
                 /* Move the value to the offset field (which the client cannot
                  * possibly use at this point) so we don't have to search for
                  * this label when we hit the ret instr.
@@ -2335,12 +2335,12 @@ void
 mangle_finalize(dcontext_t *dcontext, instrlist_t *ilist, fragment_t *f)
 {
 #ifdef X86
-    if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)) {
         finalize_selfmod_sandbox(dcontext, f);
     }
 #endif
 #ifdef LINUX
-    if (TEST(INSTR_RSEQ_ENDPOINT, ilist->flags))
+    if (TESTANY(INSTR_RSEQ_ENDPOINT, ilist->flags))
         mangle_rseq_finalize(dcontext, ilist, f);
 #endif
 }

--- a/core/arch/retcheck.c
+++ b/core/arch/retcheck.c
@@ -1843,7 +1843,7 @@ ret_after_call_check(dcontext_t *dcontext, app_pc target_addr, app_pc src_addr)
         /* special handling of unreadable memory targets - most likely
          * corrupted app, but could also be an unsuccessful attack
          */
-        if (TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ret_unreadable))) {
+        if (TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ret_unreadable))) {
             if (!is_readable_without_exception(target_addr, 4)) {
                 SYSLOG_INTERNAL_WARNING_ONCE("return target " PFX " unreadable",
                                              target_addr);

--- a/core/arch/riscv64/emit_utils.c
+++ b/core/arch/riscv64/emit_utils.c
@@ -132,7 +132,7 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
     }
 
     /* TODO i#3544: coarse-grain NYI on RISCV64 */
-    ASSERT_NOT_IMPLEMENTED(!TEST(FRAG_COARSE_GRAIN, f->flags));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(FRAG_COARSE_GRAIN, f->flags));
 
     if (LINKSTUB_DIRECT(l_flags)) {
         APP(&ilist,
@@ -543,7 +543,7 @@ unlink_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     ASSERT(LINKSTUB_INDIRECT(l->flags));
     /* Target is always the same, so if it's already unlinked, this is a nop. */
-    if (!TEST(LINK_LINKED, l->flags))
+    if (!TESTANY(LINK_LINKED, l->flags))
         return;
     ibl_code = get_ibl_routine_code(dcontext, extract_branchtype(l->flags), f->flags);
     exit_target = ibl_code->unlinked_ibl_entry;
@@ -1268,7 +1268,7 @@ void
 append_fcache_enter_prologue(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
 {
     ASSERT_NOT_IMPLEMENTED(!absolute &&
-                           !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
+                           !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
 
     instr_t *no_signals = INSTR_CREATE_label(dcontext);
 

--- a/core/arch/sideline.c
+++ b/core/arch/sideline.c
@@ -680,7 +680,7 @@ sideline_optimize(fragment_t *f,
     /* Emit fragment but don't make visible yet */
     /* mark both old and new as DO_NOT_SIDELINE */
     /* XXX: if f is shared we must hold change_linking_lock here */
-    ASSERT(!TEST(FRAG_SHARED, f->flags));
+    ASSERT(!TESTANY(FRAG_SHARED, f->flags));
     f->flags |= FRAG_DO_NOT_SIDELINE;
     flags = f->flags;
     DEBUG_DECLARE(ok =)

--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -82,7 +82,7 @@ also see emit_inline_ibl_stub() below
  * a different memory space with self-protection
  */
 #define UNPROT_OFFS(dcontext, offs)                                            \
-    (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)                      \
+    (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)                   \
          ? (((ptr_uint_t)((dcontext)->upcontext.separate_upcontext)) + (offs)) \
          : (((ptr_uint_t)(dcontext)) + (offs)))
 
@@ -322,13 +322,13 @@ insert_jmp_to_ibl(byte *pc, fragment_t *f, linkstub_t *l, cache_pc exit_target,
          * this exit since it's never referenced.
          */
         LOG(THREAD, LOG_LINKS, 4, "\tF%d using %s shared syscalls link stub\n", f->id,
-            TEST(FRAG_IS_TRACE, f->flags) ? "trace" : "bb");
-        l = (linkstub_t *)(TEST(FRAG_IS_TRACE, f->flags)
+            TESTANY(FRAG_IS_TRACE, f->flags) ? "trace" : "bb");
+        l = (linkstub_t *)(TESTANY(FRAG_IS_TRACE, f->flags)
                                ? get_shared_syscalls_trace_linkstub()
                                : get_shared_syscalls_bb_linkstub());
     }
 #endif
-    if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
         /* XXX: once we separate these we should switch to 15-byte w/
          * store-to-mem instead of in a spilled xbx, to use same
          * slots as coarse direct stubs
@@ -374,7 +374,7 @@ nop_pad_ilist(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist, bool emit
 
     for (inst = instrlist_first(ilist); inst != NULL; inst = instr_get_next(inst)) {
         /* don't support non exit cti patchable instructions yet */
-        ASSERT_NOT_IMPLEMENTED(!TEST(INSTR_HOT_PATCHABLE, inst->flags));
+        ASSERT_NOT_IMPLEMENTED(!TESTANY(INSTR_HOT_PATCHABLE, inst->flags));
         if (instr_is_exit_cti(inst)) {
             /* see if we need to be able to patch this instruction */
             if (is_exit_cti_patchable(dcontext, inst, f->flags)) {
@@ -544,7 +544,7 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
 
     /* select the correct exit target */
     if (LINKSTUB_DIRECT(l_flags)) {
-        if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
             /* need to target the fcache return prefix */
             exit_target = fcache_return_coarse_prefix(stub_pc, NULL);
             ASSERT(exit_target != NULL);
@@ -554,7 +554,7 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
         ASSERT(LINKSTUB_INDIRECT(l_flags));
         /* caller shouldn't call us if no stub */
         ASSERT(EXIT_HAS_STUB(l_flags, f->flags));
-        if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
             /* need to target the ibl prefix */
             exit_target =
                 get_coarse_ibl_prefix(dcontext, stub_pc, extract_branchtype(l_flags));
@@ -583,7 +583,7 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
 
     if (indirect) {
         pc = insert_jmp_to_ibl(pc, f, l, exit_target, dcontext);
-    } else if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    } else if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
         /* This is an entrance stub.  It may be executed even when linked,
          * so we store target info to memory instead of a register.
          * The exact bytes used here are assumed by entrance_stub_target_tag().
@@ -766,7 +766,7 @@ link_indirect_exit_arch(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
         pc = EXIT_CTI_PC(f, l);
         /* for x64, or -unsafe_ignore_eflags_trace, a trace may have a jne to the stub */
         if (*pc == JNE_OPCODE_1) {
-            ASSERT(TEST(FRAG_IS_TRACE, f->flags));
+            ASSERT(TESTANY(FRAG_IS_TRACE, f->flags));
 #ifndef X64
             ASSERT(INTERNAL_OPTION(unsafe_ignore_eflags_trace));
 #endif
@@ -798,7 +798,7 @@ indirect_linkstub_stub_pc(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
         return NULL;
     /* for x64, or -unsafe_ignore_eflags_trace, a trace may have a jne to the stub */
     if (*cti == JNE_OPCODE_1) {
-        ASSERT(TEST(FRAG_IS_TRACE, f->flags));
+        ASSERT(TESTANY(FRAG_IS_TRACE, f->flags));
 #ifndef X64
         ASSERT(INTERNAL_OPTION(unsafe_ignore_eflags_trace));
 #endif
@@ -808,13 +808,13 @@ indirect_linkstub_stub_pc(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
             stub = (cache_pc)PC_RELATIVE_TARGET(cti + 1 /*opcode byte*/);
         } else {
             /* case 6532/10987: frozen coarse has no jmp to stub */
-            ASSERT(TEST(FRAG_COARSE_GRAIN, f->flags));
+            ASSERT(TESTANY(FRAG_COARSE_GRAIN, f->flags));
             ASSERT(coarse_is_indirect_stub(cti));
             stub = cti;
         }
     }
     ASSERT(stub >= cti && (stub - cti) <= MAX_FRAGMENT_SIZE);
-    if (!TEST(LINK_LINKED, l->flags)) {
+    if (!TESTANY(LINK_LINKED, l->flags)) {
         /* the unlink target is not always the start of the stub */
         stub -= linkstub_unlink_entry_offset(dcontext, f, l);
         /* XXX: for -no_indirect_stubs we could point exit cti directly
@@ -857,11 +857,11 @@ unlink_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
      * state (we do have multi-stage modifications for inlined stubs)
      */
     byte *stub_pc = (byte *)EXIT_STUB_PC(dcontext, f, l);
-    ASSERT(!TEST(FRAG_COARSE_GRAIN, f->flags));
+    ASSERT(!TESTANY(FRAG_COARSE_GRAIN, f->flags));
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     ASSERT(LINKSTUB_INDIRECT(l->flags));
     /* target is always the same, so if it's already unlinked, this is a nop */
-    if (!TEST(LINK_LINKED, l->flags))
+    if (!TESTANY(LINK_LINKED, l->flags))
         return;
 
 #ifdef WINDOWS
@@ -893,7 +893,7 @@ unlink_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
             pc = EXIT_CTI_PC(f, l);
             /* for x64, or -unsafe_ignore_eflags_trace, a trace may have a jne */
             if (*pc == JNE_OPCODE_1) {
-                ASSERT(TEST(FRAG_IS_TRACE, f->flags));
+                ASSERT(TESTANY(FRAG_IS_TRACE, f->flags));
 #ifndef X64
                 ASSERT(INTERNAL_OPTION(unsafe_ignore_eflags_trace));
 #endif
@@ -1013,7 +1013,7 @@ coarse_is_entrance_stub(cache_pc stub)
 int
 fragment_ibt_prefix_size(uint flags)
 {
-    bool use_eflags_restore = TEST(FRAG_IS_TRACE, flags)
+    bool use_eflags_restore = TESTANY(FRAG_IS_TRACE, flags)
         ? !DYNAMO_OPTION(trace_single_restore_prefix)
         : !DYNAMO_OPTION(bb_single_restore_prefix);
     /* The common case is !INTERNAL_OPTION(unsafe_ignore_eflags*) so
@@ -1031,9 +1031,9 @@ fragment_ibt_prefix_size(uint flags)
     }
     if (!use_eflags_restore)
         return PREFIX_BASE(flags) - RESTORE_XAX_PREFIX(flags);
-    if (TEST(FRAG_WRITES_EFLAGS_6, flags)) /* no flag restoration needed */
+    if (TESTANY(FRAG_WRITES_EFLAGS_6, flags)) /* no flag restoration needed */
         return PREFIX_BASE(flags);
-    else if (TEST(FRAG_WRITES_EFLAGS_OF, flags)) /* no OF restoration needed */
+    else if (TESTANY(FRAG_WRITES_EFLAGS_OF, flags)) /* no OF restoration needed */
         return (PREFIX_BASE(flags) + PREFIX_SIZE_FIVE_EFLAGS);
     else { /* must restore all 6 flags */
         if (INTERNAL_OPTION(unsafe_ignore_overflow)) {
@@ -1094,7 +1094,7 @@ void
 insert_fragment_prefix(dcontext_t *dcontext, fragment_t *f)
 {
     byte *pc = (byte *)f->start_pc;
-    bool insert_eflags_xax_restore = TEST(FRAG_IS_TRACE, f->flags)
+    bool insert_eflags_xax_restore = TESTANY(FRAG_IS_TRACE, f->flags)
         ? !DYNAMO_OPTION(trace_single_restore_prefix)
         : !DYNAMO_OPTION(bb_single_restore_prefix);
     ASSERT(f->prefix_size == 0); /* shouldn't be any prefixes yet */
@@ -1104,8 +1104,8 @@ insert_fragment_prefix(dcontext_t *dcontext, fragment_t *f)
              !INTERNAL_OPTION(unsafe_ignore_eflags_ibl)) &&
             insert_eflags_xax_restore) {
             if (!INTERNAL_OPTION(unsafe_ignore_eflags_prefix) &&
-                !TEST(FRAG_WRITES_EFLAGS_6, f->flags)) {
-                if (!TEST(FRAG_WRITES_EFLAGS_OF, f->flags) &&
+                !TESTANY(FRAG_WRITES_EFLAGS_6, f->flags)) {
+                if (!TESTANY(FRAG_WRITES_EFLAGS_OF, f->flags) &&
                     !INTERNAL_OPTION(unsafe_ignore_overflow)) {
                     DEBUG_DECLARE(byte *restore_of_prefix_pc = pc;)
                     /* must restore OF
@@ -1183,7 +1183,7 @@ append_fcache_enter_prologue(dcontext_t *dcontext, instrlist_t *ilist, bool abso
                               opnd_create_reg(REG_DCXT)));
 #endif
         APP(ilist, XINST_CREATE_load(dcontext, opnd_create_reg(REG_DCXT), OPND_ARG1));
-        if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+        if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
             APP(ilist, RESTORE_FROM_DC(dcontext, REG_DCXT_PROT, PROT_OFFS));
     }
 #ifdef UNIX
@@ -1380,18 +1380,18 @@ append_restore_simd_reg(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
  *    RESTORE_FROM_UPCONTEXT xbx_OFFSET,%xbx
  *    RESTORE_FROM_UPCONTEXT xcx_OFFSET,%xcx
  *    RESTORE_FROM_UPCONTEXT xdx_OFFSET,%xdx
- *  if (absolute || !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *  if (absolute || !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *    RESTORE_FROM_UPCONTEXT xdx_OFFSET,%xdx
- *  if (absolute || !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *  if (absolute || !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *    RESTORE_FROM_UPCONTEXT xsi_OFFSET,%xsi
  *  endif
- *  if (absolute || TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *  if (absolute || TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *    RESTORE_FROM_UPCONTEXT xdi_OFFSET,%xdi
  *  endif
  *    RESTORE_FROM_UPCONTEXT xbp_OFFSET,%xbp
  *    RESTORE_FROM_UPCONTEXT xsp_OFFSET,%xsp
  *  if (!absolute)
- *    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *      RESTORE_FROM_UPCONTEXT xsi_OFFSET,%xsi
  *    else
  *      RESTORE_FROM_UPCONTEXT xdi_OFFSET,%xdi
@@ -1416,16 +1416,16 @@ append_restore_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
     APP(ilist, RESTORE_FROM_DC(dcontext, REG_XCX, XCX_OFFSET));
     APP(ilist, RESTORE_FROM_DC(dcontext, REG_XDX, XDX_OFFSET));
     /* must restore esi last */
-    if (absolute || !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+    if (absolute || !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
         APP(ilist, RESTORE_FROM_DC(dcontext, REG_XSI, XSI_OFFSET));
     /* must restore edi last */
-    if (absolute || TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+    if (absolute || TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
         APP(ilist, RESTORE_FROM_DC(dcontext, REG_XDI, XDI_OFFSET));
     APP(ilist, RESTORE_FROM_DC(dcontext, REG_XBP, XBP_OFFSET));
     APP(ilist, RESTORE_FROM_DC(dcontext, REG_XSP, XSP_OFFSET));
     /* must restore esi last */
     if (!absolute) {
-        if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+        if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
             APP(ilist, RESTORE_FROM_DC(dcontext, REG_XSI, XSI_OFFSET));
         else
             APP(ilist, RESTORE_FROM_DC(dcontext, REG_XDI, XDI_OFFSET));
@@ -1453,7 +1453,7 @@ append_restore_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
  *  endif
  *    SAVE_TO_UPCONTEXT %xcx,xcx_OFFSET
  *    SAVE_TO_UPCONTEXT %xdx,xdx_OFFSET
- *  if (absolute || !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+ *  if (absolute || !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
  *    SAVE_TO_UPCONTEXT %xsi,xsi_OFFSET
  *  endif
  *
@@ -1526,7 +1526,7 @@ append_save_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool ibl_end, bool abs
         APP(ilist, SAVE_TO_DC(dcontext, REG_XCX, XCX_OFFSET));
     }
     APP(ilist, SAVE_TO_DC(dcontext, REG_XDX, XDX_OFFSET));
-    if (absolute || !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+    if (absolute || !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
         APP(ilist, SAVE_TO_DC(dcontext, REG_XSI, XSI_OFFSET));
     if (absolute) /* else xdi saved above */
         APP(ilist, SAVE_TO_DC(dcontext, REG_XDI, XDI_OFFSET));
@@ -1764,7 +1764,7 @@ insert_save_eflags(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where, uin
     /* no support for absolute addresses on x64: we always use tls/reg */
     IF_X64(ASSERT_NOT_IMPLEMENTED(!absolute));
 
-    if (TEST(FRAG_WRITES_EFLAGS_6, flags)) /* no flag save needed */
+    if (TESTANY(FRAG_WRITES_EFLAGS_6, flags)) /* no flag save needed */
         return;
     /* save the flags */
     /*>>>    SAVE_TO_TLS/UPCONTEXT %xax,xax_tls_slot/xax_OFFSET  */
@@ -1792,7 +1792,7 @@ insert_save_eflags(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where, uin
         PRE(ilist, where, SAVE_TO_DC(dcontext, REG_XAX, XAX_OFFSET));
     }
     PRE(ilist, where, INSTR_CREATE_lahf(dcontext));
-    if (!TEST(FRAG_WRITES_EFLAGS_OF, flags) &&
+    if (!TESTANY(FRAG_WRITES_EFLAGS_OF, flags) &&
         !INTERNAL_OPTION(unsafe_ignore_overflow)) { /* OF needs saving */
         /* Move OF flags into the OF flag spill slot. */
         PRE(ilist, where, INSTR_CREATE_setcc(dcontext, OP_seto, opnd_create_reg(REG_AL)));
@@ -1812,9 +1812,9 @@ insert_restore_eflags(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
     /* no support for absolute addresses on x64: we always use tls/reg */
     IF_X64(ASSERT_NOT_IMPLEMENTED(!absolute));
 
-    if (TEST(FRAG_WRITES_EFLAGS_6, flags)) /* no flag save was done */
+    if (TESTANY(FRAG_WRITES_EFLAGS_6, flags)) /* no flag save was done */
         return;
-    if (!TEST(FRAG_WRITES_EFLAGS_OF, flags) && /* OF was saved */
+    if (!TESTANY(FRAG_WRITES_EFLAGS_OF, flags) && /* OF was saved */
         !INTERNAL_OPTION(unsafe_ignore_overflow)) {
         /* restore OF using add that overflows and sets OF
          * if OF was on when we did seto
@@ -2859,7 +2859,7 @@ emit_indirect_branch_lookup(dcontext_t *dcontext, generated_code_t *code, byte *
         ASSERT(linkstub != NULL);
     }
 
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         /* in order to write next_tag we must unprotect -- and we don't
          * have safe stack yet!  so we duplicate fcache_return code here,
          * but we keep xcx w/ next tag around until we can store it as next_tag.

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -1212,9 +1212,9 @@ insert_push_cs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
  * targets, we should have the private ibl have special code to test the
  * flags and copy xcx to the tls slot if necessary.
  */
-#define SAVE_TO_DC_OR_TLS(dc, flags, reg, tls_offs, dc_offs)          \
-    ((DYNAMO_OPTION(private_ib_in_tls) || TEST(FRAG_SHARED, (flags))) \
-         ? instr_create_save_to_tls(dc, reg, tls_offs)                \
+#define SAVE_TO_DC_OR_TLS(dc, flags, reg, tls_offs, dc_offs)             \
+    ((DYNAMO_OPTION(private_ib_in_tls) || TESTANY(FRAG_SHARED, (flags))) \
+         ? instr_create_save_to_tls(dc, reg, tls_offs)                   \
          : instr_create_save_to_dcontext((dc), (reg), (dc_offs)))
 
 #define SAVE_TO_DC_OR_TLS_OR_REG(dc, flags, reg, tls_offs, dc_offs, dest_reg)       \
@@ -1223,9 +1223,9 @@ insert_push_cs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
          ? INSTR_CREATE_mov_ld(dc, opnd_create_reg(dest_reg), opnd_create_reg(reg)) \
          : SAVE_TO_DC_OR_TLS(dc, flags, reg, tls_offs, dc_offs))
 
-#define RESTORE_FROM_DC_OR_TLS(dc, flags, reg, tls_offs, dc_offs)     \
-    ((DYNAMO_OPTION(private_ib_in_tls) || TEST(FRAG_SHARED, (flags))) \
-         ? instr_create_restore_from_tls(dc, reg, tls_offs)           \
+#define RESTORE_FROM_DC_OR_TLS(dc, flags, reg, tls_offs, dc_offs)        \
+    ((DYNAMO_OPTION(private_ib_in_tls) || TESTANY(FRAG_SHARED, (flags))) \
+         ? instr_create_restore_from_tls(dc, reg, tls_offs)              \
          : instr_create_restore_from_dcontext((dc), (reg), (dc_offs)))
 
 static void
@@ -1496,7 +1496,7 @@ mangle_far_indirect_helper(dcontext_t *dcontext, instrlist_t *ilist, instr_t *in
         opnd_set_size(&sel, OPSZ_2);
 
         /* all scratch space should be in TLS only */
-        ASSERT(TEST(FRAG_SHARED, flags) || DYNAMO_OPTION(private_ib_in_tls));
+        ASSERT(TESTANY(FRAG_SHARED, flags) || DYNAMO_OPTION(private_ib_in_tls));
         PRE(ilist, instr,
             SAVE_TO_DC_OR_TLS_OR_REG(dcontext, flags, REG_XBX, MANGLE_FAR_SPILL_SLOT,
                                      XBX_OFFSET, REG_R10));
@@ -1542,7 +1542,7 @@ mangle_indirect_call(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
      * XXX Just a note that converted calls are not subjected to any of
      * the specialized builds' processing further down.
      */
-    if (TEST(INSTR_IND_CALL_DIRECT, instr->flags)) {
+    if (TESTANY(INSTR_IND_CALL_DIRECT, instr->flags)) {
         /* convert the call to a push of the return address */
         insert_push_retaddr(dcontext, ilist, instr, retaddr, pushsz);
         /* remove the call */
@@ -1630,7 +1630,7 @@ mangle_far_return_save_selector(dcontext_t *dcontext, instrlist_t *ilist, instr_
          */
         /* We could do a pop but state xl8 is already set up to restore lea */
         /* all scratch space should be in TLS only */
-        ASSERT(TEST(FRAG_SHARED, flags) || DYNAMO_OPTION(private_ib_in_tls));
+        ASSERT(TESTANY(FRAG_SHARED, flags) || DYNAMO_OPTION(private_ib_in_tls));
         PRE(ilist, instr,
             SAVE_TO_DC_OR_TLS_OR_REG(dcontext, flags, REG_XBX, MANGLE_FAR_SPILL_SLOT,
                                      XBX_OFFSET, REG_R10));
@@ -1726,7 +1726,7 @@ mangle_return(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         }
     }
 
-    if (TEST(INSTR_CLOBBER_RETADDR, instr->flags)) {
+    if (TESTANY(INSTR_CLOBBER_RETADDR, instr->flags)) {
         /* we put the value in the offset field earlier */
         ptr_uint_t val = (ptr_uint_t)instr->offset;
         insert_mov_ptr_uint_beyond_TOS(dcontext, ilist, instr, val, retsz);
@@ -2019,13 +2019,13 @@ mangle_syscall_arch(dcontext_t *dcontext, instrlist_t *ilist, uint flags, instr_
         PRE(ilist, next_instr,
             INSTR_CREATE_mov_st(dcontext, opnd_create_reg(REG_XCX),
                                 opnd_create_reg(REG_XDX)));
-    } else if (TEST(INSTR_BRANCH_SPECIAL_EXIT, instr->flags)) {
+    } else if (TESTANY(INSTR_BRANCH_SPECIAL_EXIT, instr->flags)) {
         int num = instr_get_interrupt_number(instr);
         ASSERT(instr_get_opcode(instr) == OP_int);
         if (num == 0x81 || num == 0x82) {
             int reason = (num == 0x81) ? EXIT_REASON_NI_SYSCALL_INT_0x81
                                        : EXIT_REASON_NI_SYSCALL_INT_0x82;
-            if (DYNAMO_OPTION(private_ib_in_tls) || TEST(FRAG_SHARED, flags)) {
+            if (DYNAMO_OPTION(private_ib_in_tls) || TESTANY(FRAG_SHARED, flags)) {
                 insert_shared_get_dcontext(dcontext, ilist, instr, true /*save_xdi*/);
                 PRE(ilist, instr,
                     INSTR_CREATE_mov_st(
@@ -2055,7 +2055,7 @@ mangle_syscall_arch(dcontext_t *dcontext, instrlist_t *ilist, uint flags, instr_
 
     if (does_syscall_ret_to_callsite()) {
         uint len = instr_length(dcontext, instr);
-        if (TEST(INSTR_SHARED_SYSCALL, instr->flags)) {
+        if (TESTANY(INSTR_SHARED_SYSCALL, instr->flags)) {
             ASSERT(DYNAMO_OPTION(shared_syscalls));
             /* this syscall will be performed by the shared_syscall code
              * we just need to place a return address into the dcontext
@@ -2094,7 +2094,7 @@ mangle_syscall_arch(dcontext_t *dcontext, instrlist_t *ilist, uint flags, instr_
         /* Handle ignorable syscall.  non-ignorable system calls are
          * destroyed and removed from the list at the end of this func.
          */
-        else if (!TEST(INSTR_NI_SYSCALL, instr->flags)) {
+        else if (!TESTANY(INSTR_NI_SYSCALL, instr->flags)) {
             if (get_syscall_method() == SYSCALL_METHOD_INT && DYNAMO_OPTION(sygate_int)) {
                 /* for Sygate need to mangle into a call to int_syscall_addr
                  * is anyone going to get screwed up by this change
@@ -2118,13 +2118,13 @@ mangle_syscall_arch(dcontext_t *dcontext, instrlist_t *ilist, uint flags, instr_
          * page at 0x7ffe0000 can't be made writable anyway, so hooking
          * isn't possible.
          */
-        if (TEST(INSTR_SHARED_SYSCALL, instr->flags)) {
+        if (TESTANY(INSTR_SHARED_SYSCALL, instr->flags)) {
             ASSERT(DYNAMO_OPTION(shared_syscalls));
         }
         /* Handle ignorable syscall.  non-ignorable system calls are
          * destroyed and removed from the list at the end of this func.
          */
-        else if (!TEST(INSTR_NI_SYSCALL, instr->flags)) {
+        else if (!TESTANY(INSTR_NI_SYSCALL, instr->flags)) {
 
             instr_t *mov_imm;
 
@@ -2156,7 +2156,7 @@ mangle_syscall_arch(dcontext_t *dcontext, instrlist_t *ilist, uint flags, instr_
     } else {
         SYSLOG_INTERNAL_ERROR("unsupported system call method");
         LOG(THREAD, LOG_INTERP, 1, "don't know convention for this syscall method\n");
-        if (!TEST(INSTR_NI_SYSCALL, instr->flags))
+        if (!TESTANY(INSTR_NI_SYSCALL, instr->flags))
             return;
         ASSERT_NOT_IMPLEMENTED(false);
     }
@@ -2217,7 +2217,7 @@ void
 mangle_single_step(dcontext_t *dcontext, instrlist_t *ilist, uint flags, instr_t *instr)
 {
     /* Sets exit reason dynamically. */
-    if (DYNAMO_OPTION(private_ib_in_tls) || TEST(FRAG_SHARED, flags)) {
+    if (DYNAMO_OPTION(private_ib_in_tls) || TESTANY(FRAG_SHARED, flags)) {
         insert_shared_get_dcontext(dcontext, ilist, instr, true /*save_xdi*/);
         PRE(ilist, instr,
             INSTR_CREATE_mov_st(
@@ -2253,7 +2253,7 @@ float_pc_update(dcontext_t *dcontext)
         dcontext->upcontext.upcontext.exit_reason == EXIT_REASON_FLOAT_PC_XSAVE64) {
         /* Check whether the FPU state was saved */
         uint64 header_bv = *(uint64 *)(state + FXSAVE_SIZE);
-        if (!TEST(XCR0_FP, header_bv)) {
+        if (!TESTANY(XCR0_FP, header_bv)) {
             LOG(THREAD, LOG_INTERP, 2, "%s: xsave did not save FP state => nop\n",
                 __FUNCTION__);
         }
@@ -2352,7 +2352,7 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             dr_instr_category_t type;
             if (instr_is_app(prev) && instr_is_floating_type(prev, &type)) {
                 bool control_instr = false;
-                if (TEST(DR_INSTR_CATEGORY_STATE, type) /* quick check */ &&
+                if (TESTANY(DR_INSTR_CATEGORY_STATE, type) /* quick check */ &&
                     /* Check the list from Intel Vol 1 8.1.8 */
                     (op == OP_fnclex || op == OP_fldcw || op == OP_fnstcw ||
                      op == OP_fnstsw || op == OP_fnstenv || op == OP_fldenv ||
@@ -2398,12 +2398,12 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
          * XXX: we can't recover the loss of coarse-grained: we live with that.
          */
         exit_is_normal = true;
-        ASSERT_CURIOSITY(!TEST(FRAG_CANNOT_BE_TRACE, *flags) ||
+        ASSERT_CURIOSITY(!TESTANY(FRAG_CANNOT_BE_TRACE, *flags) ||
                          /* i#1562: it could be marked as no-trace for other reasons */
-                         TEST(FRAG_SELFMOD_SANDBOXED, *flags));
+                         TESTANY(FRAG_SELFMOD_SANDBOXED, *flags));
     } else {
         int reason = 0;
-        CLIENT_ASSERT(!TEST(FRAG_IS_TRACE, *flags),
+        CLIENT_ASSERT(!TESTANY(FRAG_IS_TRACE, *flags),
                       "removing an FPU instr in a trace with an FPU state save "
                       "is not supported");
         switch (op) {
@@ -2419,7 +2419,7 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         case OP_xsaveopt64: reason = EXIT_REASON_FLOAT_PC_XSAVE64; break;
         default: ASSERT_NOT_REACHED();
         }
-        if (DYNAMO_OPTION(private_ib_in_tls) || TEST(FRAG_SHARED, *flags)) {
+        if (DYNAMO_OPTION(private_ib_in_tls) || TESTANY(FRAG_SHARED, *flags)) {
             insert_shared_get_dcontext(dcontext, ilist, instr, true /*save_xdi*/);
             PRE(ilist, instr,
                 INSTR_CREATE_mov_st(
@@ -2456,7 +2456,7 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             instr_create_save_to_tls(dcontext, REG_XDI, FLOAT_PC_STATE_SLOT));
 
         /* Restore app %xdi */
-        if (TEST(FRAG_SHARED, *flags))
+        if (TESTANY(FRAG_SHARED, *flags))
             insert_shared_restore_dcontext_reg(dcontext, ilist, instr);
         else {
             PRE(ilist, instr,
@@ -2475,7 +2475,7 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         /* XXX: there could be some other reason this was marked
          * cannot-be-trace that we're undoing here...
          */
-        if (TEST(FRAG_CANNOT_BE_TRACE, *flags))
+        if (TESTANY(FRAG_CANNOT_BE_TRACE, *flags))
             *flags &= ~FRAG_CANNOT_BE_TRACE;
     }
 }
@@ -2639,8 +2639,8 @@ mangle_rel_addr(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     instr_get_rel_addr_target(instr, &tgt);
     STATS_INC(rip_rel_instrs);
 #    ifdef RCT_IND_BRANCH
-    if (TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-        TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) {
+    if (TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+        TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) {
         /* PR 215408: record addresses taken via rip-relative instrs */
         rct_add_rip_rel_addr(dcontext, tgt _IF_DEBUG(instr_get_translation(instr)));
     }
@@ -3617,7 +3617,7 @@ sandbox_top_of_bb(dcontext_t *dcontext, instrlist_t *ilist, bool s2ro, uint flag
             INSTR_CREATE_cmp(dcontext, OPND_CREATE_ABSMEM(counter, OPSZ_4),
                              OPND_CREATE_INT_32OR8(thresh)));
 #endif
-        if (TEST(FRAG_WRITES_EFLAGS_6, flags) IF_X64(&&false)) {
+        if (TESTANY(FRAG_WRITES_EFLAGS_6, flags) IF_X64(&&false)) {
             jmp = INSTR_CREATE_jcc(dcontext, OP_jge, opnd_create_pc(start_pc));
             instr_branch_set_special_exit(jmp, true);
             /* an exit cti, not a meta instr */
@@ -3631,7 +3631,7 @@ sandbox_top_of_bb(dcontext_t *dcontext, instrlist_t *ilist, bool s2ro, uint flag
             PRE(ilist, instr,
                 RESTORE_FROM_DC_OR_TLS(dcontext, REG_XCX, TLS_XCX_SLOT, XCX_OFFSET));
 #endif
-            if (!TEST(FRAG_WRITES_EFLAGS_6, flags)) {
+            if (!TESTANY(FRAG_WRITES_EFLAGS_6, flags)) {
                 ASSERT(restore_eflags_and_exit == NULL);
                 restore_eflags_and_exit = INSTR_CREATE_label(dcontext);
                 PRE(ilist, instr,
@@ -3744,7 +3744,7 @@ sandbox_top_of_bb(dcontext_t *dcontext, instrlist_t *ilist, bool s2ro, uint flag
         RESTORE_FROM_DC_OR_TLS(dcontext, REG_XSI, TLS_XBX_SLOT, XSI_OFFSET));
     PRE(ilist, instr,
         RESTORE_FROM_DC_OR_TLS(dcontext, REG_XDI, TLS_XDX_SLOT, XDI_OFFSET));
-    if (!TEST(FRAG_WRITES_EFLAGS_6, flags)) {
+    if (!TESTANY(FRAG_WRITES_EFLAGS_6, flags)) {
         instr_t *start_bb = INSTR_CREATE_label(dcontext);
         PRE(ilist, instr, INSTR_CREATE_jcc(dcontext, OP_je, opnd_create_instr(start_bb)));
         if (restore_eflags_and_exit != NULL) /* somebody needs this label */
@@ -3851,7 +3851,7 @@ insert_selfmod_sandbox(dcontext_t *dcontext, instrlist_t *ilist, uint flags,
                          */
                         ASSERT(EXIT_IS_CALL(instr_exit_branch_type(next)) ||
                                (DYNAMO_OPTION(IAT_convert) &&
-                                TEST(INSTR_IND_CALL_DIRECT, instr->flags)));
+                                TESTANY(INSTR_IND_CALL_DIRECT, instr->flags)));
 
                         LOG(THREAD, LOG_INTERP, 3,
                             " ignoring CALL* at end of fragment\n");
@@ -3973,9 +3973,9 @@ finalize_selfmod_sandbox(dcontext_t *dcontext, fragment_t *f)
     int k = ((ptr_uint_t)f->tag) > UINT_MAX ? 1 : 0;
 #endif
     i = (sandbox_top_of_bb_check_s2ro(dcontext, f->tag)) ? 1 : 0;
-    j = (TEST(FRAG_WRITES_EFLAGS_6, f->flags)
+    j = (TESTANY(FRAG_WRITES_EFLAGS_6, f->flags)
              ? 0
-             : (TEST(FRAG_WRITES_EFLAGS_OF, f->flags) ? 1 : 2));
+             : (TESTANY(FRAG_WRITES_EFLAGS_OF, f->flags) ? 1 : 2));
     pc = FCACHE_ENTRY_PC(f) + selfmod_copy_start_offs[i][j] IF_X64([k]);
     /* The copy start gets updated after sandbox_top_of_bb. */
     *((cache_pc *)vmcode_get_writable_addr(pc)) = copy_pc;

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -470,9 +470,9 @@ proc_init_arch(void)
             } else {
                 LOG(GLOBAL, LOG_TOP, 1, "\tOS does NOT support AVX-512\n");
             }
-            get_xstate_area_offsets(TEST(XCR0_OPMASK, bv_low),
-                                    TEST(XCR0_ZMM_HI256, bv_low),
-                                    TEST(XCR0_HI16_ZMM, bv_low));
+            get_xstate_area_offsets(TESTANY(XCR0_OPMASK, bv_low),
+                                    TESTANY(XCR0_ZMM_HI256, bv_low),
+                                    TESTANY(XCR0_HI16_ZMM, bv_low));
         }
     }
     for (i = 0; i < DEBUG_REGISTERS_NB; i++) {
@@ -502,7 +502,7 @@ proc_has_feature(feature_bit_t f)
     }
 
     bit = f % 32;
-    return TEST((1 << bit), val);
+    return TESTANY((1 << bit), val);
 }
 
 /* No synchronization routines necessary.  The Pentium hardware

--- a/core/config.c
+++ b/core/config.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -778,9 +778,9 @@ should_inject_from_rununder(const char *runstr, bool app_specific, bool from_env
         return false;
     /* env var counts as app-specific */
     if (!app_specific && !from_env) {
-        if (TEST(RUNUNDER_ALL, rununder))
+        if (TESTANY(RUNUNDER_ALL, rununder))
             *rununder_on = true;
-    } else if (TEST(RUNUNDER_ON, rununder))
+    } else if (TESTANY(RUNUNDER_ON, rununder))
         *rununder_on = true;
     /* Linux ignores RUNUNDER_EXPLICIT, RUNUNDER_COMMANDLINE_*, RUNUNDER_ONCE */
     return true;

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -117,7 +117,7 @@ exited_due_to_ni_syscall(dcontext_t *dcontext)
 {
     if (TESTANY(LINK_NI_SYSCALL_ALL, dcontext->last_exit->flags))
         return true;
-    if (TEST(LINK_SPECIAL_EXIT, dcontext->last_exit->flags) &&
+    if (TESTANY(LINK_SPECIAL_EXIT, dcontext->last_exit->flags) &&
         (dcontext->upcontext.upcontext.exit_reason == EXIT_REASON_NI_SYSCALL_INT_0x81 ||
          dcontext->upcontext.upcontext.exit_reason == EXIT_REASON_NI_SYSCALL_INT_0x82))
         return true;
@@ -215,7 +215,7 @@ d_r_dispatch(dcontext_t *dcontext)
                                                      false /*!for_trace*/, NULL);
                 SELF_PROTECT_LOCAL(dcontext, READONLY);
             }
-            if (targetf != NULL && TEST(FRAG_COARSE_GRAIN, targetf->flags)) {
+            if (targetf != NULL && TESTANY(FRAG_COARSE_GRAIN, targetf->flags)) {
                 /* targetf is a static temp fragment protected by bb_building_lock,
                  * so we must make a local copy to use before releasing the lock.
                  * XXX: best to pass local wrapper to build_basic_block_fragment
@@ -283,7 +283,7 @@ dispatch_enter_fcache_stats(dcontext_t *dcontext, fragment_t *targetf)
 {
 #ifdef DEBUG
 #    ifdef DGC_DIAGNOSTICS
-    if (TEST(FRAG_DYNGEN, targetf->flags) && !is_dyngen_vsyscall(targetf->tag)) {
+    if (TESTANY(FRAG_DYNGEN, targetf->flags) && !is_dyngen_vsyscall(targetf->tag)) {
         char buf[MAXIMUM_SYMBOL_LENGTH];
         bool stack = is_address_on_stack(dcontext, targetf->tag);
         LOG(THREAD, LOG_DISPATCH, 1,
@@ -293,7 +293,7 @@ dispatch_enter_fcache_stats(dcontext_t *dcontext, fragment_t *targetf)
         if (!LINKSTUB_FAKE(dcontext->last_exit)) {
             app_pc translated_pc;
             /* can't recreate if fragment is deleted -- but should be fake then */
-            ASSERT(!TEST(FRAG_WAS_DELETED, dcontext->last_fragment->flags));
+            ASSERT(!TESTANY(FRAG_WAS_DELETED, dcontext->last_fragment->flags));
             translated_pc = recreate_app_pc(
                 dcontext, EXIT_CTI_PC(dcontext->last_fragment, dcontext->last_exit),
                 dcontext->last_fragment);
@@ -336,14 +336,14 @@ dispatch_enter_fcache_stats(dcontext_t *dcontext, fragment_t *targetf)
             IF_X86_ELSE(
                 IF_X64_ELSE(FRAG_IS_32(targetf->flags) ? "(32-bit)" : "", ""),
                 IF_ARM_ELSE(FRAG_IS_THUMB(targetf->flags) ? "(T32)" : "(A32)", "")),
-            TEST(FRAG_COARSE_GRAIN, targetf->flags) ? "(coarse)" : "",
+            TESTANY(FRAG_COARSE_GRAIN, targetf->flags) ? "(coarse)" : "",
             ((targetf->flags & FRAG_IS_TRACE_HEAD) != 0) ? "(trace head)" : "",
             ((targetf->flags & FRAG_IS_TRACE) != 0) ? "(trace)" : "");
         LOG(THREAD, LOG_DISPATCH, 2, "%s",
-            TEST(FRAG_SHARED, targetf->flags) ? "(shared)" : "");
+            TESTANY(FRAG_SHARED, targetf->flags) ? "(shared)" : "");
 #    ifdef DGC_DIAGNOSTICS
         LOG(THREAD, LOG_DISPATCH, 2, "%s",
-            TEST(FRAG_DYNGEN, targetf->flags) ? "(dyngen)" : "");
+            TESTANY(FRAG_DYNGEN, targetf->flags) ? "(dyngen)" : "");
 #    endif
         LOG(THREAD, LOG_DISPATCH, 2, "\n");
 
@@ -371,7 +371,7 @@ dispatch_enter_fcache(dcontext_t *dcontext, fragment_t *targetf)
     if (dcontext->last_exit == get_coarse_exit_linkstub() ||
         /* We need to lazy link if either of src or tgt is coarse */
         (LINKSTUB_DIRECT(dcontext->last_exit->flags) &&
-         TEST(FRAG_COARSE_GRAIN, targetf->flags))) {
+         TESTANY(FRAG_COARSE_GRAIN, targetf->flags))) {
         coarse_lazy_link(dcontext, targetf);
     }
 
@@ -400,7 +400,7 @@ dispatch_enter_fcache(dcontext_t *dcontext, fragment_t *targetf)
      */
     DOKSTATS({
         /* stopped in dispatch_exit_fcache_stats */
-        if (TEST(FRAG_IS_TRACE, targetf->flags))
+        if (TESTANY(FRAG_IS_TRACE, targetf->flags))
             KSTART(fcache_trace_trace);
         else
             KSTART(fcache_default); /* fcache_bb_bb or fcache_bb_trace */
@@ -477,7 +477,7 @@ dispatch_enter_fcache(dcontext_t *dcontext, fragment_t *targetf)
      * if the target fragment has an instr that updates the segment selector,
      * update the corresponding information maintained by DR.
      */
-    if (INTERNAL_OPTION(mangle_app_seg) && TEST(FRAG_HAS_MOV_SEG, targetf->flags)) {
+    if (INTERNAL_OPTION(mangle_app_seg) && TESTANY(FRAG_HAS_MOV_SEG, targetf->flags)) {
         os_handle_mov_seg(dcontext, targetf->tag);
     }
 #endif
@@ -487,7 +487,7 @@ dispatch_enter_fcache(dcontext_t *dcontext, fragment_t *targetf)
                IF_X64(||
                       (dr_get_isa_mode(dcontext) == DR_ISA_IA32 &&
                        !FRAG_IS_32(targetf->flags) && DYNAMO_OPTION(x86_to_x64))));
-    if (TEST(FRAG_SHARED, targetf->flags))
+    if (TESTANY(FRAG_SHARED, targetf->flags))
         fcache_enter = get_fcache_enter_shared_routine(dcontext);
     else
         fcache_enter = get_fcache_enter_private_routine(dcontext);
@@ -934,7 +934,7 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
             }
         }
 #ifdef WINDOWS
-        else if (TEST(LINK_CALLBACK_RETURN, dcontext->last_exit->flags)) {
+        else if (TESTANY(LINK_CALLBACK_RETURN, dcontext->last_exit->flags)) {
             handle_callback_return(dcontext);
             ASSERT_NOT_REACHED();
         }
@@ -958,7 +958,7 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
         }
 #endif
 
-        if (TEST(LINK_SPECIAL_EXIT, dcontext->last_exit->flags)) {
+        if (TESTANY(LINK_SPECIAL_EXIT, dcontext->last_exit->flags)) {
             if (dcontext->upcontext.upcontext.exit_reason == EXIT_REASON_SELFMOD) {
                 /* Case 8177: If we have a flushed fragment hit a self-write, we
                  * cannot delete it in our self-write handler (b/c of case 3559's
@@ -985,7 +985,7 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
             } else if (dcontext->upcontext.upcontext.exit_reason ==
                        EXIT_REASON_SINGLE_STEP) {
                 /* Delete basic block to generate only one single step exception. */
-                ASSERT(!TEST(FRAG_SHARED, dcontext->last_fragment->flags));
+                ASSERT(!TESTANY(FRAG_SHARED, dcontext->last_fragment->flags));
                 fragment_delete(dcontext, dcontext->last_fragment, FRAGDEL_ALL);
                 /* Restore */
                 dcontext->upcontext.upcontext.exit_reason = EXIT_REASON_SELFMOD;
@@ -1118,7 +1118,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
         /* PR 204770: use trace component bb tag for RCT source address */
         app_pc src_tag = dcontext->last_fragment->tag;
         if (!LINKSTUB_FAKE(dcontext->last_exit) &&
-            TEST(FRAG_IS_TRACE, dcontext->last_fragment->flags)) {
+            TESTANY(FRAG_IS_TRACE, dcontext->last_fragment->flags)) {
             /* XXX: should we call this for direct exits as well, up front? */
             src_tag = get_trace_exit_component_tag(dcontext, dcontext->last_fragment,
                                                    dcontext->last_exit);
@@ -1131,7 +1131,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
          * routine
          */
         if (dynamo_options.ret_after_call &&
-            TEST(LINK_RETURN, dcontext->last_exit->flags)) {
+            TESTANY(LINK_RETURN, dcontext->last_exit->flags)) {
             /* ret_after_call will raise a security violation on failure */
             SELF_PROTECT_LOCAL(dcontext, WRITABLE);
             ret_after_call_check(dcontext, dcontext->next_tag, src_tag);
@@ -1269,7 +1269,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
                     /* XXX: if f is shared we must hold change_linking_lock
                      * for the flags and vm area operations here
                      */
-                    ASSERT(!TEST(FRAG_SHARED, f->flags));
+                    ASSERT(!TESTANY(FRAG_SHARED, f->flags));
                     f->flags |= FRAG_CANNOT_DELETE;
                     DEBUG_DECLARE(ok =)
                     vm_area_add_to_list(dcontext, f->tag, &vmlist, orig_flags, f,
@@ -1489,17 +1489,17 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
         if (DYNAMO_OPTION(coarse_units)) {
             LOG(THREAD, LOG_DISPATCH, 2, "Exit from coarse ibl from tag " PFX ": %s %s",
                 dcontext->coarse_exit.src_tag,
-                TEST(FRAG_IS_TRACE, last_f->flags) ? "trace" : "bb",
-                TEST(LINK_RETURN, dcontext->last_exit->flags)  ? "ret"
-                    : EXIT_IS_CALL(dcontext->last_exit->flags) ? "call*"
-                                                               : "jmp*");
+                TESTANY(FRAG_IS_TRACE, last_f->flags) ? "trace" : "bb",
+                TESTANY(LINK_RETURN, dcontext->last_exit->flags) ? "ret"
+                    : EXIT_IS_CALL(dcontext->last_exit->flags)   ? "call*"
+                                                                 : "jmp*");
         } else {
             /* We can get here for -indirect_stubs via client special ibl */
             LOG(THREAD, LOG_DISPATCH, 2, "Exit from sourceless ibl: %s %s",
-                TEST(FRAG_IS_TRACE, last_f->flags) ? "trace" : "bb",
-                TEST(LINK_RETURN, dcontext->last_exit->flags)  ? "ret"
-                    : EXIT_IS_CALL(dcontext->last_exit->flags) ? "call*"
-                                                               : "jmp*");
+                TESTANY(FRAG_IS_TRACE, last_f->flags) ? "trace" : "bb",
+                TESTANY(LINK_RETURN, dcontext->last_exit->flags) ? "ret"
+                    : EXIT_IS_CALL(dcontext->last_exit->flags)   ? "call*"
+                                                                 : "jmp*");
         }
     } else if (dcontext->last_exit == get_coarse_exit_linkstub()) {
         DOLOG(2, LOG_DISPATCH, {
@@ -1523,7 +1523,7 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
     }
 
     DOSTATS({
-        if (TEST(FRAG_IS_TRACE, last_f->flags))
+        if (TESTANY(FRAG_IS_TRACE, last_f->flags))
             STATS_INC(num_trace_exits);
         else
             STATS_INC(num_bb_exits);
@@ -1532,7 +1532,7 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
     LOG(THREAD, LOG_DISPATCH, 2, " %s%s",
         IF_X86_ELSE(IF_X64_ELSE(FRAG_IS_32(last_f->flags) ? "(32-bit)" : "", ""),
                     IF_ARM_ELSE(FRAG_IS_THUMB(last_f->flags) ? "(T32)" : "(A32)", "")),
-        TEST(FRAG_SHARED, last_f->flags) ? "(shared)" : "");
+        TESTANY(FRAG_SHARED, last_f->flags) ? "(shared)" : "");
     DOLOG(2, LOG_SYMBOLS, {
         char symbuf[MAXIMUM_SYMBOL_LENGTH];
         print_symbolic_address(last_f->tag, symbuf, sizeof(symbuf), true);
@@ -1540,7 +1540,7 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
     });
 
 #    if defined(DEBUG) && defined(DGC_DIAGNOSTICS)
-    if (TEST(FRAG_DYNGEN, last_f->flags) && !is_dyngen_vsyscall(last_f->tag)) {
+    if (TESTANY(FRAG_DYNGEN, last_f->flags) && !is_dyngen_vsyscall(last_f->tag)) {
         char buf[MAXIMUM_SYMBOL_LENGTH];
         bool stack = is_address_on_stack(dcontext, last_f->tag);
         app_pc translated_pc;
@@ -1589,10 +1589,11 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
             STATS_INC(num_exits_ind_good_miss);
             KSWITCH(num_exits_ind_good_miss);
         } else if (is_building_trace(dcontext) &&
-                   !TEST(LINK_LINKED, dcontext->last_exit->flags)) {
+                   !TESTANY(LINK_LINKED, dcontext->last_exit->flags)) {
             LOG(THREAD, LOG_DISPATCH, 2, " (in trace-building mode)");
             STATS_INC(num_exits_ind_trace_build);
-        } else if (TEST(FRAG_WAS_DELETED, last_f->flags) || !INTERNAL_OPTION(link_ibl)) {
+        } else if (TESTANY(FRAG_WAS_DELETED, last_f->flags) ||
+                   !INTERNAL_OPTION(link_ibl)) {
             LOG(THREAD, LOG_DISPATCH, 2, " (src unlinked)");
             STATS_INC(num_exits_ind_src_unlinked);
         } else {
@@ -1600,13 +1601,13 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
                 " (target " PFX " in cache but not lookup table)", dcontext->next_tag);
             STATS_INC(num_exits_ind_bad_miss);
 
-            if (TEST(FRAG_IS_TRACE, last_f->flags)) {
+            if (TESTANY(FRAG_IS_TRACE, last_f->flags)) {
                 STATS_INC(num_exits_ind_bad_miss_trace);
-                if (next_f && TEST(FRAG_IS_TRACE, next_f->flags)) {
+                if (next_f && TESTANY(FRAG_IS_TRACE, next_f->flags)) {
                     STATS_INC(num_exits_ind_bad_miss_trace2trace);
                     KSWITCH(num_exits_ind_bad_miss_trace2trace);
-                } else if (next_f && !TEST(FRAG_IS_TRACE, next_f->flags)) {
-                    if (!TEST(FRAG_IS_TRACE_HEAD, next_f->flags)) {
+                } else if (next_f && !TESTANY(FRAG_IS_TRACE, next_f->flags)) {
+                    if (!TESTANY(FRAG_IS_TRACE_HEAD, next_f->flags)) {
                         STATS_INC(num_exits_ind_bad_miss_trace2bb_nth);
                         KSWITCH(num_exits_ind_bad_miss_trace2bb_nth);
                     } else {
@@ -1616,12 +1617,12 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
                 }
             } else {
                 STATS_INC(num_exits_ind_bad_miss_bb);
-                if (next_f && TEST(FRAG_IS_TRACE, next_f->flags)) {
+                if (next_f && TESTANY(FRAG_IS_TRACE, next_f->flags)) {
                     STATS_INC(num_exits_ind_bad_miss_bb2trace);
                     KSWITCH(num_exits_ind_bad_miss_bb2trace);
-                } else if (next_f && !TEST(FRAG_IS_TRACE, next_f->flags)) {
+                } else if (next_f && !TESTANY(FRAG_IS_TRACE, next_f->flags)) {
                     DOSTATS({
-                        if (TEST(FRAG_IS_TRACE_HEAD, next_f->flags))
+                        if (TESTANY(FRAG_IS_TRACE_HEAD, next_f->flags))
                             STATS_INC(num_exits_ind_bad_miss_bb2bb_th);
                     });
                     STATS_INC(num_exits_ind_bad_miss_bb2bb);
@@ -1630,18 +1631,18 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
             }
         }
         DOSTATS({
-            if (!TEST(FRAG_IS_TRACE, last_f->flags))
+            if (!TESTANY(FRAG_IS_TRACE, last_f->flags))
                 STATS_INC(num_exits_ind_non_trace);
         });
 #    ifdef RETURN_AFTER_CALL
         /* split by ind branch type */
-        if (TEST(LINK_RETURN, dcontext->last_exit->flags)) {
+        if (TESTANY(LINK_RETURN, dcontext->last_exit->flags)) {
             LOG(THREAD, LOG_DISPATCH, 2, " (return from " PFX " non-trace tgt " PFX ")",
                 EXIT_CTI_PC(dcontext->last_fragment, dcontext->last_exit),
                 dcontext->next_tag);
             STATS_INC(num_exits_ret);
             DOSTATS({
-                if (TEST(FRAG_IS_TRACE, last_f->flags))
+                if (TESTANY(FRAG_IS_TRACE, last_f->flags))
                     STATS_INC(num_exits_ret_trace);
             });
         } else if (TESTANY(LINK_CALL | LINK_JMP, dcontext->last_exit->flags)) {
@@ -1661,7 +1662,7 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
             LOG(THREAD, LOG_DISPATCH, 2,
                 "WARNING: unknown indirect exit from " PFX ", in %s fragment " PFX,
                 EXIT_CTI_PC(dcontext->last_fragment, dcontext->last_exit),
-                (TEST(FRAG_IS_TRACE, last_f->flags)) ? "trace" : "bb", last_f);
+                (TESTANY(FRAG_IS_TRACE, last_f->flags)) ? "trace" : "bb", last_f);
             STATS_INC(num_exits_ind_unknown);
             ASSERT_NOT_REACHED();
         }
@@ -1679,7 +1680,7 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
             KSWITCH(num_exits_dir_syscall);
         }
 #    ifdef WINDOWS
-        else if (TEST(LINK_CALLBACK_RETURN, dcontext->last_exit->flags)) {
+        else if (TESTANY(LINK_CALLBACK_RETURN, dcontext->last_exit->flags)) {
             LOG(THREAD, LOG_DISPATCH, 2, " (block ends with callback return)");
             STATS_INC(num_exits_dir_cbret);
         }
@@ -1708,12 +1709,12 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
             LOG(THREAD, LOG_DISPATCH, 2, " (cannot link F%d->F%d)", last_f->id,
                 next_f->id);
             if (is_building_trace(dcontext) &&
-                !TEST(LINK_LINKED, dcontext->last_exit->flags)) {
+                !TESTANY(LINK_LINKED, dcontext->last_exit->flags)) {
                 LOG(THREAD, LOG_DISPATCH, 2, " (in trace-building mode)");
                 STATS_INC(num_exits_dir_trace_build);
             }
 #        ifndef TRACE_HEAD_CACHE_INCR
-            else if (TEST(FRAG_IS_TRACE_HEAD, next_f->flags)) {
+            else if (TESTANY(FRAG_IS_TRACE_HEAD, next_f->flags)) {
                 LOG(THREAD, LOG_DISPATCH, 2, " (target F%d is trace head)", next_f->id);
                 STATS_INC(num_exits_dir_trace_head);
             }
@@ -1731,9 +1732,9 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
 #        endif
             else if (INTERNAL_OPTION(nolink)) {
                 LOG(THREAD, LOG_DISPATCH, 2, " (nolink option is on)");
-            } else if (!TEST(FRAG_LINKED_OUTGOING, last_f->flags)) {
+            } else if (!TESTANY(FRAG_LINKED_OUTGOING, last_f->flags)) {
                 LOG(THREAD, LOG_DISPATCH, 2, " (F%d is unlinked-out)", last_f->id);
-            } else if (!TEST(FRAG_LINKED_INCOMING, next_f->flags)) {
+            } else if (!TESTANY(FRAG_LINKED_INCOMING, next_f->flags)) {
                 LOG(THREAD, LOG_DISPATCH, 2, " (F%d is unlinked-in)", next_f->id);
             } else {
                 LOG(THREAD, LOG_DISPATCH, 2, " (unknown reason)");
@@ -1746,12 +1747,13 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
             }
         }
 #        ifdef TRACE_HEAD_CACHE_INCR
-        else if (TEST(FRAG_IS_TRACE_HEAD, next_f->flags)) {
+        else if (TESTANY(FRAG_IS_TRACE_HEAD, next_f->flags)) {
             LOG(THREAD, LOG_DISPATCH, 2, " (trace head F%d now hot!)", next_f->id);
             STATS_INC(num_exits_dir_trace_hot);
         }
 #        endif
-        else if (TEST(FRAG_IS_TRACE, next_f->flags) && TEST(FRAG_SHARED, last_f->flags)) {
+        else if (TESTANY(FRAG_IS_TRACE, next_f->flags) &&
+                 TESTANY(FRAG_SHARED, last_f->flags)) {
             LOG(THREAD, LOG_DISPATCH, 2,
                 " (shared trace head shadowed by private trace F%d)", next_f->id);
             STATS_INC(num_exits_dir_nolink_sharing);
@@ -1760,8 +1762,8 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
             LOG(THREAD, LOG_DISPATCH, 2, " (self-loop in F%d, replaced by F%d)",
                 last_f->id, next_f->id);
             STATS_INC(num_exits_dir_self_replacement);
-        } else if (TEST(FRAG_COARSE_GRAIN, next_f->flags) &&
-                   !TEST(FRAG_COARSE_GRAIN, last_f->flags)) {
+        } else if (TESTANY(FRAG_COARSE_GRAIN, next_f->flags) &&
+                   !TESTANY(FRAG_COARSE_GRAIN, last_f->flags)) {
             LOG(THREAD, LOG_DISPATCH, 2, " (fine fragment targeting coarse trace head)");
             /* XXX: We would assert that FRAG_IS_TRACE_HEAD is set, but
              * we have no way of setting that up for fine to coarse links
@@ -1873,7 +1875,7 @@ handle_system_call(dcontext_t *dcontext)
     /* make sure to ask about syscall before pre_syscall, which will swap new mc in! */
     bool use_prev_dcontext = is_cb_return_syscall(dcontext);
 #elif defined(X86)
-    if (TEST(LINK_NI_SYSCALL_INT, dcontext->last_exit->flags)) {
+    if (TESTANY(LINK_NI_SYSCALL_INT, dcontext->last_exit->flags)) {
         LOG(THREAD, LOG_SYSCALLS, 2, "Using do_int_syscall\n");
         do_syscall = (app_pc)get_do_int_syscall_entry(dcontext);
         /* last_exit will be for the syscall so set a flag (could alternatively
@@ -1886,7 +1888,7 @@ handle_system_call(dcontext_t *dcontext)
             LOG(THREAD, LOG_SYSCALLS, 2, "Using do_vmkuw_syscall\n");
         }
 #    endif
-    } else if (TEST(LINK_SPECIAL_EXIT, dcontext->last_exit->flags)) {
+    } else if (TESTANY(LINK_SPECIAL_EXIT, dcontext->last_exit->flags)) {
         if (dcontext->upcontext.upcontext.exit_reason == EXIT_REASON_NI_SYSCALL_INT_0x81)
             do_syscall = (app_pc)get_do_int81_syscall_entry(dcontext);
         else {

--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -154,11 +154,11 @@ uint
 module_segment_prot_to_osprot(ELF_PROGRAM_HEADER_TYPE *prog_hdr)
 {
     uint segment_prot = 0;
-    if (TEST(PF_X, prog_hdr->p_flags))
+    if (TESTANY(PF_X, prog_hdr->p_flags))
         segment_prot |= MEMPROT_EXEC;
-    if (TEST(PF_W, prog_hdr->p_flags))
+    if (TESTANY(PF_W, prog_hdr->p_flags))
         segment_prot |= MEMPROT_WRITE;
-    if (TEST(PF_R, prog_hdr->p_flags))
+    if (TESTANY(PF_R, prog_hdr->p_flags))
         segment_prot |= MEMPROT_READ;
     return segment_prot;
 }
@@ -411,25 +411,26 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
 
     /* reserve the memory from os for library */
     initial_map_size = elf->image_size;
-    if (TEST(MODLOAD_SEPARATE_BSS, flags)) {
+    if (TESTANY(MODLOAD_SEPARATE_BSS, flags)) {
         /* place an extra no-access page after .bss */
         initial_map_size += PAGE_SIZE;
     }
-    lib_base = (*map_func)(-1, &initial_map_size, 0, map_base,
-                           MEMPROT_NONE, /* so the separating page is no-access */
-                           MAP_FILE_COPY_ON_WRITE | MAP_FILE_IMAGE |
-                               /* i#1001: a PIE executable may have NULL as preferred
-                                * base, in which case the map can be anywhere
-                                */
-                               ((fixed && map_base != NULL) ? MAP_FILE_FIXED : 0) |
-                               (TEST(MODLOAD_REACHABLE, flags) ? MAP_FILE_REACHABLE : 0) |
-                               (TEST(MODLOAD_IS_APP, flags) ? MAP_FILE_APP : 0));
+    lib_base =
+        (*map_func)(-1, &initial_map_size, 0, map_base,
+                    MEMPROT_NONE, /* so the separating page is no-access */
+                    MAP_FILE_COPY_ON_WRITE | MAP_FILE_IMAGE |
+                        /* i#1001: a PIE executable may have NULL as preferred
+                         * base, in which case the map can be anywhere
+                         */
+                        ((fixed && map_base != NULL) ? MAP_FILE_FIXED : 0) |
+                        (TESTANY(MODLOAD_REACHABLE, flags) ? MAP_FILE_REACHABLE : 0) |
+                        (TESTANY(MODLOAD_IS_APP, flags) ? MAP_FILE_APP : 0));
     if (lib_base == NULL)
         return NULL;
     LOG(GLOBAL, LOG_LOADER, 3,
         "%s: initial reservation " PFX "-" PFX " vs preferred " PFX "\n", __FUNCTION__,
         lib_base, lib_base + initial_map_size, map_base);
-    if (TEST(MODLOAD_SEPARATE_BSS, flags) && initial_map_size > elf->image_size)
+    if (TESTANY(MODLOAD_SEPARATE_BSS, flags) && initial_map_size > elf->image_size)
         elf->image_size = initial_map_size - PAGE_SIZE;
     else
         elf->image_size = initial_map_size;
@@ -478,8 +479,8 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
             }
             seg_prot = module_segment_prot_to_osprot(prog_hdr);
             pg_offs = ALIGN_BACKWARD(prog_hdr->p_offset, PAGE_SIZE);
-            if (TEST(MODLOAD_SKIP_WRITABLE, flags) && TEST(MEMPROT_WRITE, seg_prot) &&
-                mem_end == lib_end) {
+            if (TESTANY(MODLOAD_SKIP_WRITABLE, flags) &&
+                TESTANY(MEMPROT_WRITE, seg_prot) && mem_end == lib_end) {
                 /* We only actually skip if it's the final segment, to allow
                  * unmapping with a single mmap and not worrying about sthg
                  * else having been unmapped at the end in the meantime.

--- a/core/drlibc/drlibc_unix.c
+++ b/core/drlibc/drlibc_unix.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -92,11 +92,11 @@ uint
 memprot_to_osprot(uint prot)
 {
     uint mmap_prot = 0;
-    if (TEST(MEMPROT_EXEC, prot))
+    if (TESTANY(MEMPROT_EXEC, prot))
         mmap_prot |= PROT_EXEC;
-    if (TEST(MEMPROT_READ, prot))
+    if (TESTANY(MEMPROT_READ, prot))
         mmap_prot |= PROT_READ;
-    if (TEST(MEMPROT_WRITE, prot))
+    if (TESTANY(MEMPROT_WRITE, prot))
         mmap_prot |= PROT_WRITE;
     return mmap_prot;
 }
@@ -238,7 +238,7 @@ os_get_file_size_by_handle(file_t fd, uint64 *size)
 bool
 os_create_dir(const char *fname, create_directory_flags_t create_dir_flags)
 {
-    bool require_new = TEST(CREATE_DIR_REQUIRE_NEW, create_dir_flags);
+    bool require_new = TESTANY(CREATE_DIR_REQUIRE_NEW, create_dir_flags);
 #ifdef SYS_mkdir
     int rc = dynamorio_syscall(SYS_mkdir, 2, fname, S_IRWXU | S_IRWXG);
 #else
@@ -318,13 +318,13 @@ os_open(const char *fname, int os_open_flags)
     int mode = 0;
     const int create_mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
 
-    if (TEST(OS_OPEN_ALLOW_LARGE, os_open_flags))
+    if (TESTANY(OS_OPEN_ALLOW_LARGE, os_open_flags))
         flags |= O_LARGEFILE;
 
-    if (TEST(OS_OPEN_WRITE_ONLY, os_open_flags)) {
+    if (TESTANY(OS_OPEN_WRITE_ONLY, os_open_flags)) {
         flags |= O_WRONLY | O_CREAT;
         mode = create_mode;
-    } else if (!TEST(OS_OPEN_WRITE, os_open_flags))
+    } else if (!TESTANY(OS_OPEN_WRITE, os_open_flags))
         flags |= O_RDONLY;
     else {
         flags |= O_RDWR | O_CREAT |
@@ -335,8 +335,8 @@ os_open(const char *fname, int os_open_flags)
              * add OS_TRUNCATE or sthg we'll need to add it to
              * any current writers who don't set OS_OPEN_REQUIRE_NEW.
              */
-            (TEST(OS_OPEN_APPEND, os_open_flags) ? O_APPEND : O_TRUNC) |
-            (TEST(OS_OPEN_REQUIRE_NEW, os_open_flags) ? O_EXCL : 0);
+            (TESTANY(OS_OPEN_APPEND, os_open_flags) ? O_APPEND : O_TRUNC) |
+            (TESTANY(OS_OPEN_REQUIRE_NEW, os_open_flags) ? O_EXCL : 0);
 
         mode = create_mode;
     }
@@ -462,13 +462,13 @@ os_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc addr, uin
 #ifdef VMX86_SERVER
     flags = MAP_PRIVATE; /* MAP_SHARED not supported yet */
 #else
-    flags = TEST(MAP_FILE_COPY_ON_WRITE, map_flags) ? MAP_PRIVATE : MAP_SHARED;
+    flags = TESTANY(MAP_FILE_COPY_ON_WRITE, map_flags) ? MAP_PRIVATE : MAP_SHARED;
 #endif
     /* Allows memory request instead of mapping a file,
      * so we can request memory from a particular address with fixed argument */
     if (f == -1)
         flags |= MAP_ANONYMOUS;
-    if (TEST(MAP_FILE_FIXED, map_flags))
+    if (TESTANY(MAP_FILE_FIXED, map_flags))
         flags |= MAP_FIXED;
     map = mmap_syscall(addr, *size, memprot_to_osprot(prot), flags, f,
                        /* x86 Linux mmap uses offset in pages */

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -751,10 +751,10 @@ dynamorio_app_init_part_two_finalize(void)
             /* ENTERING_DR will increment, so decrement first
              * XXX: waste of protection change since will nop-unprotect!
              */
-            if (TEST(SELFPROT_DATA_CXTSW, DYNAMO_OPTION(protect_mask)))
+            if (TESTANY(SELFPROT_DATA_CXTSW, DYNAMO_OPTION(protect_mask)))
                 datasec_writable_cxtswprot = 0;
             /* XXX case 8073: remove once freqprot not every cxt sw */
-            if (TEST(SELFPROT_DATA_FREQ, DYNAMO_OPTION(protect_mask)))
+            if (TESTANY(SELFPROT_DATA_FREQ, DYNAMO_OPTION(protect_mask)))
                 datasec_writable_freqprot = 0;
         }
         /* this thread is now entering DR */
@@ -1648,8 +1648,8 @@ create_new_dynamo_context(bool initial, byte *dstack_in, priv_mcontext_t *mc)
     dcontext_t *dcontext;
     size_t alloc = sizeof(dcontext_t) + proc_get_cache_line_size();
     void *alloc_start =
-        (void *)((TEST(SELFPROT_GLOBAL, dynamo_options.protect_mask) &&
-                  !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+        (void *)((TESTANY(SELFPROT_GLOBAL, dynamo_options.protect_mask) &&
+                  !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
                      ?
                      /* if protecting global but not dcontext, put whole thing in unprot
                         mem */
@@ -1701,7 +1701,7 @@ create_new_dynamo_context(bool initial, byte *dstack_in, priv_mcontext_t *mc)
         /* dstack may be pre-allocated only at thread init, not at callback */
         ASSERT(dstack_in == NULL);
     }
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         dcontext->upcontext.separate_upcontext = global_unprotected_heap_alloc(
             sizeof(unprotected_context_t) HEAPACCT(ACCT_OTHER));
         /* don't need to initialize upcontext */
@@ -1745,12 +1745,12 @@ delete_dynamo_context(dcontext_t *dcontext, bool free_stack)
 
     ASSERT(dcontext->try_except.try_except_state == NULL);
 
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         global_unprotected_heap_free(dcontext->upcontext.separate_upcontext,
                                      sizeof(unprotected_context_t) HEAPACCT(ACCT_OTHER));
     }
-    if (TEST(SELFPROT_GLOBAL, dynamo_options.protect_mask) &&
-        !TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_GLOBAL, dynamo_options.protect_mask) &&
+        !TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         /* if protecting global but not dcontext, we put whole thing in unprot mem */
         global_unprotected_heap_free(dcontext->allocated_start,
                                      sizeof(dcontext_t) +
@@ -3317,7 +3317,7 @@ check_should_be_protected(uint sec)
          */
         doing_detach ||
 #    endif
-        !TEST(DATASEC_SELFPROT[sec], DYNAMO_OPTION(protect_mask)) ||
+        !TESTANY(DATASEC_SELFPROT[sec], DYNAMO_OPTION(protect_mask)) ||
         DATASEC_PROTECTED(sec))
         return true;
     STATS_INC(datasec_not_prot);
@@ -3383,7 +3383,7 @@ get_data_section_bounds(uint sec)
     ASSERT(sec >= 0 && sec < DATASEC_NUM);
     /* for DEBUG we use for data_sections_enclose_region() */
     ASSERT(IF_WINDOWS(IF_DEBUG(true ||))
-               TEST(DATASEC_SELFPROT[sec], dynamo_options.protect_mask));
+               TESTANY(DATASEC_SELFPROT[sec], dynamo_options.protect_mask));
     d_r_mutex_lock(&datasec_lock[sec]);
     ASSERT(datasec_start[sec] == NULL);
     get_named_section_bounds(get_dynamorio_dll_start(), DATASEC_NAMES[sec],
@@ -3393,7 +3393,7 @@ get_data_section_bounds(uint sec)
     ASSERT(ALIGNED(datasec_end[sec], PAGE_SIZE));
     ASSERT(datasec_start[sec] < datasec_end[sec]);
 #ifdef WINDOWS
-    if (IF_DEBUG(true ||) TEST(DATASEC_SELFPROT[sec], dynamo_options.protect_mask))
+    if (IF_DEBUG(true ||) TESTANY(DATASEC_SELFPROT[sec], dynamo_options.protect_mask))
         merge_writecopy_pages(datasec_start[sec], datasec_end[sec]);
 #endif
 }
@@ -3425,7 +3425,7 @@ data_section_init(void)
         ASSIGN_INIT_LOCK_FREE(datasec_lock[i], datasec_selfprot_lock);
         /* for DEBUG we use for data_sections_enclose_region() */
         if (IF_WINDOWS(IF_DEBUG(true ||))
-                TEST(DATASEC_SELFPROT[i], dynamo_options.protect_mask)) {
+                TESTANY(DATASEC_SELFPROT[i], dynamo_options.protect_mask)) {
             get_data_section_bounds(i);
         }
     }
@@ -3475,7 +3475,7 @@ void
 protect_data_section(uint sec, bool writable)
 {
     ASSERT(sec >= 0 && sec < DATASEC_NUM);
-    ASSERT(TEST(DATASEC_SELFPROT[sec], dynamo_options.protect_mask));
+    ASSERT(TESTANY(DATASEC_SELFPROT[sec], dynamo_options.protect_mask));
     /* We can be called very early before data_section_init() so init here
      * (data_section_init() has no dependences).
      */
@@ -3508,8 +3508,8 @@ protect_data_section(uint sec, bool writable)
             STATS_INC(datasec_prot_wasted_calls);
         (void)DATASEC_WRITABLE_MOD(sec, ++);
     }
-    LOG(TEST(DATASEC_SELFPROT[sec], SELFPROT_ON_CXT_SWITCH) ? THREAD_GET : GLOBAL,
-        LOG_VMAREAS, TEST(DATASEC_SELFPROT[sec], SELFPROT_ON_CXT_SWITCH) ? 3U : 2U,
+    LOG(TESTANY(DATASEC_SELFPROT[sec], SELFPROT_ON_CXT_SWITCH) ? THREAD_GET : GLOBAL,
+        LOG_VMAREAS, TESTANY(DATASEC_SELFPROT[sec], SELFPROT_ON_CXT_SWITCH) ? 3U : 2U,
         "protect_data_section: thread " TIDFMT " %s (recur %d, stat %d) %s %s %d\n",
         d_r_get_thread_id(), DATASEC_WRITABLE(sec) == 1 ? "changing" : "nop",
         DATASEC_WRITABLE(sec), GLOBAL_STAT(datasec_not_prot), DATASEC_NAMES[sec],

--- a/core/emit.c
+++ b/core/emit.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -58,7 +58,7 @@
 
 #define STATS_FCACHE_ADD(flags, stat, val)                  \
     DOSTATS({                                               \
-        if (TEST(FRAG_SHARED, (flags))) {                   \
+        if (TESTANY(FRAG_SHARED, (flags))) {                \
             if (IN_TRACE_CACHE(flags))                      \
                 STATS_ADD(fcache_shared_trace_##stat, val); \
             else                                            \
@@ -144,7 +144,7 @@ bool
 final_exit_shares_prev_stub(dcontext_t *dcontext, instrlist_t *ilist, uint frag_flags)
 {
     /* if a cbr is final exit pair, should they share a stub? */
-    if (INTERNAL_OPTION(cbr_single_stub) && !TEST(FRAG_COARSE_GRAIN, frag_flags)) {
+    if (INTERNAL_OPTION(cbr_single_stub) && !TESTANY(FRAG_COARSE_GRAIN, frag_flags)) {
         /* don't need to expand since is_exit_cti will rule out level 0 */
         instr_t *inst = instrlist_last(ilist);
         /* XXX: we could support code after the last cti (this is ubr so
@@ -160,9 +160,9 @@ final_exit_shares_prev_stub(dcontext_t *dcontext, instrlist_t *ilist, uint frag_
                  * our disambiguation to know which state to look at */
                 && instr_is_cbr(prev_cti)
                 /* no separate freeing */
-                && ((TEST(FRAG_SHARED, frag_flags) &&
+                && ((TESTANY(FRAG_SHARED, frag_flags) &&
                      !DYNAMO_OPTION(unsafe_free_shared_stubs)) ||
-                    (!TEST(FRAG_SHARED, frag_flags) &&
+                    (!TESTANY(FRAG_SHARED, frag_flags) &&
                      !DYNAMO_OPTION(free_private_stubs)))) {
                 return true;
             }
@@ -313,10 +313,10 @@ set_linkstub_fields(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist,
                 /* ensure LINK_ flags were transferred via instr_exit_branch_type */
                 if (instr_branch_special_exit(inst)) {
                     ASSERT(!LINKSTUB_INDIRECT(l->flags) &&
-                           TEST(LINK_SPECIAL_EXIT, l->flags));
+                           TESTANY(LINK_SPECIAL_EXIT, l->flags));
                 }
                 if (instr_branch_is_padded(inst)) {
-                    ASSERT(TEST(LINK_PADDED, l->flags));
+                    ASSERT(TESTANY(LINK_PADDED, l->flags));
                 }
             });
 
@@ -339,14 +339,14 @@ set_linkstub_fields(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist,
                 instr_exit_branch_type(inst), target, l->flags);
 
             DOCHECK(1, {
-                if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+                if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
                     ASSERT(!frag_offs_at_end);
                     /* XXX: indirect stubs should be separated
                      * eventually, but right now no good place to put them
                      * so keeping inline
                      */
                     ASSERT(LINKSTUB_INDIRECT(l->flags) ||
-                           TEST(LINK_SEPARATE_STUB, l->flags));
+                           TESTANY(LINK_SEPARATE_STUB, l->flags));
                 }
             });
 
@@ -406,7 +406,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
     SELF_PROTECT_CACHE(dcontext, NULL, WRITABLE);
 
     /* ensure some higher-level lock is held if f is shared */
-    ASSERT(!TEST(FRAG_SHARED, flags) || INTERNAL_OPTION(single_thread_in_DR) ||
+    ASSERT(!TESTANY(FRAG_SHARED, flags) || INTERNAL_OPTION(single_thread_in_DR) ||
            !USE_BB_BUILDING_LOCK() || OWN_MUTEX(&bb_building_lock) ||
            OWN_MUTEX(&trace_building_lock));
 
@@ -443,7 +443,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
         }
         if (instr_ok_to_emit(inst))
             offset += instr_length(dcontext, inst);
-        ASSERT_NOT_IMPLEMENTED(!TEST(INSTR_HOT_PATCHABLE, inst->flags));
+        ASSERT_NOT_IMPLEMENTED(!TESTANY(INSTR_HOT_PATCHABLE, inst->flags));
         if (instr_is_exit_cti(inst)) {
             target = instr_get_branch_target_pc(inst);
             len = exit_stub_size(dcontext, (cache_pc)target, flags);
@@ -476,7 +476,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
                 num_indirect_stubs++;
                 STATS_INC(num_indirect_exit_stubs);
                 LOG(THREAD, LOG_EMIT, 3, "emit_fragment: %s use ibl <" PFX ">\n",
-                    TEST(FRAG_IS_TRACE, flags) ? "trace" : "bb", target);
+                    TESTANY(FRAG_IS_TRACE, flags) ? "trace" : "bb", target);
                 stub_size_total += len;
                 STATS_FCACHE_ADD(flags, indirect_stubs, len);
             } else {
@@ -511,7 +511,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
 #endif
 
     DOSTATS({
-        if (!TEST(FRAG_IS_TRACE, flags)) {
+        if (!TESTANY(FRAG_IS_TRACE, flags)) {
             if (num_indirect_stubs > 0) {
                 if (num_indirect_stubs == 1 && num_direct_stubs == 0)
                     STATS_INC(num_bb_one_indirect_exit);
@@ -525,7 +525,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
                 else
                     STATS_INC(num_bb_many_direct_exits);
             }
-            if (TEST(FRAG_HAS_DIRECT_CTI, flags))
+            if (TESTANY(FRAG_HAS_DIRECT_CTI, flags))
                 STATS_INC(num_bb_has_elided);
             if (linkstub_frag_offs_at_end(flags, num_direct_stubs, num_indirect_stubs))
                 STATS_INC(num_bb_fragment_offset);
@@ -538,7 +538,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
     STATS_FCACHE_ADD(flags, bodies, offset);
     STATS_FCACHE_ADD(flags, prefixes, fragment_prefix_size(flags));
 
-    if (TEST(FRAG_SELFMOD_SANDBOXED, flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, flags)) {
         /* We need a copy of the original app code at bottom of
          * fragment.  We count it as part of the fragment body size,
          * and use a size field stored at the very end (whose storage
@@ -604,7 +604,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
 
     /* emit the exit stub code */
     for (l = FRAGMENT_EXIT_STUBS(f); l; l = LINKSTUB_NEXT_EXIT(l)) {
-        if (TEST(FRAG_COARSE_GRAIN, flags) && LINKSTUB_DIRECT(l->flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, flags) && LINKSTUB_DIRECT(l->flags)) {
             /* Coarse-grain fragments do not have direct exit stubs.
              * Instead they have entrance stubs, created when linking.
              */
@@ -618,7 +618,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
 
         if (final_cbr_single_stub && LINKSTUB_FINAL(l)) {
             no_stub = true;
-            if (!TEST(LINK_SEPARATE_STUB, l->flags)) {
+            if (!TESTANY(LINK_SEPARATE_STUB, l->flags)) {
                 /* still need to patch the cti, so set pc back to prev stub pc */
                 pc = prev_stub_pc;
             }
@@ -626,7 +626,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
                 prev_stub_pc);
         }
 
-        if (TEST(LINK_SEPARATE_STUB, l->flags)) {
+        if (TESTANY(LINK_SEPARATE_STUB, l->flags)) {
             if (no_stub) {
                 if (LINKSTUB_NORMAL_DIRECT(l->flags)) {
                     direct_linkstub_t *dl = (direct_linkstub_t *)l;
@@ -704,7 +704,7 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
         fcache_return_extra_space(dcontext, f, f->size - (pc - f->start_pc) - copy_sz);
     }
 
-    if (TEST(FRAG_SELFMOD_SANDBOXED, flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, flags)) {
         /* put copy of the original app code at bottom of fragment */
         cache_pc copy_pc;
 
@@ -761,8 +761,8 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
     vm_area_add_fragment(dcontext, f, vmlist);
 
     /* store translation info, if requested */
-    if (TEST(FRAG_HAS_TRANSLATION_INFO, f->flags)) {
-        ASSERT(!TEST(FRAG_COARSE_GRAIN, f->flags));
+    if (TESTANY(FRAG_HAS_TRANSLATION_INFO, f->flags)) {
+        ASSERT(!TESTANY(FRAG_COARSE_GRAIN, f->flags));
         fragment_record_translation_info(dcontext, f, ilist);
     }
 
@@ -794,13 +794,13 @@ emit_fragment_common(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist, uint 
     }
 
     if (add_to_htable) {
-        if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
             /* added in link_new_fragment */
         } else
             fragment_add(dcontext, f);
 
         DOCHECK(1, {
-            if (TEST(FRAG_SHARED, flags))
+            if (TESTANY(FRAG_SHARED, flags))
                 ASSERT(fragment_lookup_future(dcontext, tag) == NULL);
             else
                 ASSERT(fragment_lookup_private_future(dcontext, tag) == NULL);

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -156,7 +156,8 @@ typedef struct _live_header_t {
 
 /* NOTE this must be a multiple of START_PC_ALIGNMENT bytes so that the
  * start_pc is properly aligned (for -pad_jmps_shift_{bb,trace} support) */
-#define HEADER_SIZE(f) (TEST(FRAG_COARSE_GRAIN, (f)->flags) ? 0 : (sizeof(fragment_t *)))
+#define HEADER_SIZE(f) \
+    (TESTANY(FRAG_COARSE_GRAIN, (f)->flags) ? 0 : (sizeof(fragment_t *)))
 #define HEADER_SIZE_FROM_CACHE(cache) ((cache)->is_coarse ? 0 : (sizeof(fragment_t *)))
 
 /**************************************************
@@ -198,11 +199,11 @@ typedef struct _empty_slot_t {
 } empty_slot_t;
 
 /* macros to make dealing with both fragment_t and empty_slot_t easier */
-#define FRAG_EMPTY(f) (TEST(FRAG_IS_EMPTY_SLOT, (f)->flags))
+#define FRAG_EMPTY(f) (TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags))
 
-#define FRAG_START(f)                                                       \
-    (TEST(FRAG_IS_EMPTY_SLOT, (f)->flags) ? ((empty_slot_t *)(f))->start_pc \
-                                          : (f)->start_pc)
+#define FRAG_START(f)                                                          \
+    (TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags) ? ((empty_slot_t *)(f))->start_pc \
+                                             : (f)->start_pc)
 
 /* N.B.: must hold cache lock across any set of a fragment's start_pc or size
  * once that fragment is in a cache, as contig-cache-walkers need a consistent view!
@@ -210,7 +211,7 @@ typedef struct _empty_slot_t {
  */
 #define FRAG_START_ASSIGN(f, val)                    \
     do {                                             \
-        if (TEST(FRAG_IS_EMPTY_SLOT, (f)->flags))    \
+        if (TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags)) \
             ((empty_slot_t *)(f))->start_pc = (val); \
         else                                         \
             (f)->start_pc = (val);                   \
@@ -218,20 +219,20 @@ typedef struct _empty_slot_t {
 
 /* for -pad_jmps_shift_{bb,trace} we may have shifted the start_pc forward by up
  * to START_PC_ALIGNMENT-1 bytes, back align to get the right header pointer */
-#define FRAG_START_PADDING(f)                                                      \
-    ((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags) || !PAD_JMPS_SHIFT_START((f)->flags))   \
-         ? 0                                                                       \
-         : (ASSERT(CHECK_TRUNCATE_TYPE_uint(                                       \
-                (ptr_uint_t)((f)->start_pc -                                       \
-                             ALIGN_BACKWARD((f)->start_pc, START_PC_ALIGNMENT)))), \
-            (uint)((ptr_uint_t)(f)->start_pc -                                     \
+#define FRAG_START_PADDING(f)                                                       \
+    ((TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags) || !PAD_JMPS_SHIFT_START((f)->flags)) \
+         ? 0                                                                        \
+         : (ASSERT(CHECK_TRUNCATE_TYPE_uint(                                        \
+                (ptr_uint_t)((f)->start_pc -                                        \
+                             ALIGN_BACKWARD((f)->start_pc, START_PC_ALIGNMENT)))),  \
+            (uint)((ptr_uint_t)(f)->start_pc -                                      \
                    ALIGN_BACKWARD((f)->start_pc, START_PC_ALIGNMENT))))
 
 #define FRAG_HDR_START(f) (FRAG_START(f) - HEADER_SIZE(f) - FRAG_START_PADDING(f))
 
-#define FRAG_SIZE(f)                          \
-    ((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags))   \
-         ? ((empty_slot_t *)(f))->fcache_size \
+#define FRAG_SIZE(f)                           \
+    ((TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags)) \
+         ? ((empty_slot_t *)(f))->fcache_size  \
          : (f)->size + (uint)(f)->fcache_extra + FRAG_START_PADDING(f))
 
 /* N.B.: must hold cache lock across any set of a fragment's start_pc or size
@@ -240,7 +241,7 @@ typedef struct _empty_slot_t {
  */
 #define FRAG_SIZE_ASSIGN(f, val)                                            \
     do {                                                                    \
-        if (TEST(FRAG_IS_EMPTY_SLOT, (f)->flags)) {                         \
+        if (TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags)) {                      \
             ASSERT_TRUNCATE(((empty_slot_t *)(f))->fcache_size, uint, val); \
             ((empty_slot_t *)(f))->fcache_size = (val);                     \
         } else {                                                            \
@@ -251,56 +252,57 @@ typedef struct _empty_slot_t {
         }                                                                   \
     } while (0)
 
-#define FIFO_NEXT(f)                                \
-    ((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags))         \
-         ? ((empty_slot_t *)(f))->next_fcache       \
-         : (ASSERT(!TEST(FRAG_SHARED, (f)->flags)), \
+#define FIFO_NEXT(f)                                   \
+    ((TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags))         \
+         ? ((empty_slot_t *)(f))->next_fcache          \
+         : (ASSERT(!TESTANY(FRAG_SHARED, (f)->flags)), \
             ((private_fragment_t *)(f))->next_fcache))
 
 #define FIFO_NEXT_ASSIGN(f, val)                              \
     do {                                                      \
-        if (TEST(FRAG_IS_EMPTY_SLOT, (f)->flags))             \
+        if (TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags))          \
             ((empty_slot_t *)(f))->next_fcache = (val);       \
         else {                                                \
-            ASSERT(!TEST(FRAG_SHARED, (f)->flags));           \
+            ASSERT(!TESTANY(FRAG_SHARED, (f)->flags));        \
             ((private_fragment_t *)(f))->next_fcache = (val); \
         }                                                     \
     } while (0)
 
-#define FIFO_PREV(f)                                \
-    ((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags))         \
-         ? ((empty_slot_t *)(f))->prev_fcache       \
-         : (ASSERT(!TEST(FRAG_SHARED, (f)->flags)), \
+#define FIFO_PREV(f)                                   \
+    ((TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags))         \
+         ? ((empty_slot_t *)(f))->prev_fcache          \
+         : (ASSERT(!TESTANY(FRAG_SHARED, (f)->flags)), \
             ((private_fragment_t *)(f))->prev_fcache))
 
 #define FIFO_PREV_ASSIGN(f, val)                              \
     do {                                                      \
-        if (TEST(FRAG_IS_EMPTY_SLOT, (f)->flags))             \
+        if (TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags))          \
             ((empty_slot_t *)(f))->prev_fcache = (val);       \
         else {                                                \
-            ASSERT(!TEST(FRAG_SHARED, (f)->flags));           \
+            ASSERT(!TESTANY(FRAG_SHARED, (f)->flags));        \
             ((private_fragment_t *)(f))->prev_fcache = (val); \
         }                                                     \
     } while (0)
 
-#define FRAG_TAG(f) \
-    ((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags)) ? ((empty_slot_t *)(f))->start_pc : (f)->tag)
+#define FRAG_TAG(f)                                                              \
+    ((TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags)) ? ((empty_slot_t *)(f))->start_pc \
+                                               : (f)->tag)
 
 #ifdef DEBUG
-#    define FRAG_ID(f) ((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags)) ? -1 : (f)->id)
+#    define FRAG_ID(f) ((TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags)) ? -1 : (f)->id)
 #endif
 
-#define FIFO_UNIT(f)                                            \
-    (fcache_lookup_unit((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags))  \
-                            ? (((empty_slot_t *)(f))->start_pc) \
+#define FIFO_UNIT(f)                                              \
+    (fcache_lookup_unit((TESTANY(FRAG_IS_EMPTY_SLOT, (f)->flags)) \
+                            ? (((empty_slot_t *)(f))->start_pc)   \
                             : ((f)->start_pc)))
 
 /* Shared fragments do NOT use a FIFO as they cannot easily replace existing
  * fragments.  Instead they use a free list (below).
  */
-#define USE_FIFO(f) (!TEST(FRAG_SHARED, (f)->flags))
+#define USE_FIFO(f) (!TESTANY(FRAG_SHARED, (f)->flags))
 #define USE_FREE_LIST(f) \
-    (TEST(FRAG_SHARED, (f)->flags) && !TEST(FRAG_COARSE_GRAIN, (f)->flags))
+    (TESTANY(FRAG_SHARED, (f)->flags) && !TESTANY(FRAG_COARSE_GRAIN, (f)->flags))
 #define USE_FIFO_FOR_CACHE(c) (!(c)->is_shared)
 #define USE_FREE_LIST_FOR_CACHE(c) ((c)->is_shared && !(c)->is_coarse)
 
@@ -383,7 +385,7 @@ typedef struct _free_list_footer_t {
  * we're checking the next free list entry's flags by dereferencing, forcing a
  * check for NULL as well (== end of list).
  */
-#define FRAG_IS_FREE_LIST(f) ((f) == NULL || TEST(FRAG_FCACHE_FREE_LIST, (f)->flags))
+#define FRAG_IS_FREE_LIST(f) ((f) == NULL || TESTANY(FRAG_FCACHE_FREE_LIST, (f)->flags))
 
 /* De-references the fragment header stored at the start of the next
  * fcache slot, given a pc and a size for the current slot.
@@ -870,7 +872,7 @@ fcache_init(void)
         /* ensure flag in free list is at same spot as in fragment_t */
         static free_list_header_t free;
         free.flags = FRAG_FAKE | FRAG_FCACHE_FREE_LIST;
-        ASSERT(TEST(FRAG_FCACHE_FREE_LIST, ((fragment_t *)(&free))->flags));
+        ASSERT(TESTANY(FRAG_FCACHE_FREE_LIST, ((fragment_t *)(&free))->flags));
         /* ensure treating fragment_t* as next will work */
         ASSERT(offsetof(free_list_header_t, next) == offsetof(live_header_t, f));
     });
@@ -948,7 +950,7 @@ remove_unit_from_cache(fcache_unit_t *u)
 static void
 fcache_really_free_unit(fcache_unit_t *u, bool on_dead_list, bool dealloc_unit)
 {
-    if (TEST(SELFPROT_CACHE, dynamo_options.protect_mask) && !u->writable) {
+    if (TESTANY(SELFPROT_CACHE, dynamo_options.protect_mask) && !u->writable) {
         change_protection((void *)u->start_pc, u->size, WRITABLE);
     }
 #ifdef WINDOWS_PC_SAMPLE
@@ -1276,7 +1278,7 @@ void
 fcache_change_fragment_protection(dcontext_t *dcontext, fragment_t *f, bool writable)
 {
     fcache_unit_t *u;
-    ASSERT(TEST(SELFPROT_CACHE, dynamo_options.protect_mask));
+    ASSERT(TESTANY(SELFPROT_CACHE, dynamo_options.protect_mask));
     if (f != NULL) {
         u = fcache_lookup_unit(f->start_pc);
         ASSERT(u != NULL);
@@ -1563,15 +1565,15 @@ fcache_cache_init(dcontext_t *dcontext, uint flags, bool initial_unit)
         dcontext, sizeof(fcache_t) HEAPACCT(ACCT_MEM_MGT));
     cache->fifo = NULL;
     cache->size = 0;
-    cache->is_trace = TEST(FRAG_IS_TRACE, flags);
-    cache->is_shared = TEST(FRAG_SHARED, flags);
-    cache->is_coarse = TEST(FRAG_COARSE_GRAIN, flags);
+    cache->is_trace = TESTANY(FRAG_IS_TRACE, flags);
+    cache->is_shared = TESTANY(FRAG_SHARED, flags);
+    cache->is_coarse = TESTANY(FRAG_COARSE_GRAIN, flags);
     DODEBUG({ cache->is_local = false; });
     cache->coarse_info = NULL;
     DODEBUG({ cache->consistent = true; });
     if (cache->is_shared) {
         ASSERT(dcontext == GLOBAL_DCONTEXT);
-        if (TEST(FRAG_IS_TRACE, flags)) {
+        if (TESTANY(FRAG_IS_TRACE, flags)) {
             DODEBUG({ cache->name = "Trace (shared)"; });
             SET_CACHE_PARAMS(cache, shared_trace);
         } else if (cache->is_coarse) {
@@ -1583,7 +1585,7 @@ fcache_cache_init(dcontext_t *dcontext, uint flags, bool initial_unit)
         }
     } else {
         ASSERT(dcontext != GLOBAL_DCONTEXT);
-        if (TEST(FRAG_IS_TRACE, flags)) {
+        if (TESTANY(FRAG_IS_TRACE, flags)) {
             DODEBUG({ cache->name = "Trace (private)"; });
             SET_CACHE_PARAMS(cache, trace);
         } else {
@@ -1705,7 +1707,7 @@ fcache_free_list_consistency(dcontext_t *dcontext, fcache_t *cache, int bucket)
              * followed by a marked fragment_t.
              */
             ASSERT((!FRAG_IS_FREE_LIST(subseq) &&
-                    TEST(FRAG_FOLLOWS_FREE_ENTRY, subseq->flags)) ||
+                    TESTANY(FRAG_FOLLOWS_FREE_ENTRY, subseq->flags)) ||
                    /* ok to have subsequent free entry if unable to coalesce due
                     * to ushort size limits */
                    size + FRAG_NEXT_FREE(start_pc, header->size)->size >
@@ -1887,7 +1889,7 @@ fcache_shift_fragments(dcontext_t *dcontext, fcache_unit_t *unit, ssize_t shift,
              * fragment_shift_fcache_pointers re-relativized all outgoing
              * ctis by the shifted amount.
              */
-            if (TEST(FRAG_LINKED_INCOMING, f->flags)) {
+            if (TESTANY(FRAG_LINKED_INCOMING, f->flags)) {
                 unlink_fragment_incoming(dcontext, f);
                 link_fragment_incoming(dcontext, f, false /*not new*/);
             }
@@ -2154,11 +2156,11 @@ fragment_lookup_deleted(dcontext_t *dcontext, app_pc tag)
     if (SHARED_FRAGMENTS_ENABLED() && dcontext != GLOBAL_DCONTEXT) {
         fut = fragment_lookup_private_future(dcontext, tag);
         if (fut != NULL)
-            return TEST(FRAG_WAS_DELETED, fut->flags);
+            return TESTANY(FRAG_WAS_DELETED, fut->flags);
         /* if no private, lookup shared */
     }
     fut = fragment_lookup_future(dcontext, tag);
-    return (fut != NULL && TEST(FRAG_WAS_DELETED, fut->flags));
+    return (fut != NULL && TESTANY(FRAG_WAS_DELETED, fut->flags));
 }
 
 /* find a fragment that existed in the same type of cache */
@@ -2174,7 +2176,7 @@ fragment_lookup_cache_deleted(dcontext_t *dcontext, fcache_t *cache, app_pc tag)
         fut = fragment_lookup_private_future(dcontext, tag);
     } else
         fut = fragment_lookup_future(dcontext, tag);
-    if (fut != NULL && TEST(FRAG_WAS_DELETED, fut->flags))
+    if (fut != NULL && TESTANY(FRAG_WAS_DELETED, fut->flags))
         return fut;
     else
         return NULL;
@@ -2765,7 +2767,7 @@ removed_fragment_stats(dcontext_t *dcontext, fcache_t *cache, fragment_t *f)
         }
         stubs += sz;
     }
-    if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)) {
         /* we cannot go and re-decode the app bb now, since it may have been
          * changed (selfmod doesn't make page RO!), so we use a stored size
          * that's there just for stats
@@ -2818,7 +2820,7 @@ replace_fragments(dcontext_t *dcontext, fcache_t *cache, fcache_unit_t *unit,
     pc = FRAG_HDR_START(fifo);
     victim = fifo;
     while (true) {
-        if (TEST(FRAG_CANNOT_DELETE, victim->flags)) {
+        if (TESTANY(FRAG_CANNOT_DELETE, victim->flags)) {
             DODEBUG({ cache->consistent = true; });
             return false;
         }
@@ -3056,11 +3058,11 @@ add_to_free_list(dcontext_t *dcontext, fcache_t *cache, fcache_unit_t *unit,
             ASSERT(FIFO_UNIT(subseq) == unit);
             ASSERT(FRAG_HDR_START(subseq) == start_pc + size);
             /* can already be marked if we're called due to a split */
-            if (!TEST(FRAG_FOLLOWS_FREE_ENTRY, subseq->flags)) {
-                if (TEST(FRAG_SHARED, subseq->flags))
+            if (!TESTANY(FRAG_FOLLOWS_FREE_ENTRY, subseq->flags)) {
+                if (TESTANY(FRAG_SHARED, subseq->flags))
                     acquire_recursive_lock(&change_linking_lock);
                 subseq->flags |= FRAG_FOLLOWS_FREE_ENTRY;
-                if (TEST(FRAG_SHARED, subseq->flags))
+                if (TESTANY(FRAG_SHARED, subseq->flags))
                     release_recursive_lock(&change_linking_lock);
             }
         }
@@ -3068,7 +3070,7 @@ add_to_free_list(dcontext_t *dcontext, fcache_t *cache, fcache_unit_t *unit,
     /* If we're actually freeing a real fragment_t, we can coalesce with prev.
      * Other reasons to come here should never have a free entry in the prev slot.
      */
-    if (f != NULL && TEST(FRAG_FOLLOWS_FREE_ENTRY, f->flags)) {
+    if (f != NULL && TESTANY(FRAG_FOLLOWS_FREE_ENTRY, f->flags)) {
         /* coalesce with prev */
         free_list_footer_t *prev_footer =
             (free_list_footer_t *)(start_pc - sizeof(free_list_footer_t));
@@ -3253,11 +3255,11 @@ find_free_list_slot(dcontext_t *dcontext, fcache_t *cache, fragment_t *f, uint s
                     subseq->id, subseq->tag, subseq->start_pc);
                 ASSERT(FIFO_UNIT(subseq) == unit);
                 ASSERT(FRAG_HDR_START(subseq) == start_pc + free_size);
-                if (TEST(FRAG_SHARED, subseq->flags))
+                if (TESTANY(FRAG_SHARED, subseq->flags))
                     acquire_recursive_lock(&change_linking_lock);
-                ASSERT(TEST(FRAG_FOLLOWS_FREE_ENTRY, subseq->flags));
+                ASSERT(TESTANY(FRAG_FOLLOWS_FREE_ENTRY, subseq->flags));
                 subseq->flags &= ~FRAG_FOLLOWS_FREE_ENTRY;
-                if (TEST(FRAG_SHARED, subseq->flags))
+                if (TESTANY(FRAG_SHARED, subseq->flags))
                     release_recursive_lock(&change_linking_lock);
             } else {
                 /* shouldn't be free list entry following this one, unless
@@ -3399,7 +3401,7 @@ fcache_shift_start_pc(dcontext_t *dcontext, fragment_t *f, uint space)
     /* must hold cache lock across any set of a fragment's start_pc or size
      * once that fragment is in a cache, as contig-cache-walkers need a consistent view!
      */
-    if (TEST(FRAG_SHARED, f->flags)) {
+    if (TESTANY(FRAG_SHARED, f->flags)) {
         /* optimization: avoid unit lookup for private fragments.
          * this assumes that no cache lock is used for private fragments!
          */
@@ -3430,7 +3432,7 @@ fcache_shift_start_pc(dcontext_t *dcontext, fragment_t *f, uint space)
         }
     });
 
-    if (TEST(FRAG_SHARED, f->flags))
+    if (TESTANY(FRAG_SHARED, f->flags))
         PROTECT_CACHE(cache, unlock);
 }
 
@@ -3583,8 +3585,8 @@ get_cache_for_new_fragment(dcontext_t *dcontext, fragment_t *f)
 {
     fcache_thread_units_t *tu = (fcache_thread_units_t *)dcontext->fcache_field;
     fcache_t *cache = NULL;
-    if (TEST(FRAG_SHARED, f->flags)) {
-        if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    if (TESTANY(FRAG_SHARED, f->flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
             /* new fragment must be targeting the one non-frozen unit */
             coarse_info_t *info = get_executable_area_coarse_info(f->tag);
             ASSERT(info != NULL);
@@ -3702,7 +3704,7 @@ fcache_remove_fragment(dcontext_t *dcontext, fragment_t *f)
 
     /* should only be deleted through proper synched channels */
     ASSERT(dcontext != GLOBAL_DCONTEXT || dynamo_exited || dynamo_resetting ||
-           TEST(FRAG_WAS_DELETED, f->flags) || is_self_allsynch_flushing());
+           TESTANY(FRAG_WAS_DELETED, f->flags) || is_self_allsynch_flushing());
     PROTECT_CACHE(cache, lock);
 
     LOG(THREAD, LOG_CACHE, 4, "fcache_remove_fragment: F%d from %s unit\n", f->id,
@@ -3850,8 +3852,8 @@ chain_fragments_for_flush(dcontext_t *dcontext, fcache_unit_t *unit, fragment_t 
         ASSERT(f != NULL);
         ASSERT(FIFO_UNIT(f) == unit);
         ASSERT(FRAG_HDR_START(f) == pc);
-        ASSERT(!TEST(FRAG_CANNOT_DELETE, f->flags));
-        if (TEST(FRAG_WAS_DELETED, f->flags)) {
+        ASSERT(!TESTANY(FRAG_CANNOT_DELETE, f->flags));
+        if (TESTANY(FRAG_WAS_DELETED, f->flags)) {
             /* must be a consistency-flushed or lazily deleted fragment.
              * while typically it will be deleted before the other fragments
              * in this unit (since flushtime now is < ours, and lazy are deleted
@@ -4217,7 +4219,7 @@ fcache_reset_all_caches_proactively(uint target)
     ASSERT(OWN_MUTEX(&all_threads_synch_lock) && OWN_MUTEX(&thread_initexit_lock));
     STATS_INC(fcache_reset_proactively);
     DOSTATS({
-        if (TEST(RESET_PENDING_DELETION, target))
+        if (TESTANY(RESET_PENDING_DELETION, target))
             STATS_INC(fcache_reset_pending_del);
     });
 
@@ -4440,7 +4442,7 @@ fcache_reset_cache(dcontext_t *dcontext, fcache_t *cache)
              * Should do an analysis and see if we ever use it anymore.
              * It is a powerful feature to support, but also a limiting one...
              */
-            if (TEST(FRAG_CANNOT_DELETE, f->flags)) {
+            if (TESTANY(FRAG_CANNOT_DELETE, f->flags)) {
                 unit_empty = false;
                 /* XXX: this allocates memory for the empty_slot_t data struct! */
                 fifo_prepend_empty(dcontext, cache, u, NULL, last_pc, pc - last_pc);

--- a/core/fcache.h
+++ b/core/fcache.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -47,18 +47,18 @@
  * perf hit in speccpu of having separate priv bb cache that's not
  * normally used)
  */
-#define IN_TRACE_CACHE(flags)        \
-    (TEST(FRAG_IS_TRACE, (flags)) || \
-     (!DYNAMO_OPTION(shared_traces) && TEST(FRAG_TEMP_PRIVATE, (flags))))
+#define IN_TRACE_CACHE(flags)           \
+    (TESTANY(FRAG_IS_TRACE, (flags)) || \
+     (!DYNAMO_OPTION(shared_traces) && TESTANY(FRAG_TEMP_PRIVATE, (flags))))
 
 /* Case 8647: we don't need to pad jmps for coarse-grain bbs */
 #define PAD_FRAGMENT_JMPS(flags) \
-    (TEST(FRAG_COARSE_GRAIN, (flags)) ? false : DYNAMO_OPTION(pad_jmps))
+    (TESTANY(FRAG_COARSE_GRAIN, (flags)) ? false : DYNAMO_OPTION(pad_jmps))
 
-#define PAD_JMPS_SHIFT_START(flags)                                              \
-    (PAD_FRAGMENT_JMPS(flags)                                                    \
-         ? (TEST(FRAG_IS_TRACE, (flags)) ? INTERNAL_OPTION(pad_jmps_shift_trace) \
-                                         : INTERNAL_OPTION(pad_jmps_shift_bb))   \
+#define PAD_JMPS_SHIFT_START(flags)                                                 \
+    (PAD_FRAGMENT_JMPS(flags)                                                       \
+         ? (TESTANY(FRAG_IS_TRACE, (flags)) ? INTERNAL_OPTION(pad_jmps_shift_trace) \
+                                            : INTERNAL_OPTION(pad_jmps_shift_bb))   \
          : false)
 
 /* control over what to reset */
@@ -143,11 +143,11 @@ fcache_low_on_memory(void);
 
 /* macros to put mask check outside of function, for efficiency */
 /* when NULL is passed for f then the entire fcache will be affected */
-#define SELF_PROTECT_CACHE(dc, f, w)                             \
-    do {                                                         \
-        if (TEST(SELFPROT_CACHE, dynamo_options.protect_mask) && \
-            ((f) == NULL || (fcache_is_writable(f) != (w))))     \
-            fcache_change_fragment_protection(dc, f, w);         \
+#define SELF_PROTECT_CACHE(dc, f, w)                                \
+    do {                                                            \
+        if (TESTANY(SELFPROT_CACHE, dynamo_options.protect_mask) && \
+            ((f) == NULL || (fcache_is_writable(f) != (w))))        \
+            fcache_change_fragment_protection(dc, f, w);            \
     } while (0);
 
 bool

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -222,18 +222,18 @@ static const fragment_t unlinked_fragment = {
     (!TABLE_NEEDS_LOCK(ptable) || READWRITE_LOCK_HELD(&(ptable)->rwlock))
 
 /* everything except the invisible table is in here */
-#define GET_FTABLE_HELPER(pt, flags, otherwise)                               \
-    (TEST(FRAG_IS_TRACE, (flags))                                             \
-         ? (TEST(FRAG_SHARED, (flags)) ? shared_trace : &pt->trace)           \
-         : (TEST(FRAG_SHARED, (flags))                                        \
-                ? (TEST(FRAG_IS_FUTURE, (flags)) ? shared_future : shared_bb) \
-                : (TEST(FRAG_IS_FUTURE, (flags)) ? &pt->future : (otherwise))))
+#define GET_FTABLE_HELPER(pt, flags, otherwise)                                  \
+    (TESTANY(FRAG_IS_TRACE, (flags))                                             \
+         ? (TESTANY(FRAG_SHARED, (flags)) ? shared_trace : &pt->trace)           \
+         : (TESTANY(FRAG_SHARED, (flags))                                        \
+                ? (TESTANY(FRAG_IS_FUTURE, (flags)) ? shared_future : shared_bb) \
+                : (TESTANY(FRAG_IS_FUTURE, (flags)) ? &pt->future : (otherwise))))
 
 #define GET_FTABLE(pt, flags) GET_FTABLE_HELPER(pt, (flags), &pt->bb)
 
 /* indirect branch table per target type (bb vs trace) and indirect branch type */
 #define GET_IBT_TABLE(pt, flags, branch_type)                                       \
-    (TEST(FRAG_IS_TRACE, (flags))                                                   \
+    (TESTANY(FRAG_IS_TRACE, (flags))                                                \
          ? (DYNAMO_OPTION(shared_trace_ibt_tables)                                  \
                 ? &shared_pt->trace_ibt[(branch_type)]                              \
                 : &(pt)->trace_ibt[(branch_type)])                                  \
@@ -268,8 +268,8 @@ output_trace(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
 static void
 init_trace_file(per_thread_t *pt);
 
-#define SHOULD_OUTPUT_FRAGMENT(flags)                                     \
-    (TEST(FRAG_IS_TRACE, (flags)) && !TEST(FRAG_TRACE_OUTPUT, (flags)) && \
+#define SHOULD_OUTPUT_FRAGMENT(flags)                                           \
+    (TESTANY(FRAG_IS_TRACE, (flags)) && !TESTANY(FRAG_TRACE_OUTPUT, (flags)) && \
      TRACEDUMP_ENABLED())
 
 #define FRAGMENT_COARSE_WRAPPER_FLAGS                                    \
@@ -721,16 +721,16 @@ hashtable_ibl_init_internal_custom(dcontext_t *dcontext, ibl_table_t *table)
     ASSERT(sentinel_fragment.start_pc == HASHLOOKUP_SENTINEL_START_PC);
     ASSERT(HASHLOOKUP_SENTINEL_START_PC != HASHLOOKUP_NULL_START_PC);
 
-    ASSERT(TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags));
-    ASSERT(TEST(FRAG_TABLE_INCLUSIVE_HIERARCHY, table->table_flags));
+    ASSERT(TESTANY(FRAG_TABLE_IBL_TARGETED, table->table_flags));
+    ASSERT(TESTANY(FRAG_TABLE_INCLUSIVE_HIERARCHY, table->table_flags));
 
     /* every time we resize a table we reset the flush threshold,
      * since it is cleared in place after one flush
      */
-    table->groom_factor_percent = TEST(FRAG_TABLE_TRACE, table->table_flags)
+    table->groom_factor_percent = TESTANY(FRAG_TABLE_TRACE, table->table_flags)
         ? DYNAMO_OPTION(trace_ibt_groom)
         : DYNAMO_OPTION(bb_ibt_groom);
-    table->max_capacity_bits = TEST(FRAG_TABLE_TRACE, table->table_flags)
+    table->max_capacity_bits = TESTANY(FRAG_TABLE_TRACE, table->table_flags)
         ? DYNAMO_OPTION(private_trace_ibl_targets_max)
         : DYNAMO_OPTION(private_bb_ibl_targets_max);
 
@@ -743,16 +743,17 @@ hashtable_ibl_init_internal_custom(dcontext_t *dcontext, ibl_table_t *table)
     }
 #endif /* HASHTABLE_STATISTICS */
 
-    if (SHARED_IB_TARGETS() && !TEST(FRAG_TABLE_SHARED, table->table_flags)) {
+    if (SHARED_IB_TARGETS() && !TESTANY(FRAG_TABLE_SHARED, table->table_flags)) {
         /* currently we don't support a mixture */
-        ASSERT(TEST(FRAG_TABLE_TARGET_SHARED, table->table_flags));
-        ASSERT(TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags));
+        ASSERT(TESTANY(FRAG_TABLE_TARGET_SHARED, table->table_flags));
+        ASSERT(TESTANY(FRAG_TABLE_IBL_TARGETED, table->table_flags));
         ASSERT(table->branch_type != IBL_NONE);
         /* Only data for one set of tables is stored in TLS -- for the trace
          * tables in the default config OR the BB tables in shared BBs
          * only mode.
          */
-        if ((TEST(FRAG_TABLE_TRACE, table->table_flags) || SHARED_BB_ONLY_IB_TARGETS()) &&
+        if ((TESTANY(FRAG_TABLE_TRACE, table->table_flags) ||
+             SHARED_BB_ONLY_IB_TARGETS()) &&
             DYNAMO_OPTION(ibl_table_in_tls))
             update_lookuptable_tls(dcontext, table);
     }
@@ -766,7 +767,7 @@ hashtable_ibl_myinit(dcontext_t *dcontext, ibl_table_t *table, uint bits,
                      uint table_flags _IF_DEBUG(const char *table_name))
 {
     uint flags = table_flags;
-    ASSERT(dcontext != GLOBAL_DCONTEXT || TEST(FRAG_TABLE_SHARED, flags));
+    ASSERT(dcontext != GLOBAL_DCONTEXT || TESTANY(FRAG_TABLE_SHARED, flags));
     /* flags shared by all ibl tables */
     flags |= FRAG_TABLE_INCLUSIVE_HIERARCHY;
     flags |= FRAG_TABLE_IBL_TARGETED;
@@ -813,7 +814,7 @@ hashtable_ibl_myfree(dcontext_t *dcontext, ibl_table_t *table)
 {
 #ifdef HASHTABLE_STATISTICS
     if (INTERNAL_OPTION(hashtable_ibl_stats)) {
-        ASSERT(TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags));
+        ASSERT(TESTANY(FRAG_TABLE_IBL_TARGETED, table->table_flags));
         DEALLOC_UNPROT_STATS(dcontext, table);
     }
 #endif /* HASHTABLE_STATISTICS */
@@ -824,10 +825,10 @@ static void
 hashtable_fragment_free_entry(dcontext_t *dcontext, fragment_table_t *table,
                               fragment_t *f)
 {
-    if (TEST(FRAG_TABLE_INCLUSIVE_HIERARCHY, table->table_flags)) {
+    if (TESTANY(FRAG_TABLE_INCLUSIVE_HIERARCHY, table->table_flags)) {
         ASSERT_NOT_REACHED(); /* case 7691 */
     } else {
-        if (TEST(FRAG_IS_FUTURE, f->flags))
+        if (TESTANY(FRAG_IS_FUTURE, f->flags))
             fragment_free_future(dcontext, (future_fragment_t *)f);
         else
             fragment_free(dcontext, f);
@@ -856,9 +857,9 @@ fragment_add_to_hashtable(dcontext_t *dcontext, fragment_t *e, fragment_table_t 
      * thread in the process.
      */
     DOCHECK(1, {
-        if (TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags) &&
+        if (TESTANY(FRAG_TABLE_IBL_TARGETED, table->table_flags) &&
             d_r_get_num_threads() == 1)
-            ASSERT(!TEST(FRAG_IS_TRACE_HEAD, e->flags));
+            ASSERT(!TESTANY(FRAG_IS_TRACE_HEAD, e->flags));
     });
 
     return hashtable_fragment_add(dcontext, e, table);
@@ -995,7 +996,7 @@ hashtable_ibl_resized_custom(dcontext_t *dcontext, ibl_table_t *table, uint old_
     per_thread_t *pt = GET_PT(dcontext);
     bool shared_ibt_table =
         TESTALL(FRAG_TABLE_TARGET_SHARED | FRAG_TABLE_SHARED, table->table_flags);
-    ASSERT(TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags));
+    ASSERT(TESTANY(FRAG_TABLE_IBL_TARGETED, table->table_flags));
 
     /* If we change an ibl-targeted table, must patch up every
      * inlined indirect exit stub that targets it.
@@ -1049,11 +1050,11 @@ hashtable_ibl_resized_custom(dcontext_t *dcontext, ibl_table_t *table, uint old_
                                    old_ref_count, table->table_flags);
         }
         /* Update the resizing thread's private ptr. */
-        update_private_ptr_to_shared_ibt_table(dcontext, table->branch_type,
-                                               TEST(FRAG_TABLE_TRACE, table->table_flags),
-                                               false, /* no adjust
-                                                       * old ref-count */
-                                               false /* already hold lock */);
+        update_private_ptr_to_shared_ibt_table(
+            dcontext, table->branch_type, TESTANY(FRAG_TABLE_TRACE, table->table_flags),
+            false, /* no adjust
+                    * old ref-count */
+            false /* already hold lock */);
         ASSERT(table->ref_count == 1);
     }
 
@@ -1076,7 +1077,7 @@ hashtable_ibl_study_custom(dcontext_t *dcontext, ibl_table_t *table,
 {
 #    ifdef HASHTABLE_STATISTICS
     /* For trace table(s) only, use stats from emitted ibl routines */
-    if (TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags) &&
+    if (TESTANY(FRAG_TABLE_IBL_TARGETED, table->table_flags) &&
         INTERNAL_OPTION(hashtable_ibl_stats)) {
         per_thread_t *pt = GET_PT(dcontext);
         ibl_branch_type_t branch_type;
@@ -1122,12 +1123,12 @@ hashtable_fragment_reset(dcontext_t *dcontext, fragment_table_t *table)
     fragment_t *f;
 
     /* case 7691: we now use separate ibl table types */
-    ASSERT(!TEST(FRAG_TABLE_INCLUSIVE_HIERARCHY, table->table_flags));
+    ASSERT(!TESTANY(FRAG_TABLE_INCLUSIVE_HIERARCHY, table->table_flags));
     LOG(THREAD, LOG_FRAGMENT, 2, "hashtable_fragment_reset\n");
     DOLOG(1, LOG_FRAGMENT | LOG_STATS,
           { hashtable_fragment_load_statistics(dcontext, table); });
-    if (TEST(FRAG_TABLE_SHARED, table->table_flags) &&
-        TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags)) {
+    if (TESTANY(FRAG_TABLE_SHARED, table->table_flags) &&
+        TESTANY(FRAG_TABLE_IBL_TARGETED, table->table_flags)) {
         DOLOG(5, LOG_FRAGMENT, { hashtable_fragment_dump_table(dcontext, table); });
     }
     DODEBUG({
@@ -1178,7 +1179,7 @@ hashtable_fragment_reset(dcontext_t *dcontext, fragment_table_t *table)
              * if shared traces is false so we don't need to conditionalize
              * the assert.
              */
-            ASSERT(!TEST(FRAG_TRACE_BUILDING, f->flags));
+            ASSERT(!TESTANY(FRAG_TRACE_BUILDING, f->flags));
             hashtable_fragment_remove_helper(table, i, &table->table[i]);
             if (!REAL_FRAGMENT(f))
                 continue;
@@ -1187,9 +1188,9 @@ hashtable_fragment_reset(dcontext_t *dcontext, fragment_table_t *table)
              * the per-thread IBL tables contain pointers to shared fragments
              * and are OK
              */
-            ASSERT(dynamo_exited || !TEST(FRAG_SHARED, f->flags) || dynamo_resetting);
+            ASSERT(dynamo_exited || !TESTANY(FRAG_SHARED, f->flags) || dynamo_resetting);
 
-            if (TEST(FRAG_IS_FUTURE, f->flags)) {
+            if (TESTANY(FRAG_IS_FUTURE, f->flags)) {
                 DODEBUG({ ((future_fragment_t *)f)->incoming_stubs = NULL; });
                 fragment_free_future(dcontext, (future_fragment_t *)f);
             } else {
@@ -1632,8 +1633,8 @@ fragment_exit(void)
      * would just have to build them all back up again in order to
      * continue execution
      */
-    if ((TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-         TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) &&
+    if ((TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+         TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) &&
         rct_global_table.live_table != NULL) {
         DODEBUG({
             DOLOG(1, LOG_FRAGMENT | LOG_STATS, {
@@ -1731,7 +1732,7 @@ dec_table_ref_count(dcontext_t *dcontext, ibl_table_t *table, bool could_be_live
              * during the compare and hold the lock during the ref-count dec to
              * prevent a race with it being moved to the dead list.
              */
-            ibl_table_t *sh_table_ptr = TEST(FRAG_TABLE_TRACE, table->table_flags)
+            ibl_table_t *sh_table_ptr = TESTANY(FRAG_TABLE_TRACE, table->table_flags)
                 ? &shared_pt->trace_ibt[branch_type]
                 : &shared_pt->bb_ibt[branch_type];
             TABLE_RWLOCK(sh_table_ptr, write, lock);
@@ -2225,7 +2226,7 @@ static uint
 fragment_heap_size(uint flags, int direct_exits, int indirect_exits)
 {
     uint total_sz;
-    ASSERT((direct_exits + indirect_exits > 0) || TEST(FRAG_COARSE_GRAIN, flags));
+    ASSERT((direct_exits + indirect_exits > 0) || TESTANY(FRAG_COARSE_GRAIN, flags));
     total_sz = FRAGMENT_STRUCT_SIZE(flags) +
         linkstubs_heap_size(flags, direct_exits, indirect_exits);
     /* we rely on a small heap size for our ushort offset at the end */
@@ -2245,7 +2246,7 @@ fragment_create_heap(dcontext_t *dcontext, int direct_exits, int indirect_exits,
     /* linkstubs are in an array immediately after the fragment_t/trace_t struct */
     fragment_t *f = (fragment_t *)nonpersistent_heap_alloc(
         alloc_dc,
-        heapsz HEAPACCT(TEST(FRAG_IS_TRACE, flags) ? ACCT_TRACE : ACCT_FRAGMENT));
+        heapsz HEAPACCT(TESTANY(FRAG_IS_TRACE, flags) ? ACCT_TRACE : ACCT_FRAGMENT));
     LOG(THREAD, LOG_FRAGMENT, 5,
         "fragment heap size for flags 0x%08x, exits %d %d, is %d => " PFX "\n", flags,
         direct_exits, indirect_exits, heapsz, f);
@@ -2284,7 +2285,7 @@ fragment_init_heap(fragment_t *f, app_pc tag, int direct_exits, int indirect_exi
 #endif
 
     /* trace-only fields */
-    if (TEST(FRAG_IS_TRACE, flags)) {
+    if (TESTANY(FRAG_IS_TRACE, flags)) {
         trace_only_t *t = TRACE_FIELDS(f);
         t->bbs = NULL;
         /* real num_bbs won't be set until after the trace is emitted,
@@ -2321,11 +2322,11 @@ fragment_create(dcontext_t *dcontext, app_pc tag, int body_size, int direct_exit
     /* ensure no races during a reset */
     ASSERT(!dynamo_resetting);
 
-    if (TEST(FRAG_COARSE_GRAIN, flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, flags)) {
         ASSERT(DYNAMO_OPTION(coarse_units));
         ASSERT_OWN_MUTEX(USE_BB_BUILDING_LOCK(), &bb_building_lock);
-        ASSERT(!TEST(FRAG_IS_TRACE, flags));
-        ASSERT(TEST(FRAG_SHARED, flags));
+        ASSERT(!TESTANY(FRAG_IS_TRACE, flags));
+        ASSERT(TESTANY(FRAG_SHARED, flags));
         ASSERT(fragment_prefix_size(flags) == 0);
         ASSERT((direct_exits == 0 && indirect_exits == 1) ||
                (indirect_exits == 0 && (direct_exits == 1 || direct_exits == 2)));
@@ -2357,14 +2358,14 @@ fragment_create(dcontext_t *dcontext, app_pc tag, int body_size, int direct_exit
     IF_X64(ASSERT_TRUNCATE(f->id, int, next_id));
     DOSTATS({ f->id = (int)next_id; });
     DO_GLOBAL_STATS({
-        if (!TEST(FRAG_IS_TRACE, f->flags)) {
+        if (!TESTANY(FRAG_IS_TRACE, f->flags)) {
             RSTATS_INC(num_bbs);
             IF_X64(if (FRAG_IS_32(f->flags)) { STATS_INC(num_32bit_bbs); })
         }
     });
     DOSTATS({
         /* avoid double-counting for adaptive working set */
-        if (!fragment_lookup_deleted(dcontext, tag) && !TEST(FRAG_COARSE_GRAIN, flags))
+        if (!fragment_lookup_deleted(dcontext, tag) && !TESTANY(FRAG_COARSE_GRAIN, flags))
             STATS_INC(num_unique_fragments);
     });
     if (GLOBAL_STATS_ON() &&
@@ -2406,11 +2407,11 @@ fragment_create(dcontext_t *dcontext, app_pc tag, int body_size, int direct_exit
 
     /* after fcache_add_fragment so we can call get_fragment_coarse_info */
     DOSTATS({
-        if (TEST(FRAG_SHARED, flags)) {
+        if (TESTANY(FRAG_SHARED, flags)) {
             STATS_INC(num_shared_fragments);
-            if (TEST(FRAG_IS_TRACE, flags))
+            if (TESTANY(FRAG_IS_TRACE, flags))
                 STATS_INC(num_shared_traces);
-            else if (TEST(FRAG_COARSE_GRAIN, flags)) {
+            else if (TESTANY(FRAG_COARSE_GRAIN, flags)) {
                 coarse_info_t *info = get_fragment_coarse_info(f);
                 if (get_executable_area_coarse_info(f->tag) != info)
                     STATS_INC(num_coarse_secondary);
@@ -2419,7 +2420,7 @@ fragment_create(dcontext_t *dcontext, app_pc tag, int body_size, int direct_exit
                 STATS_INC(num_shared_bbs);
         } else {
             STATS_INC(num_private_fragments);
-            if (TEST(FRAG_IS_TRACE, flags))
+            if (TESTANY(FRAG_IS_TRACE, flags))
                 STATS_INC(num_private_traces);
             else
                 STATS_INC(num_private_bbs);
@@ -2481,7 +2482,7 @@ fragment_recreate_with_linkstubs(dcontext_t *dcontext, fragment_t *f_src)
      * slot -- need to mark that?
      */
     uint flags = (f_src->flags & ~FRAG_FAKE);
-    ASSERT_CURIOSITY(TEST(FRAG_COARSE_GRAIN, f_src->flags)); /* only use so far */
+    ASSERT_CURIOSITY(TESTANY(FRAG_COARSE_GRAIN, f_src->flags)); /* only use so far */
     /* XXX case 9325: build from tag here?  Need to exactly re-mangle + re-instrument.
      * We use _exact to get any elided final jmp not counted in size
      */
@@ -2504,10 +2505,10 @@ fragment_recreate_with_linkstubs(dcontext_t *dcontext, fragment_t *f_src)
     }
     ASSERT_TRUNCATE(f_tgt->size, ushort, size);
     f_tgt->size = (ushort)size;
-    ASSERT(TEST(FRAG_FAKE, f_src->flags) || size == f_src->size);
+    ASSERT(TESTANY(FRAG_FAKE, f_src->flags) || size == f_src->size);
     ASSERT_TRUNCATE(f_tgt->prefix_size, byte, fragment_prefix_size(f_src->flags));
     f_tgt->prefix_size = (byte)fragment_prefix_size(f_src->flags);
-    ASSERT(TEST(FRAG_FAKE, f_src->flags) || f_src->prefix_size == f_tgt->prefix_size);
+    ASSERT(TESTANY(FRAG_FAKE, f_src->flags) || f_src->prefix_size == f_tgt->prefix_size);
     f_tgt->fcache_extra = f_src->fcache_extra;
 
     instrlist_clear_and_destroy(dcontext, ilist);
@@ -2568,7 +2569,7 @@ fragment_free(dcontext_t *dcontext, fragment_t *f)
 cache_pc
 fragment_stubs_end_pc(fragment_t *f)
 {
-    if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags))
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags))
         return FRAGMENT_SELFMOD_COPY_PC(f);
     else
         return f->start_pc + f->size;
@@ -2625,14 +2626,14 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
     fragment_t *f;
 
     LOG(THREAD, LOG_MONITOR, 6, "fragment_lookup_type " PFX " 0x%x\n", tag, lookup_flags);
-    if (dcontext != GLOBAL_DCONTEXT && TEST(LOOKUP_PRIVATE, lookup_flags)) {
+    if (dcontext != GLOBAL_DCONTEXT && TESTANY(LOOKUP_PRIVATE, lookup_flags)) {
         /* XXX: add a hashtablex.h wrapper that checks #entries and
          * grabs lock for us for all lookups?
          */
         /* look at private tables */
         per_thread_t *pt = (per_thread_t *)dcontext->fragment_field;
         /* case 147: traces take precedence over bbs */
-        if (PRIVATE_TRACES_ENABLED() && TEST(LOOKUP_TRACE, lookup_flags)) {
+        if (PRIVATE_TRACES_ENABLED() && TESTANY(LOOKUP_TRACE, lookup_flags)) {
             /* now try trace table */
             f = hashtable_fragment_lookup(dcontext, (ptr_uint_t)tag, &pt->trace);
             if (f->tag != NULL) {
@@ -2652,7 +2653,7 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
                 return f;
             }
         }
-        if (TEST(LOOKUP_BB, lookup_flags) && pt->bb.entries > 0) {
+        if (TESTANY(LOOKUP_BB, lookup_flags) && pt->bb.entries > 0) {
             /* basic block table last */
             f = hashtable_fragment_lookup(dcontext, (ptr_uint_t)tag, &pt->bb);
             if (f->tag != NULL) {
@@ -2667,7 +2668,7 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
                         sf = hashtable_fragment_lookup(dcontext, (ptr_uint_t)tag,
                                                        shared_bb);
                         d_r_read_unlock(&shared_bb->rwlock);
-                        ASSERT(sf->tag == NULL || TEST(FRAG_TEMP_PRIVATE, f->flags));
+                        ASSERT(sf->tag == NULL || TESTANY(FRAG_TEMP_PRIVATE, f->flags));
                     }
                 });
                 ASSERT(!TESTANY(FRAG_FAKE | FRAG_COARSE_GRAIN, f->flags));
@@ -2676,8 +2677,8 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
         }
     }
 
-    if (TEST(LOOKUP_SHARED, lookup_flags)) {
-        if (DYNAMO_OPTION(shared_traces) && TEST(LOOKUP_TRACE, lookup_flags)) {
+    if (TESTANY(LOOKUP_SHARED, lookup_flags)) {
+        if (DYNAMO_OPTION(shared_traces) && TESTANY(LOOKUP_TRACE, lookup_flags)) {
             /* MUST look at shared trace table before shared bb table,
              * since a shared trace can shadow a shared trace head
              */
@@ -2691,7 +2692,7 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
             }
         }
 
-        if (DYNAMO_OPTION(shared_bbs) && TEST(LOOKUP_BB, lookup_flags)) {
+        if (DYNAMO_OPTION(shared_bbs) && TESTANY(LOOKUP_BB, lookup_flags)) {
             /* MUST look at private trace table before shared bb table,
              * since a private trace can shadow a shared trace head
              */
@@ -2756,7 +2757,7 @@ fragment_lookup_same_sharing(dcontext_t *dcontext, app_pc tag, uint flags)
     return fragment_lookup_type(
         dcontext, tag,
         LOOKUP_TRACE | LOOKUP_BB |
-            (TEST(FRAG_SHARED, flags) ? LOOKUP_SHARED : LOOKUP_PRIVATE));
+            (TESTANY(FRAG_SHARED, flags) ? LOOKUP_SHARED : LOOKUP_PRIVATE));
 }
 
 #ifdef DEBUG /*currently only used for debugging */
@@ -2884,7 +2885,7 @@ fragment_pclookup_with_linkstubs(dcontext_t *dcontext, cache_pc pc,
     fragment_t wrapper;
     fragment_t *f = fragment_pclookup(dcontext, pc, &wrapper);
     ASSERT(alloc != NULL);
-    if (f != NULL && TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    if (f != NULL && TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
         ASSERT(f == &wrapper);
         f = fragment_recreate_with_linkstubs(dcontext, f);
         *alloc = true;
@@ -2900,22 +2901,23 @@ fragment_add(dcontext_t *dcontext, fragment_t *f)
     per_thread_t *pt = (per_thread_t *)dcontext->fragment_field;
     fragment_table_t *table = GET_FTABLE(pt, f->flags);
     /* no future frags! */
-    ASSERT(!TEST(FRAG_IS_FUTURE, f->flags));
+    ASSERT(!TESTANY(FRAG_IS_FUTURE, f->flags));
 
     DOCHECK(1, {
         fragment_t *existing = fragment_lookup(dcontext, f->tag);
-        ASSERT(existing == NULL ||
-               /* For custom traces, we create and persist shadowed trace heads. */
-               TEST(FRAG_IS_TRACE_HEAD, f->flags) ||
-               TEST(FRAG_IS_TRACE_HEAD, existing->flags) ||
-               /* private trace or temp can shadow shared bb */
-               (TESTANY(FRAG_IS_TRACE | FRAG_TEMP_PRIVATE, f->flags) &&
-                TEST(FRAG_SHARED, f->flags) != TEST(FRAG_SHARED, existing->flags)) ||
-               /* shared trace can shadow shared trace head, even with
-                * -remove_shared_trace_heads */
-               (TESTALL(FRAG_IS_TRACE | FRAG_SHARED, f->flags) &&
-                !TEST(FRAG_IS_TRACE, existing->flags) &&
-                TESTALL(FRAG_SHARED | FRAG_IS_TRACE_HEAD, existing->flags)));
+        ASSERT(
+            existing == NULL ||
+            /* For custom traces, we create and persist shadowed trace heads. */
+            TESTANY(FRAG_IS_TRACE_HEAD, f->flags) ||
+            TESTANY(FRAG_IS_TRACE_HEAD, existing->flags) ||
+            /* private trace or temp can shadow shared bb */
+            (TESTANY(FRAG_IS_TRACE | FRAG_TEMP_PRIVATE, f->flags) &&
+             TESTANY(FRAG_SHARED, f->flags) != TESTANY(FRAG_SHARED, existing->flags)) ||
+            /* shared trace can shadow shared trace head, even with
+             * -remove_shared_trace_heads */
+            (TESTALL(FRAG_IS_TRACE | FRAG_SHARED, f->flags) &&
+             !TESTANY(FRAG_IS_TRACE, existing->flags) &&
+             TESTALL(FRAG_SHARED | FRAG_IS_TRACE_HEAD, existing->flags)));
     });
 
     /* We'd like the shared fragment table synch to be independent of the
@@ -2942,7 +2944,7 @@ fragment_add(dcontext_t *dcontext, fragment_t *f)
 
 #ifdef SHARING_STUDY
     if (INTERNAL_OPTION(fragment_sharing_study)) {
-        if (TEST(FRAG_IS_TRACE, f->flags))
+        if (TESTANY(FRAG_IS_TRACE, f->flags))
             add_shared_block(shared_traces, &shared_traces_lock, f);
         else
             add_shared_block(shared_blocks, &shared_blocks_lock, f);
@@ -2968,7 +2970,7 @@ fragment_delete(dcontext_t *dcontext, fragment_t *f, uint actions)
     bool acquired_fragdel_lock = false;
     LOG(THREAD, LOG_FRAGMENT, 3,
         "fragment_delete: *" PFX " F%d(" PFX ")." PFX " %s 0x%x\n", f, f->id, f->tag,
-        f->start_pc, TEST(FRAG_IS_TRACE, f->flags) ? "trace" : "bb", actions);
+        f->start_pc, TESTANY(FRAG_IS_TRACE, f->flags) ? "trace" : "bb", actions);
     DOLOG(1, LOG_FRAGMENT, {
         if ((f->flags & FRAG_CANNOT_DELETE) != 0) {
             LOG(THREAD, LOG_FRAGMENT, 2,
@@ -2982,7 +2984,7 @@ fragment_delete(dcontext_t *dcontext, fragment_t *f, uint actions)
     /* ensure the actual free of a shared fragment is done only
      * after a multi-stage flush or a reset
      */
-    ASSERT(!TEST(FRAG_SHARED, f->flags) || TEST(FRAG_WAS_DELETED, f->flags) ||
+    ASSERT(!TESTANY(FRAG_SHARED, f->flags) || TESTANY(FRAG_WAS_DELETED, f->flags) ||
            dynamo_exited || dynamo_resetting || is_self_allsynch_flushing());
 
     /* need to protect ability to reference frag fields and fcache space */
@@ -2997,32 +2999,32 @@ fragment_delete(dcontext_t *dcontext, fragment_t *f, uint actions)
      * look at fragments after that is set?  If so need to resolve rank order
      * w/ shared_cache_lock.
      */
-    if (!TEST(FRAG_WAS_DELETED, f->flags) &&
-        (!TEST(FRAGDEL_NO_HEAP, actions) || !TEST(FRAGDEL_NO_FCACHE, actions))) {
+    if (!TESTANY(FRAG_WAS_DELETED, f->flags) &&
+        (!TESTANY(FRAGDEL_NO_HEAP, actions) || !TESTANY(FRAGDEL_NO_FCACHE, actions))) {
         acquired_fragdel_lock = true;
         fragment_get_fragment_delete_mutex(dcontext);
     }
 
-    if (!TEST(FRAGDEL_NO_OUTPUT, actions)) {
-        if (TEST(FRAGDEL_NEED_CHLINK_LOCK, actions) && TEST(FRAG_SHARED, f->flags))
+    if (!TESTANY(FRAGDEL_NO_OUTPUT, actions)) {
+        if (TESTANY(FRAGDEL_NEED_CHLINK_LOCK, actions) && TESTANY(FRAG_SHARED, f->flags))
             acquire_recursive_lock(&change_linking_lock);
         else {
-            ASSERT(!TEST(FRAG_SHARED, f->flags) ||
+            ASSERT(!TESTANY(FRAG_SHARED, f->flags) ||
                    self_owns_recursive_lock(&change_linking_lock));
         }
         fragment_output(dcontext, f);
-        if (TEST(FRAGDEL_NEED_CHLINK_LOCK, actions) && TEST(FRAG_SHARED, f->flags))
+        if (TESTANY(FRAGDEL_NEED_CHLINK_LOCK, actions) && TESTANY(FRAG_SHARED, f->flags))
             release_recursive_lock(&change_linking_lock);
     }
 
-    if (!TEST(FRAGDEL_NO_MONITOR, actions))
+    if (!TESTANY(FRAGDEL_NO_MONITOR, actions))
         monitor_remove_fragment(dcontext, f);
 
-    if (!TEST(FRAGDEL_NO_UNLINK, actions)) {
-        if (TEST(FRAGDEL_NEED_CHLINK_LOCK, actions) && TEST(FRAG_SHARED, f->flags))
+    if (!TESTANY(FRAGDEL_NO_UNLINK, actions)) {
+        if (TESTANY(FRAGDEL_NEED_CHLINK_LOCK, actions) && TESTANY(FRAG_SHARED, f->flags))
             acquire_recursive_lock(&change_linking_lock);
         else {
-            ASSERT(!TEST(FRAG_SHARED, f->flags) ||
+            ASSERT(!TESTANY(FRAG_SHARED, f->flags) ||
                    self_owns_recursive_lock(&change_linking_lock));
         }
         if ((f->flags & FRAG_LINKED_INCOMING) != 0)
@@ -3030,22 +3032,22 @@ fragment_delete(dcontext_t *dcontext, fragment_t *f, uint actions)
         if ((f->flags & FRAG_LINKED_OUTGOING) != 0)
             unlink_fragment_outgoing(dcontext, f);
         incoming_remove_fragment(dcontext, f);
-        if (TEST(FRAGDEL_NEED_CHLINK_LOCK, actions) && TEST(FRAG_SHARED, f->flags))
+        if (TESTANY(FRAGDEL_NEED_CHLINK_LOCK, actions) && TESTANY(FRAG_SHARED, f->flags))
             release_recursive_lock(&change_linking_lock);
     }
 
 #ifdef LINUX
-    if (TEST(FRAG_HAS_RSEQ_ENDPOINT, f->flags))
+    if (TESTANY(FRAG_HAS_RSEQ_ENDPOINT, f->flags))
         rseq_remove_fragment(dcontext, f);
 #endif
 
-    if (!TEST(FRAGDEL_NO_HTABLE, actions))
+    if (!TESTANY(FRAGDEL_NO_HTABLE, actions))
         fragment_remove(dcontext, f);
 
-    if (!TEST(FRAGDEL_NO_VMAREA, actions))
+    if (!TESTANY(FRAGDEL_NO_VMAREA, actions))
         vm_area_remove_fragment(dcontext, f);
 
-    if (!TEST(FRAGDEL_NO_FCACHE, actions)) {
+    if (!TESTANY(FRAGDEL_NO_FCACHE, actions)) {
         fcache_remove_fragment(dcontext, f);
     }
 
@@ -3058,13 +3060,13 @@ fragment_delete(dcontext_t *dcontext, fragment_t *f, uint actions)
      * be invoked we should keep the two calls in synch.
      */
     if (dr_fragment_deleted_hook_exists() &&
-        (!TEST(FRAGDEL_NO_HEAP, actions) || !TEST(FRAGDEL_NO_FCACHE, actions)))
+        (!TESTANY(FRAGDEL_NO_HEAP, actions) || !TESTANY(FRAGDEL_NO_FCACHE, actions)))
         instrument_fragment_deleted(dcontext, f->tag, f->flags);
 #ifdef UNIX
     if (INTERNAL_OPTION(profile_pcs))
         pcprofile_fragment_deleted(dcontext, f);
 #endif
-    if (!TEST(FRAGDEL_NO_HEAP, actions)) {
+    if (!TESTANY(FRAGDEL_NO_HEAP, actions)) {
         fragment_free(dcontext, f);
     }
     if (acquired_fragdel_lock)
@@ -3093,13 +3095,13 @@ fragment_record_translation_info(dcontext_t *dcontext, fragment_t *f, instrlist_
      * set, indicating that there is a special appended field pointing
      * to the translation info.
      */
-    if (TEST(FRAG_HAS_TRANSLATION_INFO, f->flags)) {
-        ASSERT(!TEST(FRAG_WAS_DELETED, f->flags));
+    if (TESTANY(FRAG_HAS_TRANSLATION_INFO, f->flags)) {
+        ASSERT(!TESTANY(FRAG_WAS_DELETED, f->flags));
         *(FRAGMENT_TRANSLATION_INFO_ADDR(f)) =
             record_translation_info(dcontext, f, ilist);
         ASSERT(FRAGMENT_TRANSLATION_INFO(f) != NULL);
         STATS_INC(num_fragment_translation_stored);
-    } else if (TEST(FRAG_WAS_DELETED, f->flags)) {
+    } else if (TESTANY(FRAG_WAS_DELETED, f->flags)) {
         ASSERT(f->in_xlate.incoming_stubs == NULL);
         if (INTERNAL_OPTION(safe_translate_flushed)) {
             f->in_xlate.translation_info = record_translation_info(dcontext, f, ilist);
@@ -3127,11 +3129,11 @@ fragment_record_translation_info(dcontext_t *dcontext, fragment_t *f, instrlist_
 void
 fragment_remove_shared_no_flush(dcontext_t *dcontext, fragment_t *f)
 {
-    DEBUG_DECLARE(bool shared_ibt_table_used = !TEST(FRAG_IS_TRACE, f->flags)
+    DEBUG_DECLARE(bool shared_ibt_table_used = !TESTANY(FRAG_IS_TRACE, f->flags)
                       ? DYNAMO_OPTION(shared_bb_ibt_tables)
                       : DYNAMO_OPTION(shared_trace_ibt_tables);)
 
-    ASSERT_NOT_IMPLEMENTED(!TEST(FRAG_COARSE_GRAIN, f->flags));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(FRAG_COARSE_GRAIN, f->flags));
 
     LOG(GLOBAL, LOG_FRAGMENT, 4, "Remove shared %s " PFX " (@" PFX ")\n",
         fragment_type_name(f), f->tag, f->start_pc);
@@ -3142,20 +3144,20 @@ fragment_remove_shared_no_flush(dcontext_t *dcontext, fragment_t *f)
      * XXX: There are still risks that the fragment's link state may change
      */
     LOG(THREAD, LOG_FRAGMENT, 3, "fragment_remove_shared_no_flush: F%d\n", f->id);
-    ASSERT(TEST(FRAG_SHARED, f->flags));
-    if (TEST(FRAG_IS_TRACE, f->flags)) {
+    ASSERT(TESTANY(FRAG_SHARED, f->flags));
+    if (TESTANY(FRAG_IS_TRACE, f->flags)) {
         d_r_mutex_lock(&trace_building_lock);
     }
     /* grab bb building lock even for traces to further prevent link changes */
     d_r_mutex_lock(&bb_building_lock);
 
-    if (TEST(FRAG_WAS_DELETED, f->flags)) {
+    if (TESTANY(FRAG_WAS_DELETED, f->flags)) {
         /* since caller can't grab locks, we can have a race where someone
          * else deletes first -- in that case nothing to do
          */
         STATS_INC(shared_delete_noflush_race);
         d_r_mutex_unlock(&bb_building_lock);
-        if (TEST(FRAG_IS_TRACE, f->flags))
+        if (TESTANY(FRAG_IS_TRACE, f->flags))
             d_r_mutex_unlock(&trace_building_lock);
         return;
     }
@@ -3171,9 +3173,9 @@ fragment_remove_shared_no_flush(dcontext_t *dcontext, fragment_t *f)
     /* XXX: share all this code w/ vm_area_unlink_fragments()
      * The work there is just different enough to make that hard, though.
      */
-    if (TEST(FRAG_LINKED_OUTGOING, f->flags))
+    if (TESTANY(FRAG_LINKED_OUTGOING, f->flags))
         unlink_fragment_outgoing(GLOBAL_DCONTEXT, f);
-    if (TEST(FRAG_LINKED_INCOMING, f->flags))
+    if (TESTANY(FRAG_LINKED_INCOMING, f->flags))
         unlink_fragment_incoming(GLOBAL_DCONTEXT, f);
     incoming_remove_fragment(GLOBAL_DCONTEXT, f);
 
@@ -3201,15 +3203,15 @@ fragment_remove_shared_no_flush(dcontext_t *dcontext, fragment_t *f)
     /* if a flush occurs, this fragment will be ignored -- so we must store
      * translation info now, just in case
      */
-    if (!TEST(FRAG_HAS_TRANSLATION_INFO, f->flags))
+    if (!TESTANY(FRAG_HAS_TRANSLATION_INFO, f->flags))
         fragment_record_translation_info(dcontext, f, NULL);
 
     /* try to catch any potential races */
-    ASSERT(!TEST(FRAG_LINKED_OUTGOING, f->flags));
-    ASSERT(!TEST(FRAG_LINKED_INCOMING, f->flags));
+    ASSERT(!TESTANY(FRAG_LINKED_OUTGOING, f->flags));
+    ASSERT(!TESTANY(FRAG_LINKED_INCOMING, f->flags));
 
     d_r_mutex_unlock(&bb_building_lock);
-    if (TEST(FRAG_IS_TRACE, f->flags)) {
+    if (TESTANY(FRAG_IS_TRACE, f->flags)) {
         d_r_mutex_unlock(&trace_building_lock);
     }
 
@@ -3226,14 +3228,14 @@ fragment_remove_shared_no_flush(dcontext_t *dcontext, fragment_t *f)
 void
 fragment_unlink_for_deletion(dcontext_t *dcontext, fragment_t *f)
 {
-    ASSERT(!TEST(FRAG_SHARED, f->flags) ||
+    ASSERT(!TESTANY(FRAG_SHARED, f->flags) ||
            self_owns_recursive_lock(&change_linking_lock));
     /* this is not an error since fcache unit flushing puts lazily-deleted
      * fragments onto its list to ensure they are in the same pending
      * delete entry as the normal fragments -- so this routine becomes
      * a nop for them
      */
-    if (TEST(FRAG_WAS_DELETED, f->flags)) {
+    if (TESTANY(FRAG_WAS_DELETED, f->flags)) {
         LOG(THREAD, LOG_FRAGMENT | LOG_VMAREAS, 5,
             "NOT unlinking F%d(" PFX ") for deletion\n", f->id, f->start_pc);
         STATS_INC(deleted_frags_re_deleted);
@@ -3245,9 +3247,9 @@ fragment_unlink_for_deletion(dcontext_t *dcontext, fragment_t *f)
      * of traces after source modules are unloaded
      */
     fragment_output(dcontext, f);
-    if (TEST(FRAG_LINKED_OUTGOING, f->flags))
+    if (TESTANY(FRAG_LINKED_OUTGOING, f->flags))
         unlink_fragment_outgoing(dcontext, f);
-    if (TEST(FRAG_LINKED_INCOMING, f->flags))
+    if (TESTANY(FRAG_LINKED_INCOMING, f->flags))
         unlink_fragment_incoming(dcontext, f);
     /* need to remove outgoings from others' incoming and
      * redirect others' outgoing to a future.  former must be
@@ -3259,7 +3261,7 @@ fragment_unlink_for_deletion(dcontext_t *dcontext, fragment_t *f)
      */
     incoming_remove_fragment(dcontext, f);
 
-    if (TEST(FRAG_SHARED, f->flags)) {
+    if (TESTANY(FRAG_SHARED, f->flags)) {
         /* we shouldn't need to worry about someone else changing the
          * link status, since nobody else is allowed to be in DR now,
          * and afterward they all must invalidate any ptrs they hold
@@ -3295,7 +3297,7 @@ fragment_unlink_for_deletion(dcontext_t *dcontext, fragment_t *f)
     /* the original app code cannot be used to recreate state, so we must
      * store translation info now
      */
-    if (!TEST(FRAG_HAS_TRANSLATION_INFO, f->flags))
+    if (!TESTANY(FRAG_HAS_TRANSLATION_INFO, f->flags))
         fragment_record_translation_info(dcontext, f, NULL);
 
     STATS_INC(fragments_unlinked_for_deletion);
@@ -3311,11 +3313,11 @@ update_private_ibt_table_ptrs(
 {
     bool table_change = false;
 
-    if (TEST(FRAG_TABLE_SHARED, ftable->table_flags)) {
+    if (TESTANY(FRAG_TABLE_SHARED, ftable->table_flags)) {
 
         per_thread_t *pt = (per_thread_t *)dcontext->fragment_field;
 
-        if (TEST(FRAG_TABLE_TRACE, ftable->table_flags) &&
+        if (TESTANY(FRAG_TABLE_TRACE, ftable->table_flags) &&
             ftable->table != pt->trace_ibt[ftable->branch_type].table) {
             DODEBUG({
                 if (orig_table != NULL) {
@@ -3324,7 +3326,7 @@ update_private_ibt_table_ptrs(
             });
             table_change = true;
         } else if (DYNAMO_OPTION(bb_ibl_targets) &&
-                   !TEST(FRAG_TABLE_TRACE, ftable->table_flags) &&
+                   !TESTANY(FRAG_TABLE_TRACE, ftable->table_flags) &&
                    ftable->table != pt->bb_ibt[ftable->branch_type].table) {
             DODEBUG({
                 if (orig_table != NULL) {
@@ -3336,8 +3338,8 @@ update_private_ibt_table_ptrs(
         if (table_change) {
             update_private_ptr_to_shared_ibt_table(
                 dcontext, ftable->branch_type,
-                TEST(FRAG_TABLE_TRACE, ftable->table_flags), true, /* adjust old
-                                                                    * ref-count */
+                TESTANY(FRAG_TABLE_TRACE, ftable->table_flags), true, /* adjust old
+                                                                       * ref-count */
                 true /* lock */);
             DODEBUG({
                 if (orig_table != NULL)
@@ -3548,7 +3550,7 @@ fragment_prepare_for_removal_from_table(dcontext_t *dcontext, fragment_t *f,
         ftable->unlinked_entries++;
         ftable->entries--;
         TABLE_RWLOCK(ftable, write, unlock);
-        ASSERT(!TEST(FRAG_CANNOT_DELETE, f->flags));
+        ASSERT(!TESTANY(FRAG_CANNOT_DELETE, f->flags));
         return true;
     }
     TABLE_RWLOCK(ftable, write, unlock);
@@ -3572,7 +3574,7 @@ fragment_prepare_for_removal(dcontext_t *dcontext, fragment_t *f)
         return false;
     }
 
-    ASSERT(TEST(FRAG_SHARED, f->flags) || dcontext != GLOBAL_DCONTEXT);
+    ASSERT(TESTANY(FRAG_SHARED, f->flags) || dcontext != GLOBAL_DCONTEXT);
     /* We need a real per_thread_t & context below so make sure we have one. */
     if (dcontext == GLOBAL_DCONTEXT) {
         dcontext = get_thread_private_dcontext();
@@ -3590,7 +3592,7 @@ fragment_prepare_for_removal(dcontext_t *dcontext, fragment_t *f)
          * and sometimes put traces into BB tables also. We never put
          * BBs into a trace table.
          */
-        if (TEST(FRAG_IS_TRACE, f->flags)) {
+        if (TESTANY(FRAG_IS_TRACE, f->flags)) {
             if (DYNAMO_OPTION(shared_trace_ibt_tables))
                 local_pt = shared_pt;
             if (fragment_prepare_for_removal_from_table(
@@ -3598,7 +3600,7 @@ fragment_prepare_for_removal(dcontext_t *dcontext, fragment_t *f)
                 prepared = true;
         }
         if (DYNAMO_OPTION(bb_ibl_targets) &&
-            (!TEST(FRAG_IS_TRACE, f->flags) ||
+            (!TESTANY(FRAG_IS_TRACE, f->flags) ||
              DYNAMO_OPTION(bb_ibt_table_includes_traces))) {
             if (DYNAMO_OPTION(shared_bb_ibt_tables))
                 local_pt = shared_pt;
@@ -3631,7 +3633,7 @@ fragment_prepare_for_removal(dcontext_t *dcontext, fragment_t *f)
 static inline void
 fragment_ibl_stat_account(uint flags, uint ibls_targeted)
 {
-    if (TEST(FRAG_IS_TRACE, flags)) {
+    if (TESTANY(FRAG_IS_TRACE, flags)) {
         switch (ibls_targeted) {
         case 0: break; /* doesn't have to be a target of any IBL routine */
         case 1: STATS_INC(num_traces_in_1_ibl_tables); break;
@@ -3660,8 +3662,8 @@ void
 fragment_remove_from_ibt_tables(dcontext_t *dcontext, fragment_t *f, bool from_shared)
 {
     bool shared_ibt_table =
-        (!TEST(FRAG_IS_TRACE, f->flags) && DYNAMO_OPTION(shared_bb_ibt_tables)) ||
-        (TEST(FRAG_IS_TRACE, f->flags) && DYNAMO_OPTION(shared_trace_ibt_tables));
+        (!TESTANY(FRAG_IS_TRACE, f->flags) && DYNAMO_OPTION(shared_bb_ibt_tables)) ||
+        (TESTANY(FRAG_IS_TRACE, f->flags) && DYNAMO_OPTION(shared_trace_ibt_tables));
     fragment_entry_t fe = FRAGENTRY_FROM_FRAGMENT(f);
 
     ASSERT(!from_shared || !shared_ibt_table || !IS_IBL_TARGET(f->flags) ||
@@ -3680,19 +3682,19 @@ fragment_remove_from_ibt_tables(dcontext_t *dcontext, fragment_t *f, bool from_s
         ibl_branch_type_t branch_type;
         per_thread_t *pt = GET_PT(dcontext);
 
-        ASSERT(TEST(FRAG_IS_TRACE, f->flags) || DYNAMO_OPTION(bb_ibl_targets));
+        ASSERT(TESTANY(FRAG_IS_TRACE, f->flags) || DYNAMO_OPTION(bb_ibl_targets));
         for (branch_type = IBL_BRANCH_TYPE_START; branch_type < IBL_BRANCH_TYPE_END;
              branch_type++) {
             /* assuming a single tag can't be both a trace and bb */
             ibl_table_t *ibtable = GET_IBT_TABLE(pt, f->flags, branch_type);
 
-            ASSERT(!TEST(FRAG_TABLE_SHARED, ibtable->table_flags) ||
+            ASSERT(!TESTANY(FRAG_TABLE_SHARED, ibtable->table_flags) ||
                    dynamo_all_threads_synched);
             TABLE_RWLOCK(ibtable, write, lock); /* satisfy asserts, even if allsynch */
             if (hashtable_ibl_remove(fe, ibtable)) {
                 LOG(THREAD, LOG_FRAGMENT, 2, "  removed F%d(" PFX ") from IBT table %s\n",
                     f->id, f->tag,
-                    TEST(FRAG_TABLE_TRACE, ibtable->table_flags)
+                    TESTANY(FRAG_TABLE_TRACE, ibtable->table_flags)
                         ? ibl_trace_table_type_names[branch_type]
                         : ibl_bb_table_type_names[branch_type]);
 
@@ -3713,7 +3715,7 @@ fragment_remove_ibl_entries_in_region(dcontext_t *dcontext, app_pc start, app_pc
     per_thread_t *pt = GET_PT(dcontext);
     ibl_branch_type_t branch_type;
     ASSERT(pt != NULL);
-    ASSERT(TEST(FRAG_IS_TRACE, frag_flags) || DYNAMO_OPTION(bb_ibl_targets));
+    ASSERT(TESTANY(FRAG_IS_TRACE, frag_flags) || DYNAMO_OPTION(bb_ibl_targets));
     ASSERT(dcontext == get_thread_private_dcontext() || dynamo_all_threads_synched);
     for (branch_type = IBL_BRANCH_TYPE_START; branch_type < IBL_BRANCH_TYPE_END;
          branch_type++) {
@@ -3733,7 +3735,7 @@ fragment_remove_ibl_entries_in_region(dcontext_t *dcontext, app_pc start, app_pc
         LOG(THREAD, LOG_FRAGMENT, 2,
             "  removed %d entries (%d left) in " PFX "-" PFX " from IBT table %s\n",
             removed, ibtable->entries, start, end,
-            TEST(FRAG_TABLE_TRACE, ibtable->table_flags)
+            TESTANY(FRAG_TABLE_TRACE, ibtable->table_flags)
                 ? ibl_trace_table_type_names[branch_type]
                 : ibl_bb_table_type_names[branch_type]);
         TABLE_RWLOCK(ibtable, write, unlock);
@@ -3775,7 +3777,7 @@ fragment_remove(dcontext_t *dcontext, fragment_t *f)
     per_thread_t *pt = GET_PT(dcontext);
     fragment_table_t *table = GET_FTABLE(pt, f->flags);
 
-    ASSERT(TEST(FRAG_SHARED, f->flags) || dcontext != GLOBAL_DCONTEXT);
+    ASSERT(TESTANY(FRAG_SHARED, f->flags) || dcontext != GLOBAL_DCONTEXT);
     /* For consistency we remove entries from the IBT
      * tables before we remove them from the trace table.
      */
@@ -3800,7 +3802,7 @@ fragment_remove(dcontext_t *dcontext, fragment_t *f)
      */
     ASSERT(cur_trace_tag(dcontext) == f->tag
            /* PR 299808: we have invisible temp trace bbs */
-           || TEST(FRAG_TEMP_PRIVATE, f->flags));
+           || TESTANY(FRAG_TEMP_PRIVATE, f->flags));
 }
 
 /* Remove f from ftable, replacing it in the hashtable with new_f,
@@ -3831,7 +3833,7 @@ fragment_replace(dcontext_t *dcontext, fragment_t *f, fragment_t *new_f)
                 /* currently we don't have shared ib target tables,
                  * otherwise a write lock would come in the picture here
                  */
-                ASSERT(!TEST(FRAG_TABLE_SHARED, ibtable->table_flags));
+                ASSERT(!TESTANY(FRAG_TABLE_SHARED, ibtable->table_flags));
                 hashtable_ibl_replace(fe, new_fe, ibtable);
             }
         }
@@ -3863,7 +3865,7 @@ fragment_shift_fcache_pointers(dcontext_t *dcontext, fragment_t *f, ssize_t shif
     LOG(THREAD, LOG_FRAGMENT, 2, "fragment_shift_fcache_pointers: F%d + " SSZFMT "\n",
         f->id, shift);
 
-    ASSERT(!TEST(FRAG_IS_FUTURE, f->flags)); /* only in-cache frags */
+    ASSERT(!TESTANY(FRAG_IS_FUTURE, f->flags)); /* only in-cache frags */
 
     f->start_pc += shift;
 
@@ -3889,7 +3891,7 @@ fragment_shift_fcache_pointers(dcontext_t *dcontext, fragment_t *f, ssize_t shif
             TABLE_RWLOCK(ibtable, read, unlock);
             LOG(THREAD, LOG_FRAGMENT, 2,
                 "fragment_table_shift_fcache_pointers: %s ibt %s shifted by %d\n",
-                TEST(FRAG_IS_TRACE, f->flags) ? "trace" : "BB", ibtable->name, shift);
+                TESTANY(FRAG_IS_TRACE, f->flags) ? "trace" : "BB", ibtable->name, shift);
         }
     }
 
@@ -3902,7 +3904,7 @@ fragment_shift_fcache_pointers(dcontext_t *dcontext, fragment_t *f, ssize_t shif
     });
 
 #ifdef X86
-    if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)) {
         /* just re-finalize to update */
         finalize_selfmod_sandbox(dcontext, f);
     }
@@ -4018,8 +4020,8 @@ fragment_add_ibl_target_helper(dcontext_t *dcontext, fragment_t *f,
     fragment_entry_t fe = FRAGENTRY_FROM_FRAGMENT(f);
 
     /* Never add a BB to a trace table. */
-    ASSERT(!(!TEST(FRAG_IS_TRACE, f->flags) &&
-             TEST(FRAG_TABLE_TRACE, ibl_table->table_flags)));
+    ASSERT(!(!TESTANY(FRAG_IS_TRACE, f->flags) &&
+             TESTANY(FRAG_TABLE_TRACE, ibl_table->table_flags)));
 
     /* adding is a write operation */
     TABLE_RWLOCK(ibl_table, write, lock);
@@ -4028,14 +4030,14 @@ fragment_add_ibl_target_helper(dcontext_t *dcontext, fragment_t *f,
      * FRAG_IS_TRACE_HEAD check in add_ibl_target() and now. We never add trace
      * heads to an IBT target table.
      */
-    if (TEST(FRAG_IS_TRACE_HEAD, f->flags)) {
+    if (TESTANY(FRAG_IS_TRACE_HEAD, f->flags)) {
         TABLE_RWLOCK(ibl_table, write, unlock);
         STATS_INC(num_th_bb_ibt_add_race);
         return;
     }
     /* For shared tables, check again in case another thread snuck in
      * before the preceding lock and added the target. */
-    if (TEST(FRAG_TABLE_SHARED, ibl_table->table_flags)) {
+    if (TESTANY(FRAG_TABLE_SHARED, ibl_table->table_flags)) {
         current = hashtable_ibl_lookup(dcontext, (ptr_uint_t)f->tag, ibl_table);
         if (IBL_ENTRY_IS_EMPTY(current))
             hashtable_ibl_add(dcontext, fe, ibl_table);
@@ -4058,14 +4060,14 @@ fragment_add_ibl_target_helper(dcontext_t *dcontext, fragment_t *f,
     }
     TABLE_RWLOCK(ibl_table, write, unlock);
     DOSTATS({
-        if (!TEST(FRAG_IS_TRACE, f->flags))
+        if (!TESTANY(FRAG_IS_TRACE, f->flags))
             STATS_INC(num_bbs_ibl_targets);
         /* We assume that traces can be added to trace and BB IBT tables but
          * not just to BB tables. We count only traces added to trace tables
          * so that we don't double increment.
          */
-        else if (TEST(FRAG_IS_TRACE, f->flags) &&
-                 TEST(FRAG_TABLE_TRACE, ibl_table->table_flags))
+        else if (TESTANY(FRAG_IS_TRACE, f->flags) &&
+                 TESTANY(FRAG_TABLE_TRACE, ibl_table->table_flags))
             STATS_INC(num_traces_ibl_targets);
     });
 
@@ -4087,7 +4089,7 @@ fragment_add_ibl_target_helper(dcontext_t *dcontext, fragment_t *f,
         dump_lookup_table(dcontext, ibl_table);
     });
     DODEBUG({
-        if (TEST(FRAG_SHARED, f->flags) && !TEST(FRAG_IS_TRACE, f->flags)) {
+        if (TESTANY(FRAG_SHARED, f->flags) && !TESTANY(FRAG_IS_TRACE, f->flags)) {
             LOG(THREAD, LOG_FRAGMENT, 2, "add_ibl_target: shared BB F%d(" PFX ") added\n",
                 f->id, f->tag);
         }
@@ -4108,8 +4110,8 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
             f = fragment_coarse_lookup_wrapper(dcontext, tag, &wrapper);
             if (f != NULL) {
 #if defined(RETURN_AFTER_CALL) || defined(RCT_IND_BRANCH)
-                if (TEST(COARSE_FILL_IBL_MASK(branch_type),
-                         DYNAMO_OPTION(coarse_fill_ibl))) {
+                if (TESTANY(COARSE_FILL_IBL_MASK(branch_type),
+                            DYNAMO_OPTION(coarse_fill_ibl))) {
                     /* On-demand per-type ibl filling from the persisted RAC/RCT
                      * table.  We limit to the first thread to ask for it by
                      * clearing the coarse_info_t pending_table fields.
@@ -4152,8 +4154,8 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
              * removed from the IBT table so we don't needlessly add it.
              */
             if (f != NULL &&
-                (TEST(FRAG_IS_TRACE_HEAD, f->flags) ||
-                 TEST(FRAG_IS_TRACE, dcontext->last_fragment->flags))) {
+                (TESTANY(FRAG_IS_TRACE_HEAD, f->flags) ||
+                 TESTANY(FRAG_IS_TRACE, dcontext->last_fragment->flags))) {
                 /* XXX: change the logic if trace headness becomes a private property */
                 f = NULL;                    /* ignore fragment */
                 STATS_INC(num_ib_th_target); /* counted in num_ibt_cold_misses */
@@ -4164,7 +4166,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
     LOG(THREAD, LOG_FRAGMENT, 3,
         "fragment_add_ibl_target tag " PFX ", branch %d, F%d %s\n", tag, branch_type,
         f != NULL ? f->id : 0,
-        (f != NULL && TEST(FRAG_IS_TRACE, f->flags)) ? "existing trace" : "");
+        (f != NULL && TESTANY(FRAG_IS_TRACE, f->flags)) ? "existing trace" : "");
 
     /* a valid IBT fragment exists */
     if (f != NULL) {
@@ -4197,14 +4199,14 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
          * the shared/private property applies to all IBT tables -- either
          * all are shared or none are.
          */
-        if (TEST(FRAG_TABLE_SHARED, ibl_table->table_flags) &&
-            !TEST(FRAG_SHARED, f->flags)) {
+        if (TESTANY(FRAG_TABLE_SHARED, ibl_table->table_flags) &&
+            !TESTANY(FRAG_SHARED, f->flags)) {
             STATS_INC(num_ibt_shared_private_conflict);
             return;
         }
 
-        ASSERT(TEST(FRAG_IS_TRACE, f->flags) ==
-               TEST(FRAG_TABLE_TRACE, ibl_table->table_flags));
+        ASSERT(TESTANY(FRAG_IS_TRACE, f->flags) ==
+               TESTANY(FRAG_TABLE_TRACE, ibl_table->table_flags));
         /* We can't assert that an IBL target isn't a trace head due to a race
          * between trace head marking and adding to a table. See the comments
          * in fragment_add_to_hashtable().
@@ -4231,13 +4233,13 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
              * table.) We fool the helper routine into using the BB
              * table by passing in a non-trace value for the flags argument.
              */
-            if (TEST(FRAG_IS_TRACE, f->flags) && DYNAMO_OPTION(bb_ibl_targets) &&
+            if (TESTANY(FRAG_IS_TRACE, f->flags) && DYNAMO_OPTION(bb_ibl_targets) &&
                 DYNAMO_OPTION(bb_ibt_table_includes_traces)) {
                 ibl_table_t *ibl_table_too =
                     GET_IBT_TABLE(pt, f->flags & ~FRAG_IS_TRACE, branch_type);
 
                 ASSERT(ibl_table_too != NULL);
-                ASSERT(!TEST(FRAG_TABLE_TRACE, ibl_table_too->table_flags));
+                ASSERT(!TESTANY(FRAG_TABLE_TRACE, ibl_table_too->table_flags));
                 /* Make sure this thread's local ptrs & state is up to
                  * date in case a resize occurred while it was in the cache. */
                 update_private_ibt_table_ptrs(dcontext, ibl_table_too _IF_DEBUG(NULL));
@@ -4249,10 +4251,10 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
             if (is_building_trace(dcontext)) {
                 reason = "trace building";
                 STATS_INC(num_ibt_exit_trace_building);
-            } else if (TEST(FRAG_WAS_DELETED, dcontext->last_fragment->flags)) {
+            } else if (TESTANY(FRAG_WAS_DELETED, dcontext->last_fragment->flags)) {
                 reason = "src unlinked (frag deleted)";
                 STATS_INC(num_ibt_exit_src_unlinked_frag_deleted);
-            } else if (!TEST(LINK_LINKED, dcontext->last_exit->flags) &&
+            } else if (!TESTANY(LINK_LINKED, dcontext->last_exit->flags) &&
                        TESTALL(FRAG_SHARED | FRAG_IS_TRACE_HEAD,
                                dcontext->last_fragment->flags) &&
                        fragment_lookup_type(dcontext, dcontext->last_fragment->tag,
@@ -4266,10 +4268,10 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
                        is_fragment_index_wraparound(dcontext, ibl_table, f)) {
                 reason = "sentinel";
                 STATS_INC(num_ibt_leaks_likely_sentinel);
-            } else if (TEST(FRAG_SELFMOD_SANDBOXED, dcontext->last_fragment->flags)) {
+            } else if (TESTANY(FRAG_SELFMOD_SANDBOXED, dcontext->last_fragment->flags)) {
                 reason = "src sandboxed";
                 STATS_INC(num_ibt_exit_src_sandboxed);
-            } else if (TEST(FRAG_TABLE_SHARED, ibl_table->table_flags) &&
+            } else if (TESTANY(FRAG_TABLE_SHARED, ibl_table->table_flags) &&
                        orig_lookuptable != ibl_table->table) {
                 /* A table resize could cause a miss when the target is
                  * in the new table. */
@@ -4277,10 +4279,12 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
                 STATS_INC(num_ibt_exit_shared_table_resize);
             } else if (DYNAMO_OPTION(bb_ibl_targets) &&
                        IS_SHARED_SYSCALLS_LINKSTUB(dcontext->last_exit) &&
-                       !DYNAMO_OPTION(disable_traces) && !TEST(FRAG_IS_TRACE, f->flags)) {
+                       !DYNAMO_OPTION(disable_traces) &&
+                       !TESTANY(FRAG_IS_TRACE, f->flags)) {
                 reason = "shared syscall exit cannot target BBs";
                 STATS_INC(num_ibt_exit_src_trace_shared_syscall);
-            } else if (DYNAMO_OPTION(bb_ibl_targets) && TEST(FRAG_IS_TRACE, f->flags) &&
+            } else if (DYNAMO_OPTION(bb_ibl_targets) &&
+                       TESTANY(FRAG_IS_TRACE, f->flags) &&
                        !DYNAMO_OPTION(bb_ibt_table_includes_traces)) {
                 reason = "BBs do not target traces";
                 STATS_INC(num_ibt_exit_src_trace_shared_syscall);
@@ -4288,7 +4292,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
                 reason = "-no_link_ibl prevents ibl";
                 STATS_INC(num_ibt_exit_nolink);
             } else if (DYNAMO_OPTION(disable_traces) &&
-                       !TEST(FRAG_LINKED_OUTGOING, dcontext->last_fragment->flags)) {
+                       !TESTANY(FRAG_LINKED_OUTGOING, dcontext->last_fragment->flags)) {
                 reason = "IBL fragment unlinked in signal handler";
                 STATS_INC(num_ibt_exit_src_unlinked_signal);
             } else {
@@ -4336,7 +4340,7 @@ fragment_create_future(dcontext_t *dcontext, app_pc tag, uint flags)
         flags | FRAG_FAKE | FRAG_IS_FUTURE);
     STATS_INC(num_future_fragments);
     DOSTATS({
-        if (TEST(FRAG_SHARED, flags))
+        if (TESTANY(FRAG_SHARED, flags))
             STATS_INC(num_shared_future_fragments);
     });
     fut->tag = tag;
@@ -4390,7 +4394,7 @@ static bool
 fragment_delete_future_filter(fragment_t *f)
 {
     future_fragment_t *fut = (future_fragment_t *)f;
-    ASSERT(TEST(FRAG_IS_FUTURE, f->flags));
+    ASSERT(TESTANY(FRAG_IS_FUTURE, f->flags));
     return (fut->incoming_stubs == NULL);
 }
 
@@ -4680,7 +4684,7 @@ static void
 rct_table_free_internal(dcontext_t *dcontext, app_pc_table_t *table)
 {
     hashtable_app_pc_free(dcontext, table);
-    ASSERT(TEST(HASHTABLE_PERSISTENT, table->table_flags));
+    ASSERT(TESTANY(HASHTABLE_PERSISTENT, table->table_flags));
     HEAP_TYPE_FREE(dcontext, table, app_pc_table_t, ACCT_AFTER_CALL, PROTECTED);
 }
 
@@ -4843,10 +4847,10 @@ rct_module_table_copy(dcontext_t *dcontext, app_pc modpc, rct_type_t which,
         if (!DYNAMO_OPTION(ret_after_call))
             return NULL;
     } else {
-        ASSERT(TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-               TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump)));
-        if (!TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) &&
-            !TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump)))
+        ASSERT(TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+               TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump)));
+        if (!TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) &&
+            !TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump)))
             return NULL;
     }
     os_get_module_info_lock();
@@ -5024,7 +5028,7 @@ coarse_persisted_fill_ibl(dcontext_t *dcontext, coarse_info_t *info,
     /* Caller must hold info lock */
     ASSERT_OWN_MUTEX(true, &info->lock);
     ASSERT(exists_coarse_ibl_pending_table(dcontext, info, branch_type));
-    ASSERT(TEST(COARSE_FILL_IBL_MASK(branch_type), DYNAMO_OPTION(coarse_fill_ibl)));
+    ASSERT(TESTANY(COARSE_FILL_IBL_MASK(branch_type), DYNAMO_OPTION(coarse_fill_ibl)));
     if (!exists_coarse_ibl_pending_table(dcontext, info, branch_type))
         return;
 
@@ -5218,7 +5222,7 @@ fragment_self_write(dcontext_t *dcontext)
         dcontext->last_fragment->tag,
         EXIT_CTI_PC(dcontext->last_fragment, dcontext->last_exit));
     STATS_INC(num_self_writes);
-    if (TEST(FRAG_WAS_DELETED, dcontext->last_fragment->flags)) {
+    if (TESTANY(FRAG_WAS_DELETED, dcontext->last_fragment->flags)) {
         /* Case 8177: case 3559 unionized fragment_t.in_xlate, so we cannot delete a
          * fragment that has already been unlinked in the first stage of a flush.
          * The flush queue check, which comes after this (b/c we want to be
@@ -5318,8 +5322,8 @@ study_all_hashtables(dcontext_t *dcontext)
     }
 #    endif
 #    if defined(RCT_IND_BRANCH) && defined(UNIX)
-    if ((TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-         TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) &&
+    if ((TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+         TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) &&
         rct_global_table.live_table != NULL) {
         hashtable_app_pc_study(dcontext, rct_global_table.live_table,
                                0 /*table consistent*/);
@@ -5707,7 +5711,7 @@ enter_nolinking(dcontext_t *dcontext, fragment_t *was_I_flushed, bool cache_tran
             SHARED_FLAGS_RECURSIVE_LOCK(f->flags, acquire, change_linking_lock);
             link_fragment_outgoing(dcontext, f, false);
             SHARED_FLAGS_RECURSIVE_LOCK(f->flags, release, change_linking_lock);
-            if (TEST(FRAG_HAS_SYSCALL, f->flags)) {
+            if (TESTANY(FRAG_HAS_SYSCALL, f->flags)) {
                 mangle_syscall_code(dcontext, f, EXIT_CTI_PC(f, dcontext->last_exit),
                                     true /*skip exit cti*/);
             }
@@ -6609,7 +6613,7 @@ flush_invalidate_ibl_shared_target(dcontext_t *dcontext, fragment_t *f)
     ASSERT(flush_threads != NULL);
     ASSERT(flush_num_threads > 0);
     ASSERT(flush_last_stage == 2);
-    ASSERT(TEST(FRAG_SHARED, f->flags));
+    ASSERT(TESTANY(FRAG_SHARED, f->flags));
     /*case 7966: has no pt, no flushing either */
     if (RUNNING_WITHOUT_CODE_CACHE()) {
         ASSERT_NOT_REACHED(); /* shouldn't get here */
@@ -6889,7 +6893,7 @@ flush_vmvector_regions(dcontext_t *dcontext, vm_area_vector_t *toflush, bool fre
 {
     vmvector_iterator_t vmvi;
     app_pc start, end;
-    ASSERT(toflush != NULL && !TEST(VECTOR_SHARED, toflush->flags));
+    ASSERT(toflush != NULL && !TESTANY(VECTOR_SHARED, toflush->flags));
     ASSERT(!RUNNING_WITHOUT_CODE_CACHE());
     ASSERT(DYNAMO_OPTION(coarse_units) &&
            DYNAMO_OPTION(use_persisted) IF_HOTP(&&DYNAMO_OPTION(hot_patching)));
@@ -6920,7 +6924,7 @@ flush_vmvector_regions(dcontext_t *dcontext, vm_area_vector_t *toflush, bool fre
 void
 fragment_output(dcontext_t *dcontext, fragment_t *f)
 {
-    ASSERT(!TEST(FRAG_SHARED, f->flags) ||
+    ASSERT(!TESTANY(FRAG_SHARED, f->flags) ||
            self_owns_recursive_lock(&change_linking_lock));
     if (SHOULD_OUTPUT_FRAGMENT(f->flags)) {
         per_thread_t *pt = (dcontext == GLOBAL_DCONTEXT)
@@ -6990,7 +6994,7 @@ output_trace_binary(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
         0,
         f->size,
         (INTERNAL_OPTION(tracedump_origins) ? t->num_bbs : 0),
-        IF_X86_64_ELSE(!TEST(FRAG_32_BIT, f->flags), false),
+        IF_X86_64_ELSE(!TESTANY(FRAG_32_BIT, f->flags), false),
     };
     tracedump_stub_data_t stub;
     /* Should we widen the identifier? */
@@ -7047,7 +7051,7 @@ output_trace_binary(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
         stub.cti_offs = l->cti_offset;
         stub.stub_pc = stub_pc;
         stub.target = EXIT_TARGET_TAG(dcontext, f, l);
-        stub.linked = TEST(LINK_LINKED, l->flags);
+        stub.linked = TESTANY(LINK_LINKED, l->flags);
         stub.stub_size = EXIT_HAS_STUB(l->flags, f->flags)
             ? DIRECT_EXIT_STUB_SIZE(f->flags)
             : 0 /* no stub neededd: -no_indirect_stubs */;
@@ -7057,7 +7061,7 @@ output_trace_binary(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
         memcpy(p, &stub, STUB_DATA_FIXED_SIZE);
         p += STUB_DATA_FIXED_SIZE;
 
-        if (TEST(LINK_SEPARATE_STUB, l->flags) && stub_pc != NULL) {
+        if (TESTANY(LINK_SEPARATE_STUB, l->flags) && stub_pc != NULL) {
             TRACEBUF_MAKE_ROOM(p, buf, DIRECT_EXIT_STUB_SIZE(f->flags));
             ASSERT(stub_pc < f->start_pc || stub_pc >= f->start_pc + f->size);
             memcpy(p, stub_pc, DIRECT_EXIT_STUB_SIZE(f->flags));
@@ -7101,11 +7105,11 @@ output_trace(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
     bool locked_vmareas = false;
     dr_isa_mode_t old_mode;
     ASSERT(SHOULD_OUTPUT_FRAGMENT(f->flags));
-    ASSERT(TEST(FRAG_IS_TRACE, f->flags));
-    ASSERT(!TEST(FRAG_SELFMOD_SANDBOXED, f->flags)); /* no support for selfmod */
+    ASSERT(TESTANY(FRAG_IS_TRACE, f->flags));
+    ASSERT(!TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)); /* no support for selfmod */
     /* already been output?  caller should check this flag, just like trace flag */
-    ASSERT(!TEST(FRAG_TRACE_OUTPUT, f->flags));
-    ASSERT(!TEST(FRAG_SHARED, f->flags) ||
+    ASSERT(!TESTANY(FRAG_TRACE_OUTPUT, f->flags));
+    ASSERT(!TESTANY(FRAG_SHARED, f->flags) ||
            self_owns_recursive_lock(&change_linking_lock));
     f->flags |= FRAG_TRACE_OUTPUT;
 
@@ -7126,7 +7130,7 @@ output_trace(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
     }
     trace_num = tcount;
     tcount++;
-    if (!TEST(FRAG_SHARED, f->flags)) {
+    if (!TESTANY(FRAG_SHARED, f->flags)) {
         /* No lock is needed because we use thread-private files.
          * If dumping traces for a different thread (dynamo_other_thread_exit
          * for ex.) caller is responsible for the necessary synchronization. */
@@ -7256,7 +7260,7 @@ output_trace(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
 
 output_trace_done:
     dr_set_isa_mode(dcontext, old_mode, NULL);
-    if (TEST(FRAG_SHARED, f->flags) && !dynamo_resetting) {
+    if (TESTANY(FRAG_SHARED, f->flags) && !dynamo_resetting) {
         ASSERT_OWN_MUTEX(true, &tracedump_mutex);
         d_r_mutex_unlock(&tracedump_mutex);
         if (locked_vmareas)
@@ -7776,7 +7780,7 @@ fragment_coarse_add(dcontext_t *dcontext, coarse_info_t *info, app_pc tag, cache
                    fragment_coarse_lookup(dcontext, tag) == NULL);
             f = fragment_lookup(dcontext, tag);
             /* ok for trace to shadow coarse trace head */
-            ASSERT(f == NULL || TEST(FRAG_IS_TRACE, f->flags));
+            ASSERT(f == NULL || TESTANY(FRAG_IS_TRACE, f->flags));
         }
     });
     TABLE_RWLOCK(htable, write, lock);
@@ -8077,7 +8081,8 @@ fragment_lookup_fine_and_coarse(dcontext_t *dcontext, app_pc tag, fragment_t *wr
              * (can have shared trace shadowing shared coarse trace head bb,
              * or private bb with same tag)
              */
-            ASSERT(TEST(FRAG_IS_TRACE, res->flags) || !TEST(FRAG_SHARED, res->flags) ||
+            ASSERT(TESTANY(FRAG_IS_TRACE, res->flags) ||
+                   !TESTANY(FRAG_SHARED, res->flags) ||
                    fragment_coarse_lookup(dcontext, tag) == NULL);
         }
     }
@@ -8095,7 +8100,7 @@ fragment_lookup_fine_and_coarse_sharing(dcontext_t *dcontext, app_pc tag,
                                         uint share_flags)
 {
     fragment_t *res = fragment_lookup_same_sharing(dcontext, tag, share_flags);
-    if (DYNAMO_OPTION(coarse_units) && TEST(FRAG_SHARED, share_flags)) {
+    if (DYNAMO_OPTION(coarse_units) && TESTANY(FRAG_SHARED, share_flags)) {
         ASSERT(wrapper != NULL);
         if (res == NULL) {
             res = fragment_coarse_lookup_wrapper(dcontext, tag, wrapper);
@@ -8116,7 +8121,7 @@ get_fragment_coarse_info(fragment_t *f)
     /* We have multiple potential units per vmarea region, so we use the fcache
      * pc to get the unambiguous owning unit
      */
-    if (!TEST(FRAG_COARSE_GRAIN, f->flags))
+    if (!TESTANY(FRAG_COARSE_GRAIN, f->flags))
         return NULL;
     ASSERT(FCACHE_ENTRY_PC(f) != NULL);
     return get_fcache_coarse_info(FCACHE_ENTRY_PC(f));

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -189,12 +189,12 @@
      FRAG_SHARED | FRAG_TEMP_PRIVATE)
 
 /* FRAG_IS_X86_TO_X64 is in x64 mode */
-#define FRAG_ISA_MODE(flags)                                                        \
-    IF_X86_ELSE(                                                                    \
-        IF_X64_ELSE((FRAG_IS_32(flags)) ? DR_ISA_IA32 : DR_ISA_AMD64, DR_ISA_IA32), \
-        IF_AARCHXX_ELSE(IF_X64_ELSE(DR_ISA_ARM_A64,                                 \
-                                    (TEST(FRAG_THUMB, (flags)) ? DR_ISA_ARM_THUMB   \
-                                                               : DR_ISA_ARM_A32)),  \
+#define FRAG_ISA_MODE(flags)                                                          \
+    IF_X86_ELSE(                                                                      \
+        IF_X64_ELSE((FRAG_IS_32(flags)) ? DR_ISA_IA32 : DR_ISA_AMD64, DR_ISA_IA32),   \
+        IF_AARCHXX_ELSE(IF_X64_ELSE(DR_ISA_ARM_A64,                                   \
+                                    (TESTANY(FRAG_THUMB, (flags)) ? DR_ISA_ARM_THUMB  \
+                                                                  : DR_ISA_ARM_A32)), \
                         DR_ISA_RV64))
 
 static inline uint
@@ -367,10 +367,10 @@ typedef struct _private_trace_t {
 } private_trace_t;
 
 /* convenient way to deal w/ trace fields: this returns trace_only_t* */
-#define TRACE_FIELDS(f)                                      \
-    (ASSERT(TEST(FRAG_IS_TRACE, (f)->flags)),                \
-     (TEST(FRAG_SHARED, (f)->flags) ? &(((trace_t *)(f))->t) \
-                                    : &(((private_trace_t *)(f))->t)))
+#define TRACE_FIELDS(f)                                         \
+    (ASSERT(TESTANY(FRAG_IS_TRACE, (f)->flags)),                \
+     (TESTANY(FRAG_SHARED, (f)->flags) ? &(((trace_t *)(f))->t) \
+                                       : &(((private_trace_t *)(f))->t)))
 
 /* XXX: Can be used to determine if a frag should have a prefix since currently
  * all IB targets have the same prefix. Use a different macro if different frags
@@ -389,11 +389,11 @@ typedef struct _private_trace_t {
  * However it's not very useful to go after the short lived FRAG_TEMP_PRIVATE
  */
 /* can a frag w/the given flags be an IBL target? */
-#define IS_IBL_TARGET(flags)                                                       \
-    (TEST(FRAG_IS_TRACE, (flags))                                                  \
-         ? (TEST(FRAG_SHARED, (flags)) || !DYNAMO_OPTION(shared_trace_ibt_tables)) \
-         : (DYNAMO_OPTION(bb_ibl_targets) &&                                       \
-            (TEST(FRAG_SHARED, (flags)) || !DYNAMO_OPTION(shared_bb_ibt_tables))))
+#define IS_IBL_TARGET(flags)                                                          \
+    (TESTANY(FRAG_IS_TRACE, (flags))                                                  \
+         ? (TESTANY(FRAG_SHARED, (flags)) || !DYNAMO_OPTION(shared_trace_ibt_tables)) \
+         : (DYNAMO_OPTION(bb_ibl_targets) &&                                          \
+            (TESTANY(FRAG_SHARED, (flags)) || !DYNAMO_OPTION(shared_bb_ibt_tables))))
 
 #define HASHTABLE_IBL_OFFSET(branch_type)                                    \
     (((branch_type) == IBL_INDCALL) ? DYNAMO_OPTION(ibl_indcall_hash_offset) \
@@ -549,39 +549,39 @@ typedef struct _per_thread_t {
 /* translation info pointer can be at end of any struct, so rather than have
  * 8 different structs we keep it out of the formal struct definitions
  */
-#define FRAGMENT_STRUCT_SIZE(flags)                                                  \
-    ((TEST(FRAG_IS_TRACE, (flags))                                                   \
-          ? (TEST(FRAG_SHARED, (flags)) ? sizeof(trace_t) : sizeof(private_trace_t)) \
-          : (TEST(FRAG_SHARED, (flags)) ? sizeof(fragment_t)                         \
-                                        : sizeof(private_fragment_t))) +             \
-     (TEST(FRAG_HAS_TRANSLATION_INFO, flags) ? sizeof(translation_info_t *) : 0))
+#define FRAGMENT_STRUCT_SIZE(flags)                                                     \
+    ((TESTANY(FRAG_IS_TRACE, (flags))                                                   \
+          ? (TESTANY(FRAG_SHARED, (flags)) ? sizeof(trace_t) : sizeof(private_trace_t)) \
+          : (TESTANY(FRAG_SHARED, (flags)) ? sizeof(fragment_t)                         \
+                                           : sizeof(private_fragment_t))) +             \
+     (TESTANY(FRAG_HAS_TRANSLATION_INFO, flags) ? sizeof(translation_info_t *) : 0))
 
 #define FRAGMENT_EXIT_STUBS(f)                                                         \
-    (TEST(FRAG_FAKE, (f)->flags)                                                       \
+    (TESTANY(FRAG_FAKE, (f)->flags)                                                    \
          ? (ASSERT(false && "fake fragment_t has no exit stubs!"), (linkstub_t *)NULL) \
          : ((linkstub_t *)(((byte *)(f)) + FRAGMENT_STRUCT_SIZE((f)->flags))))
 
 /* selfmod copy size is stored at very end of fragment space */
-#define FRAGMENT_SELFMOD_COPY_SIZE(f)                  \
-    (ASSERT(TEST(FRAG_SELFMOD_SANDBOXED, (f)->flags)), \
+#define FRAGMENT_SELFMOD_COPY_SIZE(f)                     \
+    (ASSERT(TESTANY(FRAG_SELFMOD_SANDBOXED, (f)->flags)), \
      (*((uint *)((f)->start_pc + (f)->size - sizeof(uint)))))
 #define FRAGMENT_SELFMOD_COPY_CODE_SIZE(f) (FRAGMENT_SELFMOD_COPY_SIZE(f) - sizeof(uint))
-#define FRAGMENT_SELFMOD_COPY_PC(f)                    \
-    (ASSERT(TEST(FRAG_SELFMOD_SANDBOXED, (f)->flags)), \
+#define FRAGMENT_SELFMOD_COPY_PC(f)                       \
+    (ASSERT(TESTANY(FRAG_SELFMOD_SANDBOXED, (f)->flags)), \
      ((f)->start_pc + (f)->size - FRAGMENT_SELFMOD_COPY_SIZE(f)))
 
 #define FRAGMENT_TRANSLATION_INFO_ADDR(f)                                              \
-    (TEST(FRAG_HAS_TRANSLATION_INFO, (f)->flags)                                       \
+    (TESTANY(FRAG_HAS_TRANSLATION_INFO, (f)->flags)                                    \
          ? ((translation_info_t **)(((byte *)(f)) + FRAGMENT_STRUCT_SIZE((f)->flags) - \
                                     sizeof(translation_info_t *)))                     \
          : ((INTERNAL_OPTION(safe_translate_flushed) &&                                \
-             TEST(FRAG_WAS_DELETED, (f)->flags))                                       \
+             TESTANY(FRAG_WAS_DELETED, (f)->flags))                                    \
                 ? &((f)->in_xlate.translation_info)                                    \
                 : NULL))
 
-#define HAS_STORED_TRANSLATION_INFO(f)              \
-    (TEST(FRAG_HAS_TRANSLATION_INFO, (f)->flags) || \
-     (INTERNAL_OPTION(safe_translate_flushed) && TEST(FRAG_WAS_DELETED, (f)->flags)))
+#define HAS_STORED_TRANSLATION_INFO(f)                 \
+    (TESTANY(FRAG_HAS_TRANSLATION_INFO, (f)->flags) || \
+     (INTERNAL_OPTION(safe_translate_flushed) && TESTANY(FRAG_WAS_DELETED, (f)->flags)))
 
 #define FRAGMENT_TRANSLATION_INFO(f) \
     (HAS_STORED_TRANSLATION_INFO(f) ? (*(FRAGMENT_TRANSLATION_INFO_ADDR(f))) : NULL)
@@ -589,9 +589,9 @@ typedef struct _per_thread_t {
 static inline const char *
 fragment_type_name(fragment_t *f)
 {
-    if (TEST(FRAG_IS_TRACE_HEAD, f->flags))
+    if (TESTANY(FRAG_IS_TRACE_HEAD, f->flags))
         return "trace head";
-    else if (TEST(FRAG_IS_TRACE, f->flags))
+    else if (TESTANY(FRAG_IS_TRACE, f->flags))
         return "trace";
     else
         return "bb";
@@ -1212,9 +1212,10 @@ void
 print_shared_stats(void);
 #endif
 
-#define PROTECT_FRAGMENT_ENABLED(flags)                                              \
-    (TEST(FRAG_SHARED, (flags)) ? TEST(SELFPROT_GLOBAL, dynamo_options.protect_mask) \
-                                : TEST(SELFPROT_LOCAL, dynamo_options.protect_mask))
+#define PROTECT_FRAGMENT_ENABLED(flags)                          \
+    (TESTANY(FRAG_SHARED, (flags))                               \
+         ? TESTANY(SELFPROT_GLOBAL, dynamo_options.protect_mask) \
+         : TESTANY(SELFPROT_LOCAL, dynamo_options.protect_mask))
 
 #ifdef DEBUG
 void

--- a/core/globals.h
+++ b/core/globals.h
@@ -756,7 +756,7 @@ struct _dcontext_t {
      */
     union {
         /* we use separate_upcontext if
-         *    (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+         *    (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
          * else we use the inlined upcontext
          */
         unprotected_context_t *separate_upcontext;
@@ -1079,7 +1079,7 @@ struct _dcontext_t {
 static INLINE_FORCED priv_mcontext_t *
 get_mcontext(dcontext_t *dcontext)
 {
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask))
         return &(dcontext->upcontext.separate_upcontext->mcontext);
     else
         return &(dcontext->upcontext.upcontext.mcontext);

--- a/core/hashtable.c
+++ b/core/hashtable.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -274,7 +274,7 @@ generic_hash_iterate_remove(dcontext_t *dcontext, generic_table_t *htable, int i
 static inline bool
 strhash_key_cmp(strhash_table_t *htable, const char *s1, const char *s2)
 {
-    if (TEST(STRHASH_CASE_INSENSITIVE, htable->table_flags))
+    if (TESTANY(STRHASH_CASE_INSENSITIVE, htable->table_flags))
         return strcasecmp(s1, s2) == 0;
     else
         return strcmp(s1, s2) == 0;
@@ -326,7 +326,7 @@ strhash_hash_create(dcontext_t *dcontext, uint bits, uint load_factor_percent,
     strhash_table_t *table =
         HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, strhash_table_t, ACCT_OTHER, PROTECTED);
     hashtable_strhash_init(GLOBAL_DCONTEXT, table, bits, load_factor_percent,
-                           TEST(STRHASH_CASE_INSENSITIVE, table_flags)
+                           TESTANY(STRHASH_CASE_INSENSITIVE, table_flags)
                                ? HASH_FUNCTION_STRING_NOCASE
                                : HASH_FUNCTION_STRING,
                            0 /* hash_mask_offset */, table_flags _IF_DEBUG(table_name));

--- a/core/hashtable.h
+++ b/core/hashtable.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -81,9 +81,9 @@
 /* single_thread_in_DR does not need rw locks since we do not access shared
  * tables from ibl while holding locks (we do so in a lockless manner)
  */
-#define TABLE_NEEDS_LOCK(ptable)                      \
-    (TEST(HASHTABLE_SHARED, (ptable)->table_flags) && \
-     !TEST(HASHTABLE_READ_ONLY, (ptable)->table_flags))
+#define TABLE_NEEDS_LOCK(ptable)                         \
+    (TESTANY(HASHTABLE_SHARED, (ptable)->table_flags) && \
+     !TESTANY(HASHTABLE_READ_ONLY, (ptable)->table_flags))
 
 /* is_local is currently debug-only and only affects asserts */
 #define ASSERT_TABLE_SYNCHRONIZED(ptable, RW)                                 \
@@ -98,10 +98,10 @@
     } while (0)
 
 #define TABLE_MEMOP(table_flags, op) \
-    (TEST((table_flags), HASHTABLE_PERSISTENT) ? heap_##op : nonpersistent_heap_##op)
+    (TESTANY((table_flags), HASHTABLE_PERSISTENT) ? heap_##op : nonpersistent_heap_##op)
 
 #define TABLE_TYPE_MEMOP(table_flags, op, dc, type, which, protected) \
-    (TEST((table_flags), HASHTABLE_PERSISTENT)                        \
+    (TESTANY((table_flags), HASHTABLE_PERSISTENT)                     \
          ? HEAP_TYPE_##op(dc, type, which, protected)                 \
          : NONPERSISTENT_HEAP_TYPE_##op(dc, type, which))
 

--- a/core/hashtablex.h
+++ b/core/hashtablex.h
@@ -304,7 +304,7 @@ HTNAME(hashtable_, NAME_KEY, _table_aligned_size)(uint table_capacity, uint flag
     /* we assume table size allows 32-bit indices */
     IF_X64(ASSERT(CHECK_TRUNCATE_TYPE_uint(table_capacity * sizeof(ENTRY_TYPE))));
     size = table_capacity * sizeof(ENTRY_TYPE);
-    if (TEST(HASHTABLE_ALIGN_TABLE, flags)) {
+    if (TESTANY(HASHTABLE_ALIGN_TABLE, flags)) {
         /* aligned at least at 4, and may be aligned */
         size += proc_get_cache_line_size() - 4;
     }
@@ -379,7 +379,7 @@ HTNAME(hashtable_, NAME_KEY,
                                                                    table->table_flags);
     table->table_unaligned = (ENTRY_TYPE *)TABLE_MEMOP(table->table_flags, alloc)(
         dcontext, alloc_size HEAPACCT(HASHTABLE_WHICH_HEAP(table->table_flags)));
-    if (TEST(HASHTABLE_ALIGN_TABLE, table->table_flags)) {
+    if (TESTANY(HASHTABLE_ALIGN_TABLE, table->table_flags)) {
         ASSERT(ALIGNED(table->table_unaligned, 4)); /* guaranteed by heap_alloc */
         table->table = (ENTRY_TYPE *)ALIGN_FORWARD(table->table_unaligned,
                                                    proc_get_cache_line_size());
@@ -469,7 +469,7 @@ HTNAME(hashtable_, NAME_KEY,
 #    ifdef HASHTABLE_STATISTICS
 #        ifdef HASHTABLE_ENTRY_STATS
     if (INTERNAL_OPTION(hashtable_ibl_entry_stats)) {
-        if (TEST(HASHTABLE_USE_ENTRY_STATS, table->table_flags)) {
+        if (TESTANY(HASHTABLE_USE_ENTRY_STATS, table->table_flags)) {
 #            ifdef HASHTABLE_USE_LOOKUPTABLE
             ASSERT(sizeof(fragment_stat_entry_t) == sizeof(AUX_ENTRY_TYPE));
 #            else
@@ -533,7 +533,7 @@ HTNAME(hashtable_, NAME_KEY, _init)(dcontext_t *dcontext,
     table->added_since_dumped = 0;
 #        endif
 #    endif
-    ASSERT(dcontext != GLOBAL_DCONTEXT || TEST(HASHTABLE_SHARED, table_flags));
+    ASSERT(dcontext != GLOBAL_DCONTEXT || TESTANY(HASHTABLE_SHARED, table_flags));
     HTNAME(hashtable_, NAME_KEY, _init_internal)
     (dcontext, table, bits, load_factor_percent, func, hash_offset _IFLOOKUP(use_lookup));
     ASSIGN_INIT_READWRITE_LOCK_FREE(table->rwlock, HTLOCK_RANK);
@@ -591,7 +591,7 @@ HTNAME(hashtable_, NAME_KEY, _free)(dcontext_t *dcontext,
 #    ifdef HASHTABLE_STATISTICS
 #        ifdef HASHTABLE_ENTRY_STATS
     if (INTERNAL_OPTION(hashtable_ibl_entry_stats)) {
-        if (TEST(HASHTABLE_USE_ENTRY_STATS, table->table_flags)) {
+        if (TESTANY(HASHTABLE_USE_ENTRY_STATS, table->table_flags)) {
             HEAP_ARRAY_FREE(dcontext, table->entry_stats, fragment_stat_entry_t,
                             table->capacity, HASHTABLE_WHICH_HEAP(table->table_flags),
                             UNPROTECTED);
@@ -642,8 +642,8 @@ HTNAME(hashtable_, NAME_KEY, _check_consistency)(dcontext_t *dcontext,
          * in fragment_add_to_hashtable().
          */
         if (ENTRY_IS_INVALID(htable->table[hindex])) {
-            ASSERT(TEST(HASHTABLE_NOT_PRIMARY_STORAGE, htable->table_flags));
-            ASSERT(TEST(HASHTABLE_LOCKLESS_ACCESS, htable->table_flags));
+            ASSERT(TESTANY(HASHTABLE_NOT_PRIMARY_STORAGE, htable->table_flags));
+            ASSERT(TESTANY(HASHTABLE_LOCKLESS_ACCESS, htable->table_flags));
 #        ifdef HASHTABLE_USE_LOOKUPTABLE
             ASSERT(AUX_ENTRY_IS_INVALID(htable->lookuptable[hindex]));
 #        endif
@@ -657,7 +657,7 @@ HTNAME(hashtable_, NAME_KEY, _check_consistency)(dcontext_t *dcontext,
          * been unlinked (and so doesn't point to target_delete) can we expect
          * the lookup table and fragment_t* to be in-sync.
          */
-        else if (TEST(HASHTABLE_NOT_PRIMARY_STORAGE, htable->table_flags) ||
+        else if (TESTANY(HASHTABLE_NOT_PRIMARY_STORAGE, htable->table_flags) ||
                  AUX_PAYLOAD_IS_INVALID(dcontext, htable, htable->lookuptable[hindex])) {
             ASSERT(AUX_ENTRY_IS_SET_TO_ENTRY(htable->lookuptable[hindex],
                                              htable->table[hindex]));
@@ -767,8 +767,8 @@ HTNAME(hashtable_, NAME_KEY, _add)(dcontext_t *dcontext, ENTRY_TYPE e,
 
     ASSERT_TABLE_SYNCHRONIZED(table, WRITE); /* add requires write lock */
 
-    ASSERT(!TEST(HASHTABLE_READ_ONLY, table->table_flags));
-    if (TEST(HASHTABLE_READ_ONLY, table->table_flags))
+    ASSERT(!TESTANY(HASHTABLE_READ_ONLY, table->table_flags));
+    if (TESTANY(HASHTABLE_READ_ONLY, table->table_flags))
         return false;
 
     /* ensure higher-level synch not allowing any races between lookup and add */
@@ -817,9 +817,9 @@ HTNAME(hashtable_, NAME_KEY, _add)(dcontext_t *dcontext, ENTRY_TYPE e,
              * exited the cache at least once, so any shared tables marked
              * as FRAG_NO_CLOBBER_UNLINK can have that flag cleared.
              */
-            if (!TEST(HASHTABLE_SHARED, table->table_flags)) {
+            if (!TESTANY(HASHTABLE_SHARED, table->table_flags)) {
                 ASSERT(table->unlinked_entries > 0);
-                ASSERT(TEST(HASHTABLE_LOCKLESS_ACCESS, table->table_flags));
+                ASSERT(TESTANY(HASHTABLE_LOCKLESS_ACCESS, table->table_flags));
 #    ifdef HASHTABLE_USE_LOOKUPTABLE
                 ASSERT(
                     AUX_PAYLOAD_IS_INVALID(dcontext, table, table->lookuptable[hindex]));
@@ -861,7 +861,7 @@ HTNAME(hashtable_, NAME_KEY, _add)(dcontext_t *dcontext, ENTRY_TYPE e,
      * shared fragments
      */
 #    ifdef DEBUG
-    if (!TEST(HASHTABLE_RELAX_CLUSTER_CHECKS, table->table_flags) &&
+    if (!TESTANY(HASHTABLE_RELAX_CLUSTER_CHECKS, table->table_flags) &&
         (table->hash_func != HASH_FUNCTION_NONE || SHARED_FRAGMENTS_ENABLED())) {
         uint max_cluster_len =
             HASHTABLE_SIZE((1 + table->hash_bits) / 2 + 1 /* double */) + 64;
@@ -934,8 +934,8 @@ HTNAME(hashtable_, NAME_KEY, _check_size)(dcontext_t *dcontext,
     /* write lock must be held */
     ASSERT_TABLE_SYNCHRONIZED(table, WRITE);
 
-    ASSERT(!TEST(HASHTABLE_READ_ONLY, table->table_flags));
-    if (TEST(HASHTABLE_READ_ONLY, table->table_flags))
+    ASSERT(!TESTANY(HASHTABLE_READ_ONLY, table->table_flags));
+    if (TESTANY(HASHTABLE_READ_ONLY, table->table_flags))
         return false;
 
     /* check flush threshold to see if we'd want to flush hashtable */
@@ -1372,8 +1372,8 @@ HTNAME(hashtable_, NAME_KEY, _remove)(ENTRY_TYPE fr,
     uint hindex;
     ENTRY_TYPE *pg;
     ASSERT_TABLE_SYNCHRONIZED(htable, WRITE); /* remove requires write lock */
-    ASSERT(!TEST(HASHTABLE_READ_ONLY, htable->table_flags));
-    if (TEST(HASHTABLE_READ_ONLY, htable->table_flags))
+    ASSERT(!TESTANY(HASHTABLE_READ_ONLY, htable->table_flags));
+    if (TESTANY(HASHTABLE_READ_ONLY, htable->table_flags))
         return false;
     pg = HTNAME(hashtable_, NAME_KEY, _lookup_for_removal)(fr, htable, &hindex);
     if (pg != NULL) {
@@ -1397,8 +1397,8 @@ HTNAME(hashtable_, NAME_KEY, _replace)(ENTRY_TYPE old_e, ENTRY_TYPE new_e,
      * need global consistency and replace requires two local writes!
      */
     ASSERT_TABLE_SYNCHRONIZED(htable, WRITE);
-    ASSERT(!TEST(HASHTABLE_READ_ONLY, htable->table_flags));
-    if (TEST(HASHTABLE_READ_ONLY, htable->table_flags))
+    ASSERT(!TESTANY(HASHTABLE_READ_ONLY, htable->table_flags));
+    if (TESTANY(HASHTABLE_READ_ONLY, htable->table_flags))
         return false;
     if (pg != NULL) {
         ASSERT(ENTRY_TAG(old_e) == ENTRY_TAG(new_e));
@@ -1429,8 +1429,8 @@ HTNAME(hashtable_, NAME_KEY, _clear)(dcontext_t *dcontext,
     uint i;
     ENTRY_TYPE e;
 
-    ASSERT(!TEST(HASHTABLE_READ_ONLY, table->table_flags));
-    if (TEST(HASHTABLE_READ_ONLY, table->table_flags))
+    ASSERT(!TESTANY(HASHTABLE_READ_ONLY, table->table_flags));
+    if (TESTANY(HASHTABLE_READ_ONLY, table->table_flags))
         return;
     LOG(THREAD, LOG_HTABLE, 2, "hashtable_" KEY_STRING "_clear\n");
     DOLOG(2, LOG_HTABLE | LOG_STATS,
@@ -1451,7 +1451,7 @@ HTNAME(hashtable_, NAME_KEY, _clear)(dcontext_t *dcontext,
 #        ifdef HASHTABLE_ENTRY_STATS
     table->added_since_dumped = 0;
     if (INTERNAL_OPTION(hashtable_ibl_entry_stats) && table->entry_stats != NULL) {
-        if (TEST(HASHTABLE_USE_ENTRY_STATS, table->table_flags)) {
+        if (TESTANY(HASHTABLE_USE_ENTRY_STATS, table->table_flags)) {
             memset(table->entry_stats, 0,
                    table->capacity * sizeof(fragment_stat_entry_t));
         }
@@ -1482,8 +1482,8 @@ HTNAME(hashtable_, NAME_KEY, _range_remove)(dcontext_t *dcontext,
     uint entries_removed = 0;
     DEBUG_DECLARE(uint entries_initial = 0;)
 
-    ASSERT(!TEST(HASHTABLE_READ_ONLY, table->table_flags));
-    if (TEST(HASHTABLE_READ_ONLY, table->table_flags))
+    ASSERT(!TESTANY(HASHTABLE_READ_ONLY, table->table_flags));
+    if (TESTANY(HASHTABLE_READ_ONLY, table->table_flags))
         return 0;
     LOG(THREAD, LOG_HTABLE, 2, "hashtable_" KEY_STRING "_range_remove\n");
     DOLOG(2, LOG_HTABLE | LOG_STATS,
@@ -1536,13 +1536,13 @@ HTNAME(hashtable_, NAME_KEY, _unlinked_remove)(dcontext_t *dcontext,
     ENTRY_TYPE e UNUSED;
     uint entries_removed = 0;
 
-    ASSERT(!TEST(HASHTABLE_READ_ONLY, table->table_flags));
-    if (TEST(HASHTABLE_READ_ONLY, table->table_flags))
+    ASSERT(!TESTANY(HASHTABLE_READ_ONLY, table->table_flags));
+    if (TESTANY(HASHTABLE_READ_ONLY, table->table_flags))
         return 0;
     LOG(THREAD, LOG_HTABLE, 2, "hashtable_" KEY_STRING "_unlinked_remove\n");
     /* body based on hashtable_range_remove() */
 
-    ASSERT(TEST(HASHTABLE_LOCKLESS_ACCESS, table->table_flags));
+    ASSERT(TESTANY(HASHTABLE_LOCKLESS_ACCESS, table->table_flags));
     DOLOG(2, LOG_HTABLE | LOG_STATS,
           { HTNAME(hashtable_, NAME_KEY, _load_statistics)(dcontext, table); });
     DODEBUG({
@@ -1618,7 +1618,7 @@ HTNAME(hashtable_, NAME_KEY, _groom_table)(dcontext_t *dcontext,
     LOG(THREAD, LOG_HTABLE, 1, "hashtable_" KEY_STRING "_groom_table %s\n", table->name);
 
     /* flush only tables caching data persistent in another table */
-    ASSERT(TEST(HASHTABLE_NOT_PRIMARY_STORAGE, table->table_flags));
+    ASSERT(TESTANY(HASHTABLE_NOT_PRIMARY_STORAGE, table->table_flags));
 
     DOLOG(3, LOG_HTABLE, { HTNAME(hashtable_, NAME_KEY, _dump_table)(dcontext, table); });
 
@@ -1659,7 +1659,7 @@ HTNAME(hashtable_, NAME_KEY, _groom_helper)(dcontext_t *dcontext,
                                             HTNAME(, NAME_KEY, _table_t) * table)
 {
     /* flush only tables caching data persistent in another table */
-    ASSERT(TEST(HASHTABLE_NOT_PRIMARY_STORAGE, table->table_flags));
+    ASSERT(TESTANY(HASHTABLE_NOT_PRIMARY_STORAGE, table->table_flags));
 
     ASSERT(table->hash_bits != 0);
     /* can't double size, and there is no point in resizing
@@ -1702,7 +1702,7 @@ HTNAME(hashtable_, NAME_KEY,
 
     uint overwraps = 0;
     ENTRY_TYPE e;
-    bool lockless_access = TEST(HASHTABLE_LOCKLESS_ACCESS, table->table_flags);
+    bool lockless_access = TESTANY(HASHTABLE_LOCKLESS_ACCESS, table->table_flags);
 
     if (!INTERNAL_OPTION(hashtable_study))
         return;
@@ -1789,7 +1789,7 @@ HTNAME(hashtable_, NAME_KEY,
     /* for bug 2271 we make more lenient for non trace tables using the
      * _NONE hash function (i.e. private bb) when we are !SHARED_FRAGMENTS_ENABLED().
      */
-    if (!TEST(HASHTABLE_RELAX_CLUSTER_CHECKS, table->table_flags) &&
+    if (!TESTANY(HASHTABLE_RELAX_CLUSTER_CHECKS, table->table_flags) &&
         (lockless_access || table->hash_func != HASH_FUNCTION_NONE ||
          SHARED_FRAGMENTS_ENABLED()))
         ave_len_threshold = 5;
@@ -1798,7 +1798,7 @@ HTNAME(hashtable_, NAME_KEY,
     DOLOG(1, LOG_HTABLE | LOG_STATS, {
         /* This happens enough that it's good to get some info on it */
         if (!(total_len <= ave_len_threshold * num ||
-              (TEST(HASHTABLE_RELAX_CLUSTER_CHECKS, table->table_flags) &&
+              (TESTANY(HASHTABLE_RELAX_CLUSTER_CHECKS, table->table_flags) &&
                table->capacity <= 513))) {
             /* Hash table high average collision length */
             LOG(THREAD, LOG_HTABLE | LOG_STATS, 1,
@@ -1845,7 +1845,7 @@ HTNAME(hashtable_, NAME_KEY, _dump_table)(dcontext_t *dcontext,
     track_cache_lines = true;
     entry_size = sizeof(AUX_ENTRY_TYPE);
 #        else
-    track_cache_lines = TEST(HASHTABLE_ALIGN_TABLE, htable->table_flags);
+    track_cache_lines = TESTANY(HASHTABLE_ALIGN_TABLE, htable->table_flags);
     entry_size = sizeof(ENTRY_TYPE);
 #        endif
 

--- a/core/heap.c
+++ b/core/heap.c
@@ -1204,7 +1204,7 @@ vmcode_get_end(void)
 static vm_heap_t *
 vmheap_for_which(which_vmm_t which)
 {
-    if (TEST(VMM_REACHABLE, which) || REACHABLE_HEAP())
+    if (TESTANY(VMM_REACHABLE, which) || REACHABLE_HEAP())
         return &heapmgt->vmcode;
     else
         return &heapmgt->vmheap;
@@ -1281,7 +1281,7 @@ has_guard_pages(which_vmm_t which)
 {
     if (!DYNAMO_OPTION(guard_pages))
         return false;
-    if (TEST(VMM_PER_THREAD, which) && !DYNAMO_OPTION(per_thread_guard_pages))
+    if (TESTANY(VMM_PER_THREAD, which) && !DYNAMO_OPTION(per_thread_guard_pages))
         return false;
     return true;
 }
@@ -1364,46 +1364,46 @@ vmm_update_block_stats(which_vmm_t which, uint num_blocks, bool add)
      * We confirm our assumptions here.
      */
     ASSERT(!TESTALL(VMM_REACHABLE | VMM_STACK, which) &&
-           (TEST(VMM_REACHABLE, which) || !TEST(VMM_CACHE, which)));
+           (TESTANY(VMM_REACHABLE, which) || !TESTANY(VMM_CACHE, which)));
     /* XXX: find some way to make a stats array */
     if (add) {
-        if (TEST(VMM_HEAP, which)) {
-            if (TEST(VMM_REACHABLE, which))
+        if (TESTANY(VMM_HEAP, which)) {
+            if (TESTANY(VMM_REACHABLE, which))
                 RSTATS_ADD_PEAK(vmm_blocks_reach_heap, num_blocks);
             else
                 RSTATS_ADD_PEAK(vmm_blocks_unreach_heap, num_blocks);
-        } else if (TEST(VMM_CACHE, which))
+        } else if (TESTANY(VMM_CACHE, which))
             RSTATS_ADD_PEAK(vmm_blocks_reach_cache, num_blocks);
-        else if (TEST(VMM_STACK, which))
+        else if (TESTANY(VMM_STACK, which))
             RSTATS_ADD_PEAK(vmm_blocks_unreach_stack, num_blocks);
-        else if (TEST(VMM_SPECIAL_HEAP, which)) {
-            if (TEST(VMM_REACHABLE, which))
+        else if (TESTANY(VMM_SPECIAL_HEAP, which)) {
+            if (TESTANY(VMM_REACHABLE, which))
                 RSTATS_ADD_PEAK(vmm_blocks_reach_special_heap, num_blocks);
             else
                 RSTATS_ADD_PEAK(vmm_blocks_unreach_special_heap, num_blocks);
-        } else if (TEST(VMM_SPECIAL_MMAP, which)) {
-            if (TEST(VMM_REACHABLE, which))
+        } else if (TESTANY(VMM_SPECIAL_MMAP, which)) {
+            if (TESTANY(VMM_REACHABLE, which))
                 RSTATS_ADD_PEAK(vmm_blocks_reach_special_mmap, num_blocks);
             else
                 RSTATS_ADD_PEAK(vmm_blocks_unreach_special_mmap, num_blocks);
         }
     } else {
-        if (TEST(VMM_HEAP, which)) {
-            if (TEST(VMM_REACHABLE, which))
+        if (TESTANY(VMM_HEAP, which)) {
+            if (TESTANY(VMM_REACHABLE, which))
                 RSTATS_SUB(vmm_blocks_reach_heap, num_blocks);
             else
                 RSTATS_SUB(vmm_blocks_unreach_heap, num_blocks);
-        } else if (TEST(VMM_CACHE, which))
+        } else if (TESTANY(VMM_CACHE, which))
             RSTATS_SUB(vmm_blocks_reach_cache, num_blocks);
-        else if (TEST(VMM_STACK, which))
+        else if (TESTANY(VMM_STACK, which))
             RSTATS_SUB(vmm_blocks_unreach_stack, num_blocks);
-        else if (TEST(VMM_SPECIAL_HEAP, which)) {
-            if (TEST(VMM_REACHABLE, which))
+        else if (TESTANY(VMM_SPECIAL_HEAP, which)) {
+            if (TESTANY(VMM_REACHABLE, which))
                 RSTATS_SUB(vmm_blocks_reach_special_heap, num_blocks);
             else
                 RSTATS_SUB(vmm_blocks_unreach_special_heap, num_blocks);
-        } else if (TEST(VMM_SPECIAL_MMAP, which)) {
-            if (TEST(VMM_REACHABLE, which))
+        } else if (TESTANY(VMM_SPECIAL_MMAP, which)) {
+            if (TESTANY(VMM_REACHABLE, which))
                 RSTATS_SUB(vmm_blocks_reach_special_mmap, num_blocks);
             else
                 RSTATS_SUB(vmm_blocks_unreach_special_mmap, num_blocks);
@@ -1530,7 +1530,7 @@ reached_beyond_vmm(which_vmm_t which)
         dump_global_rstats_to_stderr();
     char message[256];
     if (DYNAMO_OPTION(satisfy_w_xor_x) &&
-        (TEST(VMM_REACHABLE, which) || REACHABLE_HEAP())) {
+        (TESTANY(VMM_REACHABLE, which) || REACHABLE_HEAP())) {
         /* We do not bother to try to mirror separate from-OS allocs: the user
          * should set -vm_size 2G instead and take the rip-rel mangling hit
          * (see i#3570).
@@ -1606,7 +1606,7 @@ vmm_heap_reserve(size_t size, heap_error_code_t *error_code, bool executable,
             });
             reached_beyond_vmm(which);
 #ifdef X64
-            if (TEST(VMM_REACHABLE, which) || REACHABLE_HEAP()) {
+            if (TESTANY(VMM_REACHABLE, which) || REACHABLE_HEAP()) {
                 /* PR 215395, make sure allocation satisfies heap reachability
                  * contraints */
                 p = os_heap_reserve_in_region(
@@ -1670,12 +1670,12 @@ vmm_heap_reserve(size_t size, heap_error_code_t *error_code, bool executable,
             DODEBUG({ out_of_vmheap_once = true; });
             if (!INTERNAL_OPTION(skip_out_of_vm_reserve_curiosity)) {
                 /* this maybe unsafe for early services w.r.t. case 666 */
-                SYSLOG_INTERNAL_WARNING("Out of %s reservation - reserving %dKB. "
-                                        "Falling back onto OS allocation",
-                                        (TEST(VMM_REACHABLE, which) || REACHABLE_HEAP())
-                                            ? "vmcode"
-                                            : "vmheap",
-                                        size / 1024);
+                SYSLOG_INTERNAL_WARNING(
+                    "Out of %s reservation - reserving %dKB. "
+                    "Falling back onto OS allocation",
+                    (TESTANY(VMM_REACHABLE, which) || REACHABLE_HEAP()) ? "vmcode"
+                                                                        : "vmheap",
+                    size / 1024);
                 ASSERT_CURIOSITY(false && "Out of vmheap reservation");
             }
             /* This actually-out trigger is only trying to help issues like a
@@ -1692,7 +1692,7 @@ vmm_heap_reserve(size_t size, heap_error_code_t *error_code, bool executable,
     /* if we fail to allocate from our reservation we fall back to the OS */
     reached_beyond_vmm(which);
 #ifdef X64
-    if (TEST(VMM_REACHABLE, which) || REACHABLE_HEAP()) {
+    if (TESTANY(VMM_REACHABLE, which) || REACHABLE_HEAP()) {
         /* PR 215395, make sure allocation satisfies heap reachability contraints */
         p = os_heap_reserve_in_region(
             (void *)ALIGN_FORWARD(heap_allowable_region_start, PAGE_SIZE),
@@ -1912,7 +1912,7 @@ vmm_heap_decommit(vm_addr_t p, size_t size, heap_error_code_t *error_code,
 static void *
 vmm_heap_alloc(size_t size, uint prot, heap_error_code_t *error_code, which_vmm_t which)
 {
-    vm_addr_t p = vmm_heap_reserve(size, error_code, TEST(MEMPROT_EXEC, prot), which);
+    vm_addr_t p = vmm_heap_reserve(size, error_code, TESTANY(MEMPROT_EXEC, prot), which);
     if (!p)
         return NULL; /* out of reserved memory */
 
@@ -2568,7 +2568,7 @@ report_low_on_memory(which_vmm_t which, oom_source_t source,
         SYSLOG_INTERNAL_WARNING("Mostly silent OOM: %s " PFX ".\n",
                                 get_oom_source_name(source), os_error_code);
         /* still produce an ldmp for internal use */
-        if (TEST(DUMPCORE_OUT_OF_MEM_SILENT, DYNAMO_OPTION(dumpcore_mask)))
+        if (TESTANY(DUMPCORE_OUT_OF_MEM_SILENT, DYNAMO_OPTION(dumpcore_mask)))
             os_dump_core("Out of memory, silently aborting program.");
     } else {
         const char *oom_source_code = get_oom_source_name(source);
@@ -2586,7 +2586,7 @@ report_low_on_memory(which_vmm_t which, oom_source_t source,
             dump_global_rstats_to_stderr();
 
         /* XXX: case 7296 - ldmp even if we have decided not to produce an event above */
-        if (TEST(DUMPCORE_OUT_OF_MEM, DYNAMO_OPTION(dumpcore_mask)))
+        if (TESTANY(DUMPCORE_OUT_OF_MEM, DYNAMO_OPTION(dumpcore_mask)))
             os_dump_core("Out of memory, aborting program.");
 
         /* pass only status code to XML where we should have a stack dump and callstack */
@@ -2870,7 +2870,8 @@ get_guarded_real_memory(size_t reserve_size, size_t commit_size, uint prot, bool
 #endif
 
     if (try_vmm)
-        p = vmm_heap_reserve(reserve_size, &error_code, TEST(MEMPROT_EXEC, prot), which);
+        p = vmm_heap_reserve(reserve_size, &error_code, TESTANY(MEMPROT_EXEC, prot),
+                             which);
 
 #ifdef WINDOWS
     if (!try_vmm || p < (vm_addr_t)min_addr) {
@@ -2878,7 +2879,7 @@ get_guarded_real_memory(size_t reserve_size, size_t commit_size, uint prot, bool
             vmm_heap_free(p, reserve_size, &error_code, which);
         p = os_heap_reserve_in_region((void *)ALIGN_FORWARD(min_addr, PAGE_SIZE),
                                       (void *)PAGE_START(POINTER_MAX), reserve_size,
-                                      &error_code, TEST(MEMPROT_EXEC, prot));
+                                      &error_code, TESTANY(MEMPROT_EXEC, prot));
         /* No reason to update heap-reachable b/c stack doesn't need to reach
          * (min_addr != NULL assumed to be stack).
          */
@@ -2890,8 +2891,8 @@ get_guarded_real_memory(size_t reserve_size, size_t commit_size, uint prot, bool
         if (p == NULL) {
             SYSLOG_INTERNAL_WARNING_ONCE("Unable to allocate dstack above app stack");
             if (!try_vmm) {
-                p = vmm_heap_reserve(reserve_size, &error_code, TEST(MEMPROT_EXEC, prot),
-                                     which);
+                p = vmm_heap_reserve(reserve_size, &error_code,
+                                     TESTANY(MEMPROT_EXEC, prot), which);
             }
         }
     }
@@ -2905,7 +2906,8 @@ get_guarded_real_memory(size_t reserve_size, size_t commit_size, uint prot, bool
         heap_low_on_memory();
         fcache_low_on_memory();
 
-        p = vmm_heap_reserve(reserve_size, &error_code, TEST(MEMPROT_EXEC, prot), which);
+        p = vmm_heap_reserve(reserve_size, &error_code, TESTANY(MEMPROT_EXEC, prot),
+                             which);
         if (p == NULL) {
             report_low_on_memory(which, OOM_RESERVE, error_code);
         }
@@ -2966,7 +2968,7 @@ heap_mmap_ex(size_t reserve_size, size_t commit_size, uint prot, bool guarded,
     void *p = get_guarded_real_memory(reserve_size, commit_size, prot, true, guarded,
                                       NULL, which _IF_DEBUG("heap_mmap"));
 #ifdef DEBUG_MEMORY
-    if (TEST(MEMPROT_WRITE, prot))
+    if (TESTANY(MEMPROT_WRITE, prot))
         memset(vmm_get_writable_addr(p, which), HEAP_ALLOCATED_BYTE, commit_size);
 #endif
     /* We rely on this for freeing _post_stack in absence of dcontext */
@@ -4707,7 +4709,7 @@ protect_local_units_helper(heap_unit_t *u, bool writable)
 static void
 protect_threadunits(thread_units_t *tu, bool writable)
 {
-    ASSERT(TEST(SELFPROT_LOCAL, dynamo_options.protect_mask));
+    ASSERT(TESTANY(SELFPROT_LOCAL, dynamo_options.protect_mask));
     if (tu->writable == writable)
         return;
     protect_local_units_helper(tu->top_unit, writable);
@@ -4730,7 +4732,7 @@ protect_local_heap(dcontext_t *dcontext, bool writable)
 void
 protect_global_heap(bool writable)
 {
-    ASSERT(TEST(SELFPROT_GLOBAL, dynamo_options.protect_mask));
+    ASSERT(TESTANY(SELFPROT_GLOBAL, dynamo_options.protect_mask));
 
     acquire_recursive_lock(&global_alloc_lock);
 

--- a/core/heap.c
+++ b/core/heap.c
@@ -2869,9 +2869,10 @@ get_guarded_real_memory(size_t reserve_size, size_t commit_size, uint prot, bool
     }
 #endif
 
-    if (try_vmm)
+    if (try_vmm) {
         p = vmm_heap_reserve(reserve_size, &error_code, TESTANY(MEMPROT_EXEC, prot),
                              which);
+    }
 
 #ifdef WINDOWS
     if (!try_vmm || p < (vm_addr_t)min_addr) {

--- a/core/heap.h
+++ b/core/heap.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -322,9 +322,10 @@ global_unprotected_heap_free(void *p, size_t size HEAPACCT(which_heap_t which));
 #define UNPROTECTED_GLOBAL_FREE global_unprotected_heap_free
 
 /* use global heap for shared fragments and their related data structures */
-#define FRAGMENT_ALLOC_DC(dc, flags) (TEST(FRAG_SHARED, (flags)) ? GLOBAL_DCONTEXT : (dc))
+#define FRAGMENT_ALLOC_DC(dc, flags) \
+    (TESTANY(FRAG_SHARED, (flags)) ? GLOBAL_DCONTEXT : (dc))
 #define FRAGMENT_TABLE_ALLOC_DC(dc, flags) \
-    (TEST(HASHTABLE_SHARED, (flags)) ? GLOBAL_DCONTEXT : (dc))
+    (TESTANY(HASHTABLE_SHARED, (flags)) ? GLOBAL_DCONTEXT : (dc))
 
 /* convenience for allocating a single type: does cast, sizeof, and HEAPACCT
  * for you, and takes param for whether protected or not

--- a/core/hotpatch.c
+++ b/core/hotpatch.c
@@ -1180,7 +1180,7 @@ hotp_load_hotp_dlls(hotp_vul_t *vul_tab, uint num_vuls)
 
             /* Liveshields give just the base name which is used to compute
              * full path, i.e., DYNAMORIO_HOME/lib/hotp/hotp_dll. */
-            if (TEST(HOTP_TYPE_HOT_PATCH, VUL(vul_tab, vul).type)) {
+            if (TESTANY(HOTP_TYPE_HOT_PATCH, VUL(vul_tab, vul).type)) {
                 strncpy(hotp_dll_path, hotp_dll_cache,
                         BUFFER_SIZE_ELEMENTS(hotp_dll_path) - 1);
                 NULL_TERMINATE_BUFFER(hotp_dll_path);
@@ -2241,8 +2241,8 @@ hotp_process_image_helper(const app_pc base, const bool loaded,
     }
 #    ifdef WINDOWS
     DOCHECK(1, {
-        if (TEST(ASLR_DLL, DYNAMO_OPTION(aslr)) &&
-            TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache))) {
+        if (TESTANY(ASLR_DLL, DYNAMO_OPTION(aslr)) &&
+            TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache))) {
             /* case 8507 - the timestamp and possibly checksum of the current mapping,
                possibly ASLRed, may not be the same as the application DLL */
             uint pe_timestamp;
@@ -3176,16 +3176,16 @@ hotp_nudge_handler(uint nudge_action_mask)
     ASSERT(DYNAMO_OPTION(liveshields) && DYNAMO_OPTION(hot_patching));
     ASSERT(nudge_action_mask != 0); /* else shouldn't be called */
 
-    if (TEST(NUDGE_GENERIC(lstats), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(lstats), nudge_action_mask)) {
         SYSLOG_INTERNAL_WARNING("Stat dumping for hot patches not done yet.");
     }
 
-    if (TEST(NUDGE_GENERIC(policy), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(policy), nudge_action_mask)) {
         LOG(GLOBAL, LOG_HOT_PATCHING, 1, "\n nudged to read in policy\n");
         nudge_action_read_policies();
     }
 
-    if (TEST(NUDGE_GENERIC(mode), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(mode), nudge_action_mask)) {
         thread_record_t **thread_table = NULL;
         int num_threads = 0;
         hotp_policy_mode_t *old_modes = NULL;
@@ -3291,8 +3291,8 @@ hotp_nudge_handler(uint nudge_action_mask)
      * the new patch points at match time, and we avoid flushing here with
      * checks in vm_area_allsynch_flush_fragments.
      */
-    if (TEST(NUDGE_GENERIC(mode), nudge_action_mask) ||
-        TEST(NUDGE_GENERIC(policy), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(mode), nudge_action_mask) ||
+        TESTANY(NUDGE_GENERIC(policy), nudge_action_mask)) {
         if (!DYNAMO_OPTION(hotp_only))
             hotp_remove_hot_patches(GLOBAL_VUL_TABLE, NUM_GLOBAL_VULS, false, NULL);
     }
@@ -3606,7 +3606,7 @@ hotp_inject_gateway_call(dcontext_t *dcontext, instrlist_t *ilist, instr_t *wher
 
     /* DSTACK_OFFSET isn't within the upcontext so if it's separate our use of
      * insert_get_mcontext_base() above is incorrect. */
-    ASSERT_NOT_IMPLEMENTED(!TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
+    ASSERT_NOT_IMPLEMENTED(!TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
 
     /* We push eax as a parameter to the call */
     GET_FROM_DC_OFFS_TO_REG(DSTACK_OFFSET, REG_XAX, false /* !have_dc */, REG_XBX);
@@ -4734,7 +4734,8 @@ hotp_gateway(const hotp_vul_t *vul_tab, const uint num_vuls, const uint vul_inde
         APP_XDX(app_reg_ptr) = (reg_t)ppoint_addr;
     } else {
         /* A hot patch can be only one type. */
-        ASSERT(TEST(HOTP_TYPE_HOT_PATCH, hotp_type) ^ TEST(HOTP_TYPE_PROBE, hotp_type));
+        ASSERT(TESTANY(HOTP_TYPE_HOT_PATCH, hotp_type) ^
+               TESTANY(HOTP_TYPE_PROBE, hotp_type));
     }
     /* Under the current design, a detector will always be called; a protector
      * will be called only if the mode says so.
@@ -4758,8 +4759,8 @@ hotp_gateway(const hotp_vul_t *vul_tab, const uint num_vuls, const uint vul_inde
         exec_status = HOTP_EXEC_EXPLOIT_DETECTED;
     } else {
         /* A hot patch can be only one type. */
-        ASSERT(TEST(HOTP_TYPE_HOT_PATCH, hotp_type) ^
-               TEST(HOTP_TYPE_GBOP_HOOK, hotp_type));
+        ASSERT(TESTANY(HOTP_TYPE_HOT_PATCH, hotp_type) ^
+               TESTANY(HOTP_TYPE_GBOP_HOOK, hotp_type));
 
         exec_status = hotp_execute_patch(detector_fn, app_reg_ptr, mode, dump_excpt_info,
                                          dump_error_info);
@@ -4797,7 +4798,7 @@ hotp_gateway(const hotp_vul_t *vul_tab, const uint num_vuls, const uint vul_inde
      * Note: In this case, the gbop protector won't get executed even though
      * its mode is set to protect.  See below.
      */
-    if (TEST(exec_status, HOTP_EXEC_LOG_EVENT) &&
+    if (TESTANY(exec_status, HOTP_EXEC_LOG_EVENT) &&
         ((mode == HOTP_MODE_DETECT) ||
          (TESTALL(HOTP_TYPE_GBOP_HOOK, hotp_type)
 #    ifdef PROGRAM_SHEPHERDING
@@ -4862,10 +4863,10 @@ hotp_gateway(const hotp_vul_t *vul_tab, const uint num_vuls, const uint vul_inde
 
         /* Which one comes first, esp with kill/raise & cflow change? */
         /* Raise an event only if requested by the protector. */
-        if (TEST(exec_status, HOTP_EXEC_LOG_EVENT)) {
+        if (TESTANY(exec_status, HOTP_EXEC_LOG_EVENT)) {
             hotp_event_notify(exec_status, true, &ppoint, gbop_bad_addr, app_reg_ptr);
         }
-        if (TEST(exec_status, HOTP_EXEC_CHANGE_CONTROL_FLOW)) {
+        if (TESTANY(exec_status, HOTP_EXEC_CHANGE_CONTROL_FLOW)) {
 
             app_rva_t return_rva =
                 PPOINT(vul_tab, vul_index, set_index, module_index, ppoint_index)
@@ -4989,16 +4990,16 @@ Question for reviewer: for hotp_only, when control comes to the gateway, should
             memcpy(hotp_cxt, &local_cxt, sizeof(hotp_context_t));
         }
 
-        if ((TEST(HOTP_EXEC_DETECTOR_ERROR, exec_status_only) ||
-             (TEST(HOTP_EXEC_PROTECTOR_ERROR, exec_status_only)))) {
-            const char *msg = TEST(HOTP_EXEC_DETECTOR_ERROR, exec_status_only)
+        if ((TESTANY(HOTP_EXEC_DETECTOR_ERROR, exec_status_only) ||
+             (TESTANY(HOTP_EXEC_PROTECTOR_ERROR, exec_status_only)))) {
+            const char *msg = TESTANY(HOTP_EXEC_DETECTOR_ERROR, exec_status_only)
                 ? "Hot patch detector error"
                 : "Hot patch protector error";
             if (dump_error_info) {
-                if (TEST(DUMPCORE_HOTP_FAILURE, DYNAMO_OPTION(dumpcore_mask)))
+                if (TESTANY(DUMPCORE_HOTP_FAILURE, DYNAMO_OPTION(dumpcore_mask)))
                     os_dump_core(msg);
             }
-            if (TEST(HOTP_EXEC_LOG_EVENT, exec_status)) {
+            if (TESTANY(HOTP_EXEC_LOG_EVENT, exec_status)) {
                 SYSLOG_CUSTOM_NOTIFY(SYSLOG_ERROR, MSG_HOT_PATCH_FAILURE, 3,
                                      "Hot patch error, continuing.",
                                      get_application_name(), get_application_pid(),

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2016-2024 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -81,7 +81,7 @@ decode_bitmask(uint enc)
     uint len = enc & 63;
     ptr_uint_t x;
 
-    if (TEST(1U << 12, enc)) {
+    if (TESTANY(1U << 12, enc)) {
         if (len == 63)
             return 0;
         x = MASK(len + 1);
@@ -262,7 +262,7 @@ encode_pc_off(OUT uint *poff, int bits, byte *pc, instr_t *instr, opnd_t opnd,
     else
         return false;
     range = (ptr_uint_t)1 << bits;
-    if (!TEST(~((range - 1) << 2), off + (range << 1))) {
+    if (!TESTANY(~((range - 1) << 2), off + (range << 1))) {
         *poff = off >> 2 & (range - 1);
         return true;
     }
@@ -697,7 +697,7 @@ static int
 mem7_scale(uint enc)
 {
     return 2 +
-        (TEST(1U << 26, enc) ? extract_uint(enc, 30, 2) : extract_uint(enc, 31, 1));
+        (TESTANY(1U << 26, enc) ? extract_uint(enc, 30, 2) : extract_uint(enc, 31, 1));
 }
 
 /* Used for memlit operand type, used by load (literal). Returns the size
@@ -710,7 +710,7 @@ memlit_size(uint enc)
     switch (extract_uint(enc, 30, 2)) {
     case 0: size = OPSZ_4; break;
     case 1: size = OPSZ_8; break;
-    case 2: size = TEST(1U << 26, enc) ? OPSZ_16 : OPSZ_4;
+    case 2: size = TESTANY(1U << 26, enc) ? OPSZ_16 : OPSZ_4;
     }
     return size;
 }
@@ -998,7 +998,7 @@ extract_imm13_size(uint enc)
     const ptr_uint_t value = extract_uint(enc, 5, 13);
 
     /* Bit 12 is high iff type is a double */
-    if (TEST(1 << 12, value))
+    if (TESTANY(1 << 12, value))
         return DOUBLE_REG;
 
     /* For the remaining, invert the value and find the index of the highest high bit
@@ -1121,7 +1121,7 @@ encode_opnd_adr_page(int scale, byte *pc, opnd_t opnd, OUT uint *enc_out, instr_
 static inline bool
 decode_opnd_dq_plus(int add, int rpos, int qpos, uint enc, OUT opnd_t *opnd)
 {
-    *opnd = opnd_create_reg((TEST(1U << qpos, enc) ? DR_REG_Q0 : DR_REG_D0) +
+    *opnd = opnd_create_reg((TESTANY(1U << qpos, enc) ? DR_REG_Q0 : DR_REG_D0) +
                             (extract_uint(enc, rpos, 5) + add) % 32);
     return true;
 }
@@ -1145,7 +1145,7 @@ encode_opnd_dq_plus(int add, int rpos, int qpos, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_dq_q(int reg_pos, uint enc, OUT opnd_t *opnd)
 {
-    const reg_id_t min_reg = TEST(1U << 30, enc) ? DR_REG_Q0 : DR_REG_D0;
+    const reg_id_t min_reg = TESTANY(1U << 30, enc) ? DR_REG_Q0 : DR_REG_D0;
     const reg_id_t reg_id = min_reg + extract_uint(enc, reg_pos, 5);
 
     const uint sz = extract_uint(enc, 22, 1);
@@ -1181,7 +1181,7 @@ encode_opnd_dq_q(int rpos, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_sd(int rpos, int qpos, uint enc, OUT opnd_t *opnd)
 {
-    *opnd = opnd_create_reg((TEST(1U << qpos, enc) ? DR_REG_D0 : DR_REG_S0) +
+    *opnd = opnd_create_reg((TESTANY(1U << qpos, enc) ? DR_REG_D0 : DR_REG_S0) +
                             (extract_uint(enc, rpos, 5) % 32));
     return true;
 }
@@ -1259,7 +1259,7 @@ encode_opnd_int(int pos, int len, bool signd, int scale, dr_opnd_flags_t flags,
 static bool
 decode_opnd_imm_bf(int pos, uint enc, OUT opnd_t *opnd)
 {
-    if (!TEST(1U << 31, enc) && extract_uint(enc, pos, 6) >= 32)
+    if (!TESTANY(1U << 31, enc) && extract_uint(enc, pos, 6) >= 32)
         return false;
     return decode_opnd_int(pos, 6, false, 0, OPSZ_6b, 0, enc, opnd);
 }
@@ -1267,7 +1267,7 @@ decode_opnd_imm_bf(int pos, uint enc, OUT opnd_t *opnd)
 static bool
 encode_opnd_imm_bf(int pos, uint enc, opnd_t opnd, uint *enc_out)
 {
-    if (!TEST(1U << 31, enc) && extract_uint(enc, pos, 6) >= 32)
+    if (!TESTANY(1U << 31, enc) && extract_uint(enc, pos, 6) >= 32)
         return false;
     return encode_opnd_int(pos, 6, false, 0, 0, opnd, enc_out);
 }
@@ -1381,7 +1381,7 @@ encode_opnd_mem9_bytes(int bytes, bool post, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_memreg_size(opnd_size_t size, uint enc, OUT opnd_t *opnd)
 {
-    if (!TEST(1U << 14, enc))
+    if (!TESTANY(1U << 14, enc))
         return false;
     dr_extend_type_t extend;
     switch (enc >> 13 & 7) {
@@ -1395,8 +1395,8 @@ decode_opnd_memreg_size(opnd_size_t size, uint enc, OUT opnd_t *opnd)
 
     *opnd = opnd_create_base_disp_aarch64(
         decode_reg(enc >> 5 & 31, true, true),
-        decode_reg(enc >> 16 & 31, TEST(1U << 13, enc), false), extend,
-        TEST(1U << 12, enc), 0, 0, size);
+        decode_reg(enc >> 16 & 31, TESTANY(1U << 13, enc), false), extend,
+        TESTANY(1U << 12, enc), 0, 0, size);
     return true;
 }
 
@@ -1411,7 +1411,7 @@ encode_opnd_memreg_size(opnd_size_t size, opnd_t opnd, OUT uint *enc_out)
 
     option = opnd_get_index_extend(opnd, &scaled, NULL);
 
-    if (!TEST(2, option))
+    if (!TESTANY(2, option))
         return false;
 
     if (!encode_reg(&rn, &xn, opnd_get_base(opnd), true) || !xn ||
@@ -1447,7 +1447,7 @@ static inline bool
 decode_opnd_rn(bool is_sp, int pos, int sz_bit, uint enc, OUT opnd_t *opnd)
 {
     *opnd = opnd_create_reg(
-        decode_reg(extract_uint(enc, pos, 5), TEST(1U << sz_bit, enc), is_sp));
+        decode_reg(extract_uint(enc, pos, 5), TESTANY(1U << sz_bit, enc), is_sp));
     return true;
 }
 
@@ -1494,7 +1494,7 @@ decode_opnd_vtn(int add, uint enc, OUT opnd_t *opnd)
 {
     if (extract_uint(enc, 10, 2) == 3 && extract_uint(enc, 30, 1) == 0)
         return false;
-    *opnd = opnd_create_reg((TEST(1U << 30, enc) ? DR_REG_Q0 : DR_REG_D0) +
+    *opnd = opnd_create_reg((TESTANY(1U << 30, enc) ? DR_REG_Q0 : DR_REG_D0) +
                             ((extract_uint(enc, 0, 5) + add) % 32));
     return true;
 }
@@ -3065,7 +3065,7 @@ encode_opnd_cmode4_s_sz_msl(uint enc, int opcode, byte *pc, opnd_t opnd,
 
     int64 sz_shft = opnd_get_immed_int(opnd);
     int shift = (int)(sz_shft & 0xffffffff);
-    if (!TEST(1U << CMODE_MSL_BIT, shift)) // MSL bit should be set
+    if (!TESTANY(1U << CMODE_MSL_BIT, shift)) // MSL bit should be set
         return false;
     shift &= 0xff;
     const int size = (int)(sz_shft >> 32);
@@ -3396,7 +3396,7 @@ encode_opnd_cmode_s_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
 
     const int64 sz_shft = opnd_get_immed_int(opnd);
     const int shift = (int)(sz_shft & 0xffffffff);
-    if (TEST(1U << CMODE_MSL_BIT, shift)) // MSL bit should not be set as this is LSL
+    if (TESTANY(1U << CMODE_MSL_BIT, shift)) // MSL bit should not be set as this is LSL
         return false;
     const int size = (int)(sz_shft >> 32);
 
@@ -5214,7 +5214,8 @@ encode_opnd_z_sz21_sd_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *e
 static inline bool
 decode_opnd_z_sz21_sd_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    const aarch64_reg_offset element_size = TEST(1u << 21, enc) ? DOUBLE_REG : SINGLE_REG;
+    const aarch64_reg_offset element_size =
+        TESTANY(1u << 21, enc) ? DOUBLE_REG : SINGLE_REG;
     return decode_single_sized(DR_REG_Z0, DR_REG_Z31, 0, 5, element_size, 0, enc, opnd);
 }
 
@@ -5468,7 +5469,7 @@ decode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, OUT opnd_t *opnd
     int offset9 = extract_int(simm9, 0, 9);
     IF_RETURN_FALSE(offset9 < -256 || offset9 > 255)
 
-    bool is_vector = TEST(1u << 14, enc);
+    bool is_vector = TESTANY(1u << 14, enc);
 
     /* Transfer size depends on whether we are transferring a Z or a P register. */
     opnd_size_t memory_transfer_size =
@@ -5499,7 +5500,7 @@ encode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, opnd_t opnd,
     bool is_x;
     uint rn;
 
-    bool is_vector = TEST(1u << 14, enc);
+    bool is_vector = TESTANY(1u << 14, enc);
 
     /* Transfer size depends on whether we are transferring a Z or a P register. */
     opnd_size_t memory_transfer_size =
@@ -6011,7 +6012,8 @@ encode_opnd_z_sz_sd(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_o
 static inline bool
 decode_opnd_z_sz_sd(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    const aarch64_reg_offset element_size = TEST(1u << 22, enc) ? DOUBLE_REG : SINGLE_REG;
+    const aarch64_reg_offset element_size =
+        TESTANY(1u << 22, enc) ? DOUBLE_REG : SINGLE_REG;
     return decode_single_sized(DR_REG_Z0, DR_REG_Z31, 0, 5, element_size, 0, enc, opnd);
 }
 
@@ -8263,11 +8265,12 @@ encode_svemem_gpr_vec_xs(uint enc, uint pos, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_svemem_gpr_vec32_st(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    const aarch64_reg_offset element_size = TEST(1u << 22, enc) ? SINGLE_REG : DOUBLE_REG;
+    const aarch64_reg_offset element_size =
+        TESTANY(1u << 22, enc) ? SINGLE_REG : DOUBLE_REG;
     const aarch64_reg_offset msz = BITS(enc, 24, 23);
-    const bool scaled = TEST(1u << 21, enc);
+    const bool scaled = TESTANY(1u << 21, enc);
 
-    const dr_extend_type_t mod = TEST(1u << 14, enc) ? DR_EXTEND_SXTW : DR_EXTEND_UXTW;
+    const dr_extend_type_t mod = TESTANY(1u << 14, enc) ? DR_EXTEND_SXTW : DR_EXTEND_UXTW;
 
     return decode_svemem_gpr_vec(enc, element_size, mod, msz, scaled, false, opnd);
 }
@@ -8276,9 +8279,10 @@ static inline bool
 encode_opnd_svemem_gpr_vec32_st(uint enc, int opcode, byte *pc, opnd_t opnd,
                                 OUT uint *enc_out)
 {
-    const aarch64_reg_offset element_size = TEST(1u << 22, enc) ? SINGLE_REG : DOUBLE_REG;
+    const aarch64_reg_offset element_size =
+        TESTANY(1u << 22, enc) ? SINGLE_REG : DOUBLE_REG;
     const uint msz = BITS(enc, 24, 23);
-    const bool scaled = TEST(1u << 21, enc);
+    const bool scaled = TESTANY(1u << 21, enc);
 
     return encode_svemem_gpr_vec(enc, element_size, msz, scaled, opnd, enc_out) &&
         encode_svemem_gpr_vec_xs(enc, 14, opnd, enc_out);
@@ -8759,7 +8763,7 @@ encode_opnd_memvm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
 static inline bool
 decode_opnd_dq16_h_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    *opnd = opnd_create_reg((TEST(1U << 30, enc) ? DR_REG_Q0 : DR_REG_D0) +
+    *opnd = opnd_create_reg((TESTANY(1U << 30, enc) ? DR_REG_Q0 : DR_REG_D0) +
                             extract_uint(enc, 16, 4));
     return true;
 }
@@ -8787,7 +8791,7 @@ encode_opnd_dq16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc
 static inline bool
 decode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    *opnd = opnd_create_reg((TEST(1U << 30, enc) ? DR_REG_D0 : DR_REG_S0) +
+    *opnd = opnd_create_reg((TESTANY(1U << 30, enc) ? DR_REG_D0 : DR_REG_S0) +
                             extract_uint(enc, 16, 4));
     return true;
 }
@@ -8866,7 +8870,7 @@ encode_opnd_vdq_q_sd_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
 static inline bool
 decode_opnd_imm6(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    if (!TEST(1U << 31, enc) && TEST(1U << 15, enc))
+    if (!TESTANY(1U << 31, enc) && TESTANY(1U << 15, enc))
         return false;
     return decode_opnd_int(10, 6, false, 0, OPSZ_6b, 0, enc, opnd);
 }
@@ -8874,7 +8878,7 @@ decode_opnd_imm6(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 static inline bool
 encode_opnd_imm6(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    if (!TEST(1U << 31, enc) && TEST(1U << 15, enc))
+    if (!TESTANY(1U << 31, enc) && TESTANY(1U << 15, enc))
         return false;
     return encode_opnd_int(10, 6, false, 0, 0, opnd, enc_out);
 }
@@ -8912,7 +8916,7 @@ encode_opnd_immr(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_imm16sh(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    if (!TEST(1U << 31, enc) && TEST(1U << 22, enc))
+    if (!TESTANY(1U << 31, enc) && TESTANY(1U << 22, enc))
         return false;
     return decode_opnd_int(21, 2, false, 4, OPSZ_6b, 0, enc, opnd);
 }
@@ -8922,7 +8926,7 @@ encode_opnd_imm16sh(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_o
 {
     uint t;
     if (!encode_opnd_int(21, 2, false, 4, 0, opnd, &t) ||
-        (!TEST(1U << 31, enc) && TEST(1U << 22, t)))
+        (!TESTANY(1U << 31, enc) && TESTANY(1U << 22, t)))
         return false;
     *enc_out = t;
     return true;
@@ -9006,7 +9010,7 @@ static inline bool
 decode_opnd_sveprf_gpr_vec32(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     const aarch64_reg_offset element_size = BITS(enc, 31, 30);
-    const dr_extend_type_t mod = TEST(1u << 22, enc) ? DR_EXTEND_SXTW : DR_EXTEND_UXTW;
+    const dr_extend_type_t mod = TESTANY(1u << 22, enc) ? DR_EXTEND_SXTW : DR_EXTEND_UXTW;
     const aarch64_reg_offset msz = BITS(enc, 14, 13);
 
     return decode_svemem_gpr_vec(enc, element_size, mod, msz, msz > 0, true, opnd);
@@ -9067,8 +9071,8 @@ decode_opnd_svemem_gpr_vec32_ld(uint enc, int opcode, byte *pc, OUT opnd_t *opnd
 {
     const aarch64_reg_offset element_size = BITS(enc, 31, 30);
     const aarch64_reg_offset msz = BITS(enc, 24, 23);
-    const bool scaled = TEST(1u << 21, enc);
-    const dr_extend_type_t mod = TEST(1u << 22, enc) ? DR_EXTEND_SXTW : DR_EXTEND_UXTW;
+    const bool scaled = TESTANY(1u << 21, enc);
+    const dr_extend_type_t mod = TESTANY(1u << 22, enc) ? DR_EXTEND_SXTW : DR_EXTEND_UXTW;
 
     return decode_svemem_gpr_vec(enc, element_size, mod, msz, scaled, false, opnd);
 }
@@ -9079,7 +9083,7 @@ encode_opnd_svemem_gpr_vec32_ld(uint enc, int opcode, byte *pc, opnd_t opnd,
 {
     const aarch64_reg_offset element_size = BITS(enc, 31, 30);
     const aarch64_reg_offset msz = BITS(enc, 24, 23);
-    const bool scaled = TEST(1u << 21, enc);
+    const bool scaled = TESTANY(1u << 21, enc);
 
     return encode_svemem_gpr_vec(enc, element_size, msz, scaled, opnd, enc_out) &&
         encode_svemem_gpr_vec_xs(enc, 22, opnd, enc_out);
@@ -9326,9 +9330,9 @@ decode_opnds_cbz(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int o
     instr_set_opcode(instr, opcode);
     instr_set_num_opnds(dcontext, instr, 0, 2);
     instr_set_src(instr, 0, opnd_create_pc(pc + extract_int(enc, 5, 19) * 4));
-    instr_set_src(
-        instr, 1,
-        opnd_create_reg(decode_reg(extract_uint(enc, 0, 5), TEST(1U << 31, enc), false)));
+    instr_set_src(instr, 1,
+                  opnd_create_reg(decode_reg(extract_uint(enc, 0, 5),
+                                             TESTANY(1U << 31, enc), false)));
     return true;
 }
 
@@ -9353,11 +9357,11 @@ static inline bool
 decode_opnds_logic_imm(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr,
                        int opcode)
 {
-    bool is_x = TEST(1U << 31, enc);
+    bool is_x = TESTANY(1U << 31, enc);
     uint imm_enc = extract_uint(enc, 10, 13);     /* encoding of bitmask */
     ptr_uint_t imm_val = decode_bitmask(imm_enc); /* value of bitmask */
     bool canonical = encode_bitmask(imm_val) == imm_enc;
-    if (imm_val == 0 || (!is_x && TEST(1U << 12, imm_enc)))
+    if (imm_val == 0 || (!is_x && TESTANY(1U << 12, imm_enc)))
         return false;
     if (!is_x)
         imm_val &= 0xffffffff;
@@ -9387,10 +9391,10 @@ encode_opnds_logic_imm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
     opnd_val = instr_get_src(instr, 1);
     if (!encode_opnd_rn(opcode != OP_ands, 0, 31, instr_get_dst(instr, 0), &rd) ||
         !encode_opnd_rn(false, 5, 31, instr_get_src(instr, 0), &rn) ||
-        TEST(1U << 31, rd ^ rn) || !opnd_is_immed_int(opnd_val))
+        TESTANY(1U << 31, rd ^ rn) || !opnd_is_immed_int(opnd_val))
         return ENCFAIL;
     imm_val = opnd_get_immed_int(opnd_val);
-    if (!TEST(1U << 31, rd)) {
+    if (!TESTANY(1U << 31, rd)) {
         if ((imm_val >> 32) != 0)
             return ENCFAIL;
         imm_val |= imm_val << 32;
@@ -9459,10 +9463,11 @@ decode_opnds_tbz(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int o
     instr_set_opcode(instr, opcode);
     instr_set_num_opnds(dcontext, instr, 0, 3);
     instr_set_src(instr, 0, opnd_create_pc(pc + extract_int(enc, 5, 14) * 4));
-    instr_set_src(instr, 1,
-                  opnd_create_reg(decode_reg(extract_uint(enc, 0, 5),
-                                             TEST(1U << 31, enc), /* true if x, else w*/
-                                             false)));
+    instr_set_src(
+        instr, 1,
+        opnd_create_reg(decode_reg(extract_uint(enc, 0, 5),
+                                   TESTANY(1U << 31, enc), /* true if x, else w*/
+                                   false)));
     instr_set_src(instr, 2,
                   opnd_create_immed_int((enc >> 19 & 31) | (enc >> 26 & 32), OPSZ_5b));
     return true;

--- a/core/ir/aarch64/disassemble.c
+++ b/core/ir/aarch64/disassemble.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -114,17 +114,17 @@ opnd_base_disp_scale_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM
 bool
 opnd_disassemble_arch(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT, opnd_t opnd)
 {
-    if (opnd_is_immed_int(opnd) && TEST(DR_OPND_IS_SHIFT, opnd_get_flags(opnd))) {
+    if (opnd_is_immed_int(opnd) && TESTANY(DR_OPND_IS_SHIFT, opnd_get_flags(opnd))) {
         dr_shift_type_t t = (dr_shift_type_t)opnd_get_immed_int(opnd);
         print_to_buffer(buf, bufsz, sofar, "%s", shift_name(t));
         return true;
     }
-    if (opnd_is_immed_int(opnd) && TEST(DR_OPND_IS_EXTEND, opnd_get_flags(opnd))) {
+    if (opnd_is_immed_int(opnd) && TESTANY(DR_OPND_IS_EXTEND, opnd_get_flags(opnd))) {
         dr_extend_type_t t = (dr_extend_type_t)opnd_get_immed_int(opnd);
         print_to_buffer(buf, bufsz, sofar, "%s", extend_name(t));
         return true;
     }
-    if (opnd_is_immed_int(opnd) && TEST(DR_OPND_IS_CONDITION, opnd_get_flags(opnd))) {
+    if (opnd_is_immed_int(opnd) && TESTANY(DR_OPND_IS_CONDITION, opnd_get_flags(opnd))) {
         dr_pred_type_t pred = DR_PRED_EQ + opnd_get_immed_int(opnd);
         print_to_buffer(buf, bufsz, sofar, "%s", pred_names[pred]);
         return true;

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2016-2024 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -352,7 +352,7 @@ instr_is_floating_type(instr_t *instr, dr_instr_category_t *type DR_PARAM_OUT)
      * Processor state is saved/restored with loads and stores.
      */
     uint cat = instr_get_category(instr);
-    if (!TEST(DR_INSTR_CATEGORY_FP, cat))
+    if (!TESTANY(DR_INSTR_CATEGORY_FP, cat))
         return false;
     if (type != NULL)
         *type = cat;
@@ -366,17 +366,17 @@ instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type DR_PARAM_OUT)
      * Processor state is saved/restored with loads and stores.
      */
     uint cat = instr_get_category(instr);
-    if (!TEST(DR_INSTR_CATEGORY_FP, cat))
+    if (!TESTANY(DR_INSTR_CATEGORY_FP, cat))
         return false;
-    else if (TEST(DR_INSTR_CATEGORY_MATH, cat)) {
+    else if (TESTANY(DR_INSTR_CATEGORY_MATH, cat)) {
         if (type != NULL)
             *type = DR_FP_MATH;
         return true;
-    } else if (TEST(DR_INSTR_CATEGORY_CONVERT, cat)) {
+    } else if (TESTANY(DR_INSTR_CATEGORY_CONVERT, cat)) {
         if (type != NULL)
             *type = DR_FP_CONVERT;
         return true;
-    } else if (TEST(DR_INSTR_CATEGORY_MOVE, cat)) {
+    } else if (TESTANY(DR_INSTR_CATEGORY_MOVE, cat)) {
         if (type != NULL)
             *type = DR_FP_MOVE;
         return true;
@@ -813,7 +813,7 @@ instr_compute_vector_address(instr_t *instr, priv_mcontext_t *mc, size_t mc_size
 {
     CLIENT_ASSERT(have_addr != NULL && addr != NULL && mc != NULL && write != NULL,
                   "SVE address computation: invalid args");
-    CLIENT_ASSERT(TEST(DR_MC_MULTIMEDIA, mc_flags),
+    CLIENT_ASSERT(TESTANY(DR_MC_MULTIMEDIA, mc_flags),
                   "dr_mcontext_t.flags must include DR_MC_MULTIMEDIA");
     CLIENT_ASSERT(mc_size >= offsetof(dr_mcontext_t, svep) + sizeof(mc->svep),
                   "Incompatible client, invalid dr_mcontext_t.size.");

--- a/core/ir/arm/decode.c
+++ b/core/ir/arm/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -185,7 +185,7 @@ is_isa_mode_legal(dr_isa_mode_t mode)
 app_pc
 canonicalize_pc_target(dcontext_t *dcontext, app_pc pc)
 {
-    if (TEST(0x1, (ptr_uint_t)pc)) {
+    if (TESTANY(0x1, (ptr_uint_t)pc)) {
         dr_isa_mode_t old_mode;
         dr_set_isa_mode(dcontext, DR_ISA_ARM_THUMB, &old_mode);
         DOLOG(2, LOG_TOP, {
@@ -447,7 +447,7 @@ decode_immed(decode_info_t *di, uint start_bit, opnd_size_t opsize, bool is_sign
     if (is_signed) {
         ptr_uint_t top_bit = (1 << (opnd_size_in_bits(opsize) - 1));
         val = (ptr_int_t)(int)((di->instr_word >> start_bit) & mask);
-        if (TEST(top_bit, val))
+        if (TESTANY(top_bit, val))
             val |= (~mask);
     } else
         val = (ptr_int_t)(ptr_uint_t)((di->instr_word >> start_bit) & mask);
@@ -525,14 +525,14 @@ decode_SIMD_modified_immed(decode_info_t *di, byte optype, opnd_t *array,
          */
         uint high = 0, low = 0;
         uint64 val64;
-        high |= TEST(0x80, val) ? 0xff000000 : 0;
-        high |= TEST(0x40, val) ? 0x00ff0000 : 0;
-        high |= TEST(0x20, val) ? 0x0000ff00 : 0;
-        high |= TEST(0x10, val) ? 0x000000ff : 0;
-        low |= TEST(0x08, val) ? 0xff000000 : 0;
-        low |= TEST(0x04, val) ? 0x00ff0000 : 0;
-        low |= TEST(0x02, val) ? 0x0000ff00 : 0;
-        low |= TEST(0x01, val) ? 0x000000ff : 0;
+        high |= TESTANY(0x80, val) ? 0xff000000 : 0;
+        high |= TESTANY(0x40, val) ? 0x00ff0000 : 0;
+        high |= TESTANY(0x20, val) ? 0x0000ff00 : 0;
+        high |= TESTANY(0x10, val) ? 0x000000ff : 0;
+        low |= TESTANY(0x08, val) ? 0xff000000 : 0;
+        low |= TESTANY(0x04, val) ? 0x00ff0000 : 0;
+        low |= TESTANY(0x02, val) ? 0x0000ff00 : 0;
+        low |= TESTANY(0x01, val) ? 0x000000ff : 0;
         val64 = ((uint64)high << 32) | low;
         array[(*counter)++] = opnd_create_immed_int64(val64, OPSZ_8);
         return true;
@@ -1668,7 +1668,7 @@ decode_T32_16_ext_bits_10_8_idx(uint instr_word)
 {
     uint idx;
     /* check whether Rn is also listed in reglist */
-    if (TEST((1 << ((instr_word >> 8) & 0x7) /*Rn*/), (instr_word & 0xff) /*reglist*/))
+    if (TESTANY((1 << ((instr_word >> 8) & 0x7) /*Rn*/), (instr_word & 0xff) /*reglist*/))
         idx = 0;
     else
         idx = 1;
@@ -1816,7 +1816,7 @@ decode_instr_info_T32_32(decode_info_t *di)
     /* First, split by whether coprocessor or not */
     if (TESTALL(0xec00, di->halfwordA)) {
         /* coproc */
-        if (TEST(0x1000, di->halfwordA)) {
+        if (TESTANY(0x1000, di->halfwordA)) {
             idx = (((instr_word >> 20) & 0x3) |
                    ((instr_word >> 21) & 0x1c)); /*bits 25:23,21:20*/
             info = &T32_coproc_f[idx];
@@ -1903,7 +1903,7 @@ decode_instr_info_T32_32(decode_info_t *di)
             idx = (idx == 0) ? 0 : 1;
             info = &T32_ext_imm126[info->code][idx];
         } else if (info->type == EXT_OPCBX) {
-            if (!TEST(0x800, di->halfwordB))
+            if (!TESTANY(0x800, di->halfwordB))
                 idx = 0;
             else
                 idx = 1 + ((di->halfwordB >> 8) & 0x7) /*bits 10:8*/;
@@ -2256,7 +2256,7 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
      * We allow either of the copy or orig to have the LSB set and do not require
      * them to match as some uses cases have a local buffer for pc.
      */
-    if (TEST(0x1, (ptr_uint_t)pc) || TEST(0x1, (ptr_uint_t)orig_pc)) {
+    if (TESTANY(0x1, (ptr_uint_t)pc) || TESTANY(0x1, (ptr_uint_t)orig_pc)) {
         di->isa_mode = DR_ISA_ARM_THUMB;
         pc = PC_AS_LOAD_TGT(DR_ISA_ARM_THUMB, pc);
         orig_pc = PC_AS_LOAD_TGT(DR_ISA_ARM_THUMB, orig_pc);
@@ -2329,7 +2329,7 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
     if (TESTANY(DECODE_PREDICATE_22 | DECODE_PREDICATE_8, info->flags)) {
         di->predicate = DR_PRED_EQ +
             decode_predicate(di->instr_word,
-                             TEST(DECODE_PREDICATE_22, info->flags) ? 22 : 8);
+                             TESTANY(DECODE_PREDICATE_22, info->flags) ? 22 : 8);
     }
 
     /* We should now have either a valid OP_ opcode or an invalid opcode */
@@ -2448,8 +2448,9 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
     CLIENT_ASSERT(instr->opcode == OP_INVALID || instr->opcode == OP_UNDECODED,
                   "decode: instr is already decoded, may need to call instr_reset()");
 
-    next_pc = read_instruction(dcontext, pc, orig_pc, &info,
-                               &di _IF_DEBUG(!TEST(INSTR_IGNORE_INVALID, instr->flags)));
+    next_pc =
+        read_instruction(dcontext, pc, orig_pc, &info,
+                         &di _IF_DEBUG(!TESTANY(INSTR_IGNORE_INVALID, instr->flags)));
     instr_set_isa_mode(instr, di.isa_mode);
     instr_set_opcode(instr, info->type);
     di.opcode = info->type; /* needed for decode_cur_pc */
@@ -2477,14 +2478,16 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
         }
         if (info->dst2_type != TYPE_NONE) {
             if (!decode_operand(&di, info->dst2_type, info->dst2_size,
-                                TEST(DECODE_4_SRCS, info->flags) ? srcs : dsts,
-                                TEST(DECODE_4_SRCS, info->flags) ? &num_srcs : &num_dsts))
+                                TESTANY(DECODE_4_SRCS, info->flags) ? srcs : dsts,
+                                TESTANY(DECODE_4_SRCS, info->flags) ? &num_srcs
+                                                                    : &num_dsts))
                 goto decode_invalid;
         }
         if (info->src1_type != TYPE_NONE) {
             if (!decode_operand(&di, info->src1_type, info->src1_size,
-                                TEST(DECODE_3_DSTS, info->flags) ? dsts : srcs,
-                                TEST(DECODE_3_DSTS, info->flags) ? &num_dsts : &num_srcs))
+                                TESTANY(DECODE_3_DSTS, info->flags) ? dsts : srcs,
+                                TESTANY(DECODE_3_DSTS, info->flags) ? &num_dsts
+                                                                    : &num_srcs))
                 goto decode_invalid;
         }
         if (info->src2_type != TYPE_NONE) {
@@ -2569,7 +2572,7 @@ decode_next_pc(void *drcontext, byte *pc)
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     dr_isa_mode_t isa_mode;
     byte *read_pc = pc;
-    if (TEST(0x1, (ptr_uint_t)pc)) {
+    if (TESTANY(0x1, (ptr_uint_t)pc)) {
         isa_mode = DR_ISA_ARM_THUMB; /* and keep LSB=1 (i#1688) */
         read_pc = PC_AS_LOAD_TGT(DR_ISA_ARM_THUMB, read_pc);
     } else {
@@ -2633,7 +2636,7 @@ decode_raw_jmp_target(dcontext_t *dcontext, byte *pc)
     if (mode == DR_ISA_ARM_A32) {
         uint word = *(uint *)pc;
         int disp = word & 0xffffff;
-        if (TEST(0x800000, disp))
+        if (TESTANY(0x800000, disp))
             disp |= 0xff000000; /* sign-extend */
         return decode_cur_pc(pc, mode, OP_b, NULL) + (disp << 2);
     } else {
@@ -2660,13 +2663,13 @@ const instr_info_t *
 instr_info_extra_opnds(const instr_info_t *info)
 {
     /* XXX i#1551: pick proper *_extra_operands table */
-    if (TEST(DECODE_EXTRA_SHIFT, info->flags))
+    if (TESTANY(DECODE_EXTRA_SHIFT, info->flags))
         return &A32_extra_operands[0];
-    else if (TEST(DECODE_EXTRA_WRITEBACK, info->flags))
+    else if (TESTANY(DECODE_EXTRA_WRITEBACK, info->flags))
         return &A32_extra_operands[1];
-    else if (TEST(DECODE_EXTRA_WRITEBACK2, info->flags))
+    else if (TESTANY(DECODE_EXTRA_WRITEBACK2, info->flags))
         return &A32_extra_operands[2];
-    else if (TEST(DECODE_EXTRA_OPERANDS, info->flags))
+    else if (TESTANY(DECODE_EXTRA_OPERANDS, info->flags))
         return (const instr_info_t *)(info->code);
     else
         return NULL;
@@ -2680,14 +2683,14 @@ instr_info_opnd_type(const instr_info_t *info, bool src, int num)
     while (info != NULL) {
         if (!src && i++ == num)
             return info->dst1_type;
-        if (TEST(DECODE_4_SRCS, info->flags)) {
+        if (TESTANY(DECODE_4_SRCS, info->flags)) {
             if (src && i++ == num)
                 return info->dst2_type;
         } else {
             if (!src && i++ == num)
                 return info->dst2_type;
         }
-        if (TEST(DECODE_3_DSTS, info->flags)) {
+        if (TESTANY(DECODE_3_DSTS, info->flags)) {
             if (!src && i++ == num)
                 return info->src1_type;
         } else {
@@ -3026,11 +3029,11 @@ check_ISA(dr_isa_mode_t isa_mode)
                     int dst_type[MAX_TYPES];
                     while (ops != NULL) {
                         dst_type[num_dsts++] = ops->dst1_type;
-                        if (TEST(DECODE_4_SRCS, ops->flags))
+                        if (TESTANY(DECODE_4_SRCS, ops->flags))
                             src_type[num_srcs++] = ops->dst2_type;
                         else
                             dst_type[num_dsts++] = ops->dst2_type;
-                        if (TEST(DECODE_3_DSTS, ops->flags))
+                        if (TESTANY(DECODE_3_DSTS, ops->flags))
                             dst_type[num_dsts++] = ops->src1_type;
                         else
                             src_type[num_srcs++] = ops->src1_type;

--- a/core/ir/arm/decode_private.h
+++ b/core/ir/arm/decode_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -670,9 +670,9 @@ it_block_info_advance(it_block_info_t *info)
 static inline dr_pred_type_t
 it_block_instr_predicate(it_block_info_t info, uint index)
 {
-    return (
-        DR_PRED_EQ +
-        (TEST(BITMAP_MASK(index), info.preds) ? info.firstcond : (info.firstcond ^ 0x1)));
+    return (DR_PRED_EQ +
+            (TESTANY(BITMAP_MASK(index), info.preds) ? info.firstcond
+                                                     : (info.firstcond ^ 0x1)));
 }
 
 #endif /* DECODE_PRIVATE_H */

--- a/core/ir/arm/disassemble.c
+++ b/core/ir/arm/disassemble.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -265,7 +265,7 @@ opnd_base_disp_scale_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM
 bool
 opnd_disassemble_arch(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT, opnd_t opnd)
 {
-    if (opnd_is_immed_int(opnd) && TEST(DR_OPND_IS_SHIFT, opnd_get_flags(opnd))) {
+    if (opnd_is_immed_int(opnd) && TESTANY(DR_OPND_IS_SHIFT, opnd_get_flags(opnd))) {
         dr_shift_type_t shift = (dr_shift_type_t)opnd_get_immed_int(opnd);
         disassemble_shift(buf, bufsz, sofar, "", "", shift, false, 0);
         return true;
@@ -306,7 +306,7 @@ opnd_disassemble_noimplicit(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOU
         opnd_t memop = writes_list ? instr_get_src(instr, 0) : instr_get_dst(instr, 0);
         CLIENT_ASSERT(opnd_is_base_disp(memop), "internal disasm error");
         if (opnd_get_reg(opnd) == opnd_get_base(memop) &&
-            !TEST(DR_OPND_IN_LIST, opnd_get_flags(opnd)))
+            !TESTANY(DR_OPND_IN_LIST, opnd_get_flags(opnd)))
             return false; /* skip */
     }
     /* Writeback implicit operands for non-list instrs */
@@ -334,11 +334,11 @@ opnd_disassemble_noimplicit(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOU
                 return false; /* skip */
             type = opnd_get_index_shift(memop, &amount);
             if (opnd_is_immed_int(opnd) &&
-                ((!TEST(DR_OPND_SHIFTED, opnd_get_flags(memop)) &&
+                ((!TESTANY(DR_OPND_SHIFTED, opnd_get_flags(memop)) &&
                   /* rule out disp==0 hiding shift type */
                   max - tostore < 3 &&
                   opnd_get_immed_int(opnd) == opnd_get_disp(memop)) ||
-                 (TEST(DR_OPND_SHIFTED, opnd_get_flags(memop)) &&
+                 (TESTANY(DR_OPND_SHIFTED, opnd_get_flags(memop)) &&
                   (opnd_get_immed_int(opnd) == type ||
                    opnd_get_immed_int(opnd) == amount))))
                 return false; /* skip */
@@ -356,7 +356,7 @@ opnd_disassemble_noimplicit(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOU
         CLIENT_ASSERT(opnd_is_base_disp(memop), "internal disasm error");
         last = instr_get_dst(instr, instr_num_dsts(instr) - 1);
         writeback = (opnd_is_reg(last) && opnd_get_reg(last) == opnd_get_base(memop) &&
-                     !TEST(DR_OPND_IN_LIST, opnd_get_flags(last)));
+                     !TESTANY(DR_OPND_IN_LIST, opnd_get_flags(last)));
         reg_disassemble(buf, bufsz, sofar, opnd_get_base(memop), 0, "",
                         writes_list ? (writeback ? "!, " : ", ")
                                     : (writeback ? "!" : ""));
@@ -377,7 +377,7 @@ opnd_disassemble_noimplicit(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOU
             opnd_t prior =
                 dst ? instr_get_dst(instr, *idx - 1) : instr_get_src(instr, *idx - 1);
             if (opnd_is_immed_int(prior) &&
-                TEST(DR_OPND_IS_SHIFT, opnd_get_flags(prior))) {
+                TESTANY(DR_OPND_IS_SHIFT, opnd_get_flags(prior))) {
                 if (opnd_get_immed_int(prior) == DR_SHIFT_RRX)
                     return true; /* do not print value, which is always 1 */
                 /* No comma in between */
@@ -390,20 +390,20 @@ opnd_disassemble_noimplicit(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOU
     }
 
     /* Register lists */
-    if (opnd_is_reg(opnd) && TEST(DR_OPND_IN_LIST, opnd_get_flags(opnd))) {
+    if (opnd_is_reg(opnd) && TESTANY(DR_OPND_IN_LIST, opnd_get_flags(opnd))) {
         /* For now we do not print ranges as "r0-r4" but print each reg.
          * This matches some other decoders but not all.
          */
         opnd_t adj = opnd_create_null();
         if (*idx > 0)
             adj = dst ? instr_get_dst(instr, *idx - 1) : instr_get_src(instr, *idx - 1);
-        if (!opnd_is_reg(adj) || !TEST(DR_OPND_IN_LIST, opnd_get_flags(adj)))
+        if (!opnd_is_reg(adj) || !TESTANY(DR_OPND_IN_LIST, opnd_get_flags(adj)))
             print_to_buffer(buf, bufsz, sofar, "{");
         internal_opnd_disassemble(buf, bufsz, sofar, dcontext, opnd, false);
         adj = opnd_create_null();
         if (*idx + 1 < max)
             adj = dst ? instr_get_dst(instr, *idx + 1) : instr_get_src(instr, *idx + 1);
-        if (!opnd_is_reg(adj) || !TEST(DR_OPND_IN_LIST, opnd_get_flags(adj))) {
+        if (!opnd_is_reg(adj) || !TESTANY(DR_OPND_IN_LIST, opnd_get_flags(adj))) {
             print_to_buffer(buf, bufsz, sofar, "}%s",
                             instr_is_priv_reglist(instr) ? "^" : "");
         }
@@ -469,7 +469,7 @@ print_opcode_name(instr_t *instr, const char *name, char *buf, size_t bufsz,
                                   opnd_get_immed_int(instr_get_src(instr, 0)));
         for (i = 1 /*1st is implied*/; i < info.num_instrs; i++) {
             print_to_buffer(buf, bufsz, sofar, "%c",
-                            TEST(BITMAP_MASK(i), info.preds) ? 't' : 'e');
+                            TESTANY(BITMAP_MASK(i), info.preds) ? 't' : 'e');
         }
     } else if (instr_is_predicated(instr)) {
         dr_pred_type_t pred = instr_get_predicate(instr);

--- a/core/ir/arm/encode.c
+++ b/core/ir/arm/encode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -1433,7 +1433,7 @@ encode_T32_modified_immed_ok(decode_info_t *di, opnd_size_t size_temp, opnd_t op
     /* 4) ROR of 1bcdefgh */
     first_one = -1;
     for (i = 31; i >= 0; i--) {
-        if (TEST(1 << i, val)) {
+        if (TESTANY(1 << i, val)) {
             if (first_one == -1)
                 first_one = i;
             else if (first_one - i >= 8)
@@ -1632,7 +1632,7 @@ static int
 opnd_get_signed_disp(opnd_t opnd)
 {
     int disp = opnd_get_disp(opnd);
-    if (TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)))
+    if (TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)))
         return -disp;
     else
         return disp;
@@ -2069,11 +2069,11 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
         if (opnd_is_base_disp(opnd) && opnd_get_base(opnd) != REG_NULL &&
             opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            (BOOLS_MATCH(TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)),
+            (BOOLS_MATCH(TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)),
                          optype == TYPE_M_NEG_I12) ||
              opnd_get_disp(opnd) == 0) &&
             encode_immed_ok(di, OPSZ_12b, opnd_get_disp(opnd), 1, false /*unsigned*/,
-                            TEST(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
+                            TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
             size_op == size_temp) {
             di->check_wb_base = opnd_get_base(opnd);
             di->check_wb_disp_sz = OPSZ_12b;
@@ -2090,7 +2090,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
             opnd_get_index(opnd) != REG_NULL &&
             !(di->T32_16 && opnd_get_index(opnd) > DR_REG_R7) &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            BOOLS_MATCH(TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)),
+            BOOLS_MATCH(TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)),
                         optype == TYPE_M_NEG_REG) &&
             opnd_get_disp(opnd) == 0 && size_op == size_temp) {
             di->check_wb_base = opnd_get_base(opnd);
@@ -2102,7 +2102,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
     case TYPE_M_NEG_SHREG:
         if (opnd_is_base_disp(opnd) && opnd_get_base(opnd) != REG_NULL &&
             opnd_get_index(opnd) != REG_NULL &&
-            BOOLS_MATCH(TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)),
+            BOOLS_MATCH(TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)),
                         optype == TYPE_M_NEG_SHREG) &&
             opnd_get_disp(opnd) == 0 && size_op == size_temp) {
             ptr_int_t sh2, val;
@@ -2122,7 +2122,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
     case TYPE_M_POS_LSH1REG:
         if (opnd_is_base_disp(opnd) && opnd_get_base(opnd) != REG_NULL &&
             opnd_get_index(opnd) != REG_NULL &&
-            !TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)) && opnd_get_disp(opnd) == 0 &&
+            !TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)) && opnd_get_disp(opnd) == 0 &&
             size_op == size_temp) {
             ptr_int_t sh2, val;
             uint amount;
@@ -2161,7 +2161,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
         return (opnd_is_base_disp(opnd) && opnd_get_base(opnd) == DR_REG_SP &&
                 opnd_get_index(opnd) == REG_NULL &&
                 opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-                !TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
+                !TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
                 encode_immed_ok(di, OPSZ_1, opnd_get_disp(opnd), 4, false /*unsigned*/,
                                 false /*pos*/) &&
                 size_op == size_temp);
@@ -2170,11 +2170,11 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
         if (opnd_is_base_disp(opnd) && opnd_get_base(opnd) != REG_NULL &&
             opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            (BOOLS_MATCH(TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)),
+            (BOOLS_MATCH(TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)),
                          optype == TYPE_M_NEG_I8) ||
              opnd_get_disp(opnd) == 0) &&
             encode_immed_ok(di, OPSZ_1, opnd_get_disp(opnd), 1, false /*unsigned*/,
-                            TEST(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
+                            TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
             size_op == size_temp) {
             di->check_wb_base = opnd_get_base(opnd);
             di->check_wb_disp_sz = OPSZ_1;
@@ -2189,11 +2189,11 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
         if (opnd_is_base_disp(opnd) && opnd_get_base(opnd) != REG_NULL &&
             opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            (BOOLS_MATCH(TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)),
+            (BOOLS_MATCH(TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)),
                          optype == TYPE_M_NEG_I8x4) ||
              opnd_get_disp(opnd) == 0) &&
             encode_immed_ok(di, OPSZ_1, opnd_get_disp(opnd), 4, false /*unsigned*/,
-                            TEST(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
+                            TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
             size_op == size_temp) {
             di->check_wb_base = opnd_get_base(opnd);
             di->check_wb_disp_sz = OPSZ_1;
@@ -2208,11 +2208,11 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
         if (opnd_is_base_disp(opnd) && opnd_get_base(opnd) != REG_NULL &&
             opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            (BOOLS_MATCH(TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)),
+            (BOOLS_MATCH(TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)),
                          optype == TYPE_M_NEG_I4_4) ||
              opnd_get_disp(opnd) == 0) &&
             encode_immed_ok(di, OPSZ_1, opnd_get_disp(opnd), 1, false /*unsigned*/,
-                            TEST(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
+                            TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
             size_op == size_temp) {
             di->check_wb_base = opnd_get_base(opnd);
             di->check_wb_disp_sz = OPSZ_1;
@@ -2227,7 +2227,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
             opnd_get_base(opnd) <= DR_REG_R7 /* T32.16 only */ &&
             opnd_get_base(opnd) != REG_NULL && opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            !TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
+            !TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
             encode_immed_ok(di, OPSZ_5b, opnd_get_disp(opnd), 1, false /*unsigned*/,
                             false /*pos*/) &&
             size_op == size_temp) {
@@ -2242,7 +2242,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
             opnd_get_base(opnd) <= DR_REG_R7 /* T32.16 only */ &&
             opnd_get_base(opnd) != REG_NULL && opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            !TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
+            !TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
             encode_immed_ok(di, OPSZ_5b, opnd_get_disp(opnd), 2, false /*unsigned*/,
                             false /*pos*/) &&
             size_op == size_temp) {
@@ -2257,7 +2257,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
             opnd_get_base(opnd) <= DR_REG_R7 /* T32.16 only */ &&
             opnd_get_base(opnd) != REG_NULL && opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            !TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
+            !TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
             encode_immed_ok(di, OPSZ_5b, opnd_get_disp(opnd), 4, false /*unsigned*/,
                             false /*pos*/) &&
             size_op == size_temp) {
@@ -2271,7 +2271,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
         if (opnd_is_base_disp(opnd) && opnd_get_base(opnd) == DR_REG_PC &&
             opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            !TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
+            !TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)) &&
             encode_immed_ok(di, OPSZ_1, opnd_get_disp(opnd), 4, false /*unsigned*/,
                             false /*pos*/) &&
             size_op == size_temp) {
@@ -2287,11 +2287,11 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
         if (opnd_is_base_disp(opnd) && opnd_get_base(opnd) == DR_REG_PC &&
             opnd_get_index(opnd) == REG_NULL &&
             opnd_get_index_shift(opnd, NULL) == DR_SHIFT_NONE &&
-            (BOOLS_MATCH(TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)),
+            (BOOLS_MATCH(TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)),
                          optype == TYPE_M_PCREL_NEG_I12) ||
              opnd_get_disp(opnd) == 0) &&
             encode_immed_ok(di, OPSZ_12b, opnd_get_disp(opnd), 1, false /*unsigned*/,
-                            TEST(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
+                            TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd))) &&
             size_op == size_temp) {
             di->check_wb_base = opnd_get_base(opnd);
             di->check_wb_disp_sz = OPSZ_12b;
@@ -2360,7 +2360,7 @@ encoding_possible(decode_info_t *di, instr_t *in, const instr_info_t *ii)
         if (pred == DR_PRED_OP) {
             di->errmsg = "DR_PRED_OP is an illegal predicate request";
             return false;
-        } else if (TEST(DECODE_PREDICATE_28_AL, ii->flags)) {
+        } else if (TESTANY(DECODE_PREDICATE_28_AL, ii->flags)) {
             if (pred != DR_PRED_AL && pred != DR_PRED_NONE) {
                 di->errmsg = "DR_PRED_AL is the only valid predicate";
                 return false;
@@ -2394,9 +2394,10 @@ encoding_possible(decode_info_t *di, instr_t *in, const instr_info_t *ii)
         }
         if (ii->dst2_type != TYPE_NONE) {
             if (!encode_opnd_ok(di, ii->dst2_type, ii->dst2_size, in,
-                                !TEST(DECODE_4_SRCS, ii->flags),
-                                TEST(DECODE_4_SRCS, ii->flags) ? &num_srcs : &num_dsts)) {
-                if (TEST(DECODE_4_SRCS, ii->flags)) {
+                                !TESTANY(DECODE_4_SRCS, ii->flags),
+                                TESTANY(DECODE_4_SRCS, ii->flags) ? &num_srcs
+                                                                  : &num_dsts)) {
+                if (TESTANY(DECODE_4_SRCS, ii->flags)) {
                     di->errmsg = "Source operand #%d has wrong type/size";
                     di->errmsg_param = num_srcs - 1;
                 } else {
@@ -2408,9 +2409,10 @@ encoding_possible(decode_info_t *di, instr_t *in, const instr_info_t *ii)
         }
         if (ii->src1_type != TYPE_NONE) {
             if (!encode_opnd_ok(di, ii->src1_type, ii->src1_size, in,
-                                TEST(DECODE_3_DSTS, ii->flags),
-                                TEST(DECODE_3_DSTS, ii->flags) ? &num_dsts : &num_srcs)) {
-                if (TEST(DECODE_3_DSTS, ii->flags)) {
+                                TESTANY(DECODE_3_DSTS, ii->flags),
+                                TESTANY(DECODE_3_DSTS, ii->flags) ? &num_dsts
+                                                                  : &num_srcs)) {
+                if (TESTANY(DECODE_3_DSTS, ii->flags)) {
                     di->errmsg = "Destination operand #%d has wrong type/size";
                     di->errmsg_param = num_dsts - 1;
                 } else {
@@ -3237,13 +3239,13 @@ encode_operands(decode_info_t *di, instr_t *in, const instr_info_t *ii)
             encode_operand(di, ii->dst1_type, ii->dst1_size, in, true, &num_dsts);
         if (ii->dst2_type != TYPE_NONE) {
             encode_operand(di, ii->dst2_type, ii->dst2_size, in,
-                           !TEST(DECODE_4_SRCS, ii->flags),
-                           TEST(DECODE_4_SRCS, ii->flags) ? &num_srcs : &num_dsts);
+                           !TESTANY(DECODE_4_SRCS, ii->flags),
+                           TESTANY(DECODE_4_SRCS, ii->flags) ? &num_srcs : &num_dsts);
         }
         if (ii->src1_type != TYPE_NONE) {
             encode_operand(di, ii->src1_type, ii->src1_size, in,
-                           TEST(DECODE_3_DSTS, ii->flags),
-                           TEST(DECODE_3_DSTS, ii->flags) ? &num_dsts : &num_srcs);
+                           TESTANY(DECODE_3_DSTS, ii->flags),
+                           TESTANY(DECODE_3_DSTS, ii->flags) ? &num_dsts : &num_srcs);
         }
         if (ii->src2_type != TYPE_NONE)
             encode_operand(di, ii->src2_type, ii->src2_size, in, false, &num_srcs);
@@ -3337,15 +3339,15 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
 
     /* Encode into di.instr_word */
     di.instr_word = info->opcode;
-    if (TEST(DECODE_PREDICATE_28, info->flags)) {
+    if (TESTANY(DECODE_PREDICATE_28, info->flags)) {
         dr_pred_type_t pred = instr_get_predicate(instr);
         if (pred == DR_PRED_NONE)
             pred = DR_PRED_AL;
         di.instr_word |= (pred - DR_PRED_EQ) << 28;
-    } else if (TEST(DECODE_PREDICATE_22, info->flags)) {
+    } else if (TESTANY(DECODE_PREDICATE_22, info->flags)) {
         dr_pred_type_t pred = instr_get_predicate(instr);
         di.instr_word |= (pred - DR_PRED_EQ) << 22;
-    } else if (TEST(DECODE_PREDICATE_8, info->flags)) {
+    } else if (TESTANY(DECODE_PREDICATE_8, info->flags)) {
         dr_pred_type_t pred = instr_get_predicate(instr);
         di.instr_word |= (pred - DR_PRED_EQ) << 8;
     }

--- a/core/ir/arm/instr.c
+++ b/core/ir/arm/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -581,53 +581,53 @@ instr_predicate_triggered_priv(instr_t *instr, priv_mcontext_t *mc)
     switch (pred) {
     case DR_PRED_NONE: return DR_PRED_TRIGGER_NOPRED;
     case DR_PRED_EQ: /* Z == 1 */
-        return (TEST(EFLAGS_Z, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
-                                          : DR_PRED_TRIGGER_MISMATCH;
+        return (TESTANY(EFLAGS_Z, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
+                                             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_NE: /* Z == 0 */
-        return (!TEST(EFLAGS_Z, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
-                                           : DR_PRED_TRIGGER_MISMATCH;
+        return (!TESTANY(EFLAGS_Z, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
+                                              : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_CS: /* C == 1 */
-        return (TEST(EFLAGS_C, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
-                                          : DR_PRED_TRIGGER_MISMATCH;
+        return (TESTANY(EFLAGS_C, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
+                                             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_CC: /* C == 0 */
-        return (!TEST(EFLAGS_C, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
-                                           : DR_PRED_TRIGGER_MISMATCH;
+        return (!TESTANY(EFLAGS_C, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
+                                              : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_MI: /* N == 1 */
-        return (TEST(EFLAGS_N, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
-                                          : DR_PRED_TRIGGER_MISMATCH;
+        return (TESTANY(EFLAGS_N, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
+                                             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_PL: /* N == 0 */
-        return (!TEST(EFLAGS_N, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
-                                           : DR_PRED_TRIGGER_MISMATCH;
+        return (!TESTANY(EFLAGS_N, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
+                                              : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_VS: /* V == 1 */
-        return (TEST(EFLAGS_V, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
-                                          : DR_PRED_TRIGGER_MISMATCH;
+        return (TESTANY(EFLAGS_V, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
+                                             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_VC: /* V == 0 */
-        return (!TEST(EFLAGS_V, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
-                                           : DR_PRED_TRIGGER_MISMATCH;
+        return (!TESTANY(EFLAGS_V, mc->apsr)) ? DR_PRED_TRIGGER_MATCH
+                                              : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_HI: /* C == 1 and Z == 0 */
-        return (TEST(EFLAGS_C, mc->apsr) && !TEST(EFLAGS_Z, mc->apsr))
+        return (TESTANY(EFLAGS_C, mc->apsr) && !TESTANY(EFLAGS_Z, mc->apsr))
             ? DR_PRED_TRIGGER_MATCH
             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_LS: /* C == 0 or Z == 1 */
-        return (!TEST(EFLAGS_C, mc->apsr) || TEST(EFLAGS_Z, mc->apsr))
+        return (!TESTANY(EFLAGS_C, mc->apsr) || TESTANY(EFLAGS_Z, mc->apsr))
             ? DR_PRED_TRIGGER_MATCH
             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_GE: /* N == V */
-        return BOOLS_MATCH(TEST(EFLAGS_N, mc->apsr), TEST(EFLAGS_V, mc->apsr))
+        return BOOLS_MATCH(TESTANY(EFLAGS_N, mc->apsr), TESTANY(EFLAGS_V, mc->apsr))
             ? DR_PRED_TRIGGER_MATCH
             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_LT: /* N != V */
-        return !BOOLS_MATCH(TEST(EFLAGS_N, mc->apsr), TEST(EFLAGS_V, mc->apsr))
+        return !BOOLS_MATCH(TESTANY(EFLAGS_N, mc->apsr), TESTANY(EFLAGS_V, mc->apsr))
             ? DR_PRED_TRIGGER_MATCH
             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_GT /* Z == 0 and N == V */:
-        return (!TEST(EFLAGS_Z, mc->apsr) &&
-                BOOLS_MATCH(TEST(EFLAGS_N, mc->apsr), TEST(EFLAGS_V, mc->apsr)))
+        return (!TESTANY(EFLAGS_Z, mc->apsr) &&
+                BOOLS_MATCH(TESTANY(EFLAGS_N, mc->apsr), TESTANY(EFLAGS_V, mc->apsr)))
             ? DR_PRED_TRIGGER_MATCH
             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_LE: /* Z == 1 or N != V */
-        return (TEST(EFLAGS_Z, mc->apsr) ||
-                !BOOLS_MATCH(TEST(EFLAGS_N, mc->apsr), TEST(EFLAGS_V, mc->apsr)))
+        return (TESTANY(EFLAGS_Z, mc->apsr) ||
+                !BOOLS_MATCH(TESTANY(EFLAGS_N, mc->apsr), TESTANY(EFLAGS_V, mc->apsr)))
             ? DR_PRED_TRIGGER_MATCH
             : DR_PRED_TRIGGER_MISMATCH;
     case DR_PRED_AL: return DR_PRED_TRIGGER_MATCH;

--- a/core/ir/arm/table_t32_16.c
+++ b/core/ir/arm/table_t32_16.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -242,7 +242,7 @@ const instr_info_t T32_16_ext_bits_10_9[][4] = {
 };
 
 /* Indexed by if Rn is listed in reglist:
- * + whether TEST(1 << Rn, reglistbits), take entry 0
+ * + whether TESTANY(1 << Rn, reglistbits), take entry 0
  * + else, take entry 1
  */
 const instr_info_t T32_16_ext_bits_10_8[][2] = {

--- a/core/ir/arm/table_t32_16_it.c
+++ b/core/ir/arm/table_t32_16_it.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -233,7 +233,7 @@ const instr_info_t T32_16_it_ext_bits_10_9[][4] = {
 };
 
 /* Indexed by if Rn is listed in reglist:
- * + whether TEST(1 << Rn, reglistbits), take entry 0
+ * + whether TESTANY(1 << Rn, reglistbits), take entry 0
  * + else, take entry 1
  */
 const instr_info_t T32_16_it_ext_bits_10_8[][2] = {

--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -149,7 +149,7 @@ disassemble_options_init(void)
         flags |= DR_DISASM_RISCV;
     }
     /* This option is separate as it's not strictly a disasm style */
-    dynamo_options.decode_strict = TEST(DR_DISASM_STRICT_INVALID, flags);
+    dynamo_options.decode_strict = TESTANY(DR_DISASM_STRICT_INVALID, flags);
     if (DYNAMO_OPTION(decode_strict))
         flags |= DR_DISASM_STRICT_INVALID; /* for completeness */
     dynamo_options.disasm_mask = flags;
@@ -164,7 +164,7 @@ disassemble_set_syntax(dr_disasm_flags_t flags)
 #endif
     dynamo_options.disasm_mask = flags;
     /* This option is separate as it's not strictly a disasm style */
-    dynamo_options.decode_strict = TEST(DR_DISASM_STRICT_INVALID, flags);
+    dynamo_options.decode_strict = TESTANY(DR_DISASM_STRICT_INVALID, flags);
 #ifndef STANDALONE_DECODER
     options_restore_readonly();
 #endif
@@ -192,9 +192,9 @@ internal_instr_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT
 static inline const char *
 immed_prefix(void)
 {
-    return (TEST(DR_DISASM_INTEL | DR_DISASM_RISCV, DYNAMO_OPTION(disasm_mask))
+    return (TESTANY(DR_DISASM_INTEL | DR_DISASM_RISCV, DYNAMO_OPTION(disasm_mask))
                 ? ""
-                : (TEST(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)) ? "#" : "$"));
+                : (TESTANY(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)) ? "#" : "$"));
 }
 
 void
@@ -206,7 +206,7 @@ reg_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT, reg_id_t 
                             DYNAMO_OPTION(disasm_mask))
                         ? "%s%s%s%s"
                         : "%s%s%%%s%s",
-                    prefix, TEST(DR_OPND_NEGATED, flags) ? "-" : "",
+                    prefix, TESTANY(DR_OPND_NEGATED, flags) ? "-" : "",
                     get_register_name(reg), suffix);
 }
 
@@ -345,13 +345,13 @@ static void
 opnd_mem_disassemble_prefix(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT,
                             opnd_t opnd)
 {
-    if (TEST(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))) {
+    if (TESTANY(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))) {
         const char *size_str = opnd_size_suffix_intel(opnd);
         if (size_str[0] != '\0')
             print_to_buffer(buf, bufsz, sofar, "%s ptr [", size_str);
         else /* assume size implied by opcode */
             print_to_buffer(buf, bufsz, sofar, "[");
-    } else if (TEST(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask))) {
+    } else if (TESTANY(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask))) {
         print_to_buffer(buf, bufsz, sofar, "[");
     }
 }
@@ -386,8 +386,9 @@ opnd_base_disp_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT
         if (index != REG_NULL) {
             reg_disassemble(
                 buf, bufsz, sofar, index, opnd_get_flags(opnd),
-                (base != REG_NULL && !TEST(DR_OPND_NEGATED, opnd_get_flags(opnd))) ? "+"
-                                                                                   : "",
+                (base != REG_NULL && !TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)))
+                    ? "+"
+                    : "",
                 index_suffix);
             opnd_base_disp_scale_disassemble(buf, bufsz, sofar, opnd);
         }
@@ -395,7 +396,7 @@ opnd_base_disp_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT
 
     if (disp != 0 || (base == REG_NULL && index == REG_NULL) ||
         opnd_is_disp_encode_zero(opnd)) {
-        if (TEST(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))
+        if (TESTANY(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))
             /* Always negating for ARM and AArch64.  I would do the same for x86 but
              * I don't want to break any existing scripts.
              */
@@ -403,18 +404,18 @@ opnd_base_disp_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT
             /* windbg negates if top byte is 0xff
              * for x64 udis86 negates if at all negative
              */
-            if (TEST(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)))
+            if (TESTANY(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)))
                 print_to_buffer(buf, bufsz, sofar, ", #");
             if (IF_X64_ELSE(disp < 0, (disp & 0xff000000) == 0xff000000)) {
                 disp = -disp;
                 print_to_buffer(buf, bufsz, sofar, "-");
             } else if (base != REG_NULL || index != REG_NULL) {
-                if (TEST(DR_OPND_NEGATED, opnd_get_flags(opnd)))
+                if (TESTANY(DR_OPND_NEGATED, opnd_get_flags(opnd)))
                     print_to_buffer(buf, bufsz, sofar, "-");
-                else if (!TEST(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)))
+                else if (!TESTANY(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)))
                     print_to_buffer(buf, bufsz, sofar, "+");
             }
-        } else if (TEST(DR_DISASM_ATT, DYNAMO_OPTION(disasm_mask))) {
+        } else if (TESTANY(DR_DISASM_ATT, DYNAMO_OPTION(disasm_mask))) {
             /* There seems to be a discrepency between windbg and binutils. The latter
              * prints a '-' displacement for negative displacements both for att and
              * intel. We are doing the same for att syntax, while we're following windbg
@@ -425,10 +426,10 @@ opnd_base_disp_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT
                 print_to_buffer(buf, bufsz, sofar, "-");
             }
         }
-        if (TEST(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)))
+        if (TESTANY(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)))
             print_to_buffer(buf, bufsz, sofar, "%d", disp);
-        else if (TEST(DR_DISASM_RISCV, DYNAMO_OPTION(disasm_mask)) &&
-                 TEST(opnd_get_flags(opnd), DR_OPND_IMM_PRINT_DECIMAL))
+        else if (TESTANY(DR_DISASM_RISCV, DYNAMO_OPTION(disasm_mask)) &&
+                 TESTANY(opnd_get_flags(opnd), DR_OPND_IMM_PRINT_DECIMAL))
             print_to_buffer(buf, bufsz, sofar, "%d", disp);
         else if ((unsigned)disp <= 0xff && !opnd_is_disp_force_full(opnd))
             print_to_buffer(buf, bufsz, sofar, "0x%02x", disp);
@@ -599,11 +600,11 @@ print_known_pc_target(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT,
                                     target, fragment->tag);
 #    endif
                     printed = true;
-                } else if (!TEST(FRAG_FAKE, fragment->flags)) {
+                } else if (!TESTANY(FRAG_FAKE, fragment->flags)) {
                     /* check exit stubs */
                     linkstub_t *ls;
                     int ls_num = 0;
-                    CLIENT_ASSERT(!TEST(FRAG_FAKE, fragment->flags),
+                    CLIENT_ASSERT(!TESTANY(FRAG_FAKE, fragment->flags),
                                   "opnd_disassemble: invalid target");
                     for (ls = FRAGMENT_EXIT_STUBS(fragment); ls;
                          ls = LINKSTUB_NEXT_EXIT(ls)) {
@@ -656,10 +657,10 @@ internal_opnd_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT,
          * We rely on instr_disassemble to temporarily change operand
          * size to sign-extend to match the size of adjacent operands.
          */
-        if (TEST(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask))) {
+        if (TESTANY(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask))) {
             print_to_buffer(buf, bufsz, sofar, "%s%s%d", immed_prefix(), sign, (uint)val);
 #ifdef AARCH64
-        } else if (TEST(opnd_get_flags(opnd), DR_OPND_IS_PREDICATE_CONSTRAINT) &&
+        } else if (TESTANY(opnd_get_flags(opnd), DR_OPND_IS_PREDICATE_CONSTRAINT) &&
                    !aarch64_predicate_constraint_is_mapped(val)) {
             print_to_buffer(buf, bufsz, sofar, aarch64_predicate_constraint_string(val));
 #endif
@@ -750,7 +751,7 @@ internal_opnd_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT,
         if (opnd_get_segment(opnd) != REG_NULL)
             reg_disassemble(buf, bufsz, sofar, opnd_get_segment(opnd), 0, "", ":");
         print_to_buffer(buf, bufsz, sofar, PFX "%s", opnd_get_addr(opnd),
-                        TEST(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask)) ? "]" : "");
+                        TESTANY(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask)) ? "]" : "");
         break;
 #endif
     default:
@@ -1121,7 +1122,7 @@ instr_needs_opnd_size_sfx(instr_t *instr)
 
 #ifdef DISASM_SUFFIX_ONLY_ON_MISMATCH /* disabled: see below */
     opnd_t src, dst;
-    if (TEST(DR_DISASM_NO_OPND_SIZE, DYNAMO_OPTION(disasm_mask)))
+    if (TESTANY(DR_DISASM_NO_OPND_SIZE, DYNAMO_OPTION(disasm_mask)))
         return false;
     /* We really only care about the primary src and primary dst */
     if (instr_num_srcs(instr) == 0 || instr_num_dsts(instr) == 0)
@@ -1146,7 +1147,7 @@ instr_needs_opnd_size_sfx(instr_t *instr)
      * never print for immeds or non-partial regs, so we can just set
      * to true for all instructions.
      */
-    if (TEST(DR_DISASM_NO_OPND_SIZE, DYNAMO_OPTION(disasm_mask)))
+    if (TESTANY(DR_DISASM_NO_OPND_SIZE, DYNAMO_OPTION(disasm_mask)))
         return false;
     return true;
 #endif
@@ -1415,11 +1416,11 @@ exit_stub_type_desc(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
         /* XXX: mark these appropriately */
     } else {
         CLIENT_ASSERT(LINKSTUB_INDIRECT(l->flags), "invalid exit stub");
-        if (TEST(LINK_RETURN, l->flags))
+        if (TESTANY(LINK_RETURN, l->flags))
             return "ret";
         if (EXIT_IS_CALL(l->flags))
             return "indcall";
-        if (TEST(LINK_JMP, l->flags)) /* JMP or IND_JMP_PLT */
+        if (TESTANY(LINK_JMP, l->flags)) /* JMP or IND_JMP_PLT */
             return "indjmp";
 #    ifdef WINDOWS
         if (is_shared_syscall_routine(dcontext, EXIT_TARGET_TAG(dcontext, f, l)))
@@ -1459,19 +1460,19 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
             outfile, "Fragment tag " PFX ", flags 0x%x, %s%s%s%ssize %d%s%s:\n",
 #    endif
             f->tag, f->flags, IF_X64_ELSE(FRAG_IS_32(f->flags) ? "32-bit, " : "", ""),
-            TEST(FRAG_COARSE_GRAIN, f->flags) ? "coarse, " : "",
-            (TEST(FRAG_SHARED, f->flags)
+            TESTANY(FRAG_COARSE_GRAIN, f->flags) ? "coarse, " : "",
+            (TESTANY(FRAG_SHARED, f->flags)
                  ? "shared, "
                  : (SHARED_FRAGMENTS_ENABLED()
-                        ? (TEST(FRAG_TEMP_PRIVATE, f->flags) ? "private temp, "
-                                                             : "private, ")
+                        ? (TESTANY(FRAG_TEMP_PRIVATE, f->flags) ? "private temp, "
+                                                                : "private, ")
                         : "")),
-            (TEST(FRAG_IS_TRACE, f->flags))            ? "trace, "
-                : (TEST(FRAG_IS_TRACE_HEAD, f->flags)) ? "tracehead, "
-                                                       : "",
-            f->size, (TEST(FRAG_CANNOT_BE_TRACE, f->flags)) ? ", cannot be trace" : "",
-            (TEST(FRAG_MUST_END_TRACE, f->flags)) ? ", must end trace" : "",
-            (TEST(FRAG_CANNOT_DELETE, f->flags)) ? ", cannot delete" : "");
+            (TESTANY(FRAG_IS_TRACE, f->flags))            ? "trace, "
+                : (TESTANY(FRAG_IS_TRACE_HEAD, f->flags)) ? "tracehead, "
+                                                          : "",
+            f->size, (TESTANY(FRAG_CANNOT_BE_TRACE, f->flags)) ? ", cannot be trace" : "",
+            (TESTANY(FRAG_MUST_END_TRACE, f->flags)) ? ", must end trace" : "",
+            (TESTANY(FRAG_CANNOT_DELETE, f->flags)) ? ", cannot delete" : "");
 
         DOLOG(2, LOG_SYMBOLS, { /* XXX: affects non-logging uses... dump_traces, etc. */
                                 char symbolbuf[MAXIMUM_SYMBOL_LENGTH];
@@ -1484,7 +1485,7 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
     if (!body)
         return;
 
-    if (body && TEST(FRAG_FAKE, f->flags)) {
+    if (body && TESTANY(FRAG_FAKE, f->flags)) {
         alloc = true;
         f = fragment_recreate_with_linkstubs(dcontext, f_in);
     } else {
@@ -1550,7 +1551,7 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
             if (EXIT_STUB_PC(dcontext, f, l) != NULL) {
                 pc = EXIT_STUB_PC(dcontext, f, l);
                 next_stop_pc = pc + linkstub_size(dcontext, f, l);
-            } else if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+            } else if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
                 cache_pc cti_pc = EXIT_CTI_PC(f, l);
                 if (cti_pc == end_pc) {
                     /* must be elided final jmp */
@@ -1570,7 +1571,7 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
                     }
                 }
             } else {
-                if (TEST(LINK_SEPARATE_STUB, l->flags))
+                if (TESTANY(LINK_SEPARATE_STUB, l->flags))
                     print_file(outfile, "  <no stub created since linked>\n");
                 else if (!EXIT_HAS_STUB(l->flags, f->flags))
                     print_file(outfile, "  <no stub needed: -no_indirect_stubs>\n");
@@ -1608,12 +1609,12 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
             pc += DIRECT_EXIT_STUB_DATA_SZ;
         }
         /* point pc back at tail of fragment code if it was off in separate stub land */
-        if (TEST(LINK_SEPARATE_STUB, l->flags))
+        if (TESTANY(LINK_SEPARATE_STUB, l->flags))
             pc = frag_pc;
         exit_num++;
     }
 
-    if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags)) {
+    if (TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)) {
         DOSTATS({ /* skip stored sz */ end_pc -= sizeof(uint); });
         print_file(outfile, "  -------- original code (from " PFX "-" PFX ") -------- \n",
                    f->tag, (f->tag + (end_pc - pc)));
@@ -1769,17 +1770,17 @@ instrlist_disassemble(void *drcontext, app_pc tag, instrlist_t *ilist, file_t ou
 static void
 callstack_dump_module_info(char *buf, size_t bufsz, size_t *sofar, app_pc pc, uint flags)
 {
-    if (TEST(CALLSTACK_MODULE_INFO, flags)) {
+    if (TESTANY(CALLSTACK_MODULE_INFO, flags)) {
         module_area_t *ma;
         os_get_module_info_lock();
         ma = module_pc_lookup(pc);
         if (ma != NULL) {
             print_to_buffer(
                 buf, bufsz, sofar,
-                TEST(CALLSTACK_USE_XML, flags) ? "mod=\"" PFX "\" offs=\"" PFX "\" "
-                                               : " <%s+" PIFX ">",
-                TEST(CALLSTACK_MODULE_PATH, flags) ? ma->full_path
-                                                   : GET_MODULE_NAME(&ma->names),
+                TESTANY(CALLSTACK_USE_XML, flags) ? "mod=\"" PFX "\" offs=\"" PFX "\" "
+                                                  : " <%s+" PIFX ">",
+                TESTANY(CALLSTACK_MODULE_PATH, flags) ? ma->full_path
+                                                      : GET_MODULE_NAME(&ma->names),
                 pc - ma->start);
         }
         os_get_module_info_unlock();
@@ -1795,11 +1796,11 @@ internal_dump_callstack_to_buffer(char *buf, size_t bufsz, size_t *sofar, app_pc
     LOG_DECLARE(char symbolbuf[MAXIMUM_SYMBOL_LENGTH];)
     const char *symbol_name = "";
 
-    if (TEST(CALLSTACK_ADD_HEADER, flags)) {
+    if (TESTANY(CALLSTACK_ADD_HEADER, flags)) {
         print_to_buffer(buf, bufsz, sofar,
-                        TEST(CALLSTACK_USE_XML, flags) ? "\t<call-stack tid=" TIDFMT ">\n"
-                                                       : "Thread " TIDFMT
-                                                         " call stack:\n",
+                        TESTANY(CALLSTACK_USE_XML, flags)
+                            ? "\t<call-stack tid=" TIDFMT ">\n"
+                            : "Thread " TIDFMT " call stack:\n",
                         /* We avoid TLS tid to work on crashes */
                         IF_WINDOWS_ELSE(d_r_get_thread_id(), get_sys_thread_id()));
     }
@@ -1810,13 +1811,13 @@ internal_dump_callstack_to_buffer(char *buf, size_t bufsz, size_t *sofar, app_pc
             symbol_name = symbolbuf;
         });
         print_to_buffer(buf, bufsz, sofar,
-                        TEST(CALLSTACK_USE_XML, flags) ? "\t<current_pc=\"" PFX
-                                                         "\" name=\"%s\" "
-                                                       : "\t" PFX " %s ",
+                        TESTANY(CALLSTACK_USE_XML, flags) ? "\t<current_pc=\"" PFX
+                                                            "\" name=\"%s\" "
+                                                          : "\t" PFX " %s ",
                         cur_pc, symbol_name);
         callstack_dump_module_info(buf, bufsz, sofar, cur_pc, flags);
         print_to_buffer(buf, bufsz, sofar,
-                        TEST(CALLSTACK_USE_XML, flags) ? "/>\n" : "\n");
+                        TESTANY(CALLSTACK_USE_XML, flags) ? "/>\n" : "\n");
     }
 
     while (pc != NULL && is_readable_without_exception_query_os((byte *)pc, 8)) {
@@ -1827,21 +1828,21 @@ internal_dump_callstack_to_buffer(char *buf, size_t bufsz, size_t *sofar, app_pc
         });
 
         print_to_buffer(buf, bufsz, sofar,
-                        TEST(CALLSTACK_USE_XML, flags) ? "\t\t" : "\t");
-        if (TEST(CALLSTACK_FRAME_PTR, flags)) {
+                        TESTANY(CALLSTACK_USE_XML, flags) ? "\t\t" : "\t");
+        if (TESTANY(CALLSTACK_FRAME_PTR, flags)) {
             print_to_buffer(buf, bufsz, sofar,
-                            TEST(CALLSTACK_USE_XML, flags)
+                            TESTANY(CALLSTACK_USE_XML, flags)
                                 ? "<frame ptr=\"" PFX "\" parent=\"" PFX "\" "
                                 : "frame ptr " PFX " => parent " PFX ", ",
                             pc, *pc);
         }
         print_to_buffer(buf, bufsz, sofar,
-                        TEST(CALLSTACK_USE_XML, flags) ? "ret=\"" PFX "\" name=\"%s\" "
-                                                       : PFX " %s ",
+                        TESTANY(CALLSTACK_USE_XML, flags) ? "ret=\"" PFX "\" name=\"%s\" "
+                                                          : PFX " %s ",
                         *(pc + 1), symbol_name);
         callstack_dump_module_info(buf, bufsz, sofar, (app_pc) * (pc + 1), flags);
         print_to_buffer(buf, bufsz, sofar,
-                        TEST(CALLSTACK_USE_XML, flags) ? "/>\n" : "\n");
+                        TESTANY(CALLSTACK_USE_XML, flags) ? "/>\n" : "\n");
 
         num++;
         /* yes I've seen weird recursive cases before */

--- a/core/ir/instr_inline_api.h
+++ b/core/ir/instr_inline_api.h
@@ -48,9 +48,9 @@
 #        define DR_IF_DEBUG IF_DEBUG
 #        define DR_IF_DEBUG_ IF_DEBUG_
 
-#        define MAKE_OPNDS_VALID(instr)                       \
-            (void)(TEST(INSTR_OPERANDS_VALID, (instr)->flags) \
-                       ? (instr)                              \
+#        define MAKE_OPNDS_VALID(instr)                          \
+            (void)(TESTANY(INSTR_OPERANDS_VALID, (instr)->flags) \
+                       ? (instr)                                 \
                        : instr_decode_with_current_dcontext(instr))
 /* CLIENT_ASSERT with a trailing comma in a debug build, otherwise nothing. */
 #        define CLIENT_ASSERT_(cond, msg) DR_IF_DEBUG_(CLIENT_ASSERT(cond, msg))
@@ -446,28 +446,28 @@ INSTR_INLINE
 bool
 instr_operands_valid(instr_t *instr)
 {
-    return TEST(INSTR_OPERANDS_VALID, instr->flags);
+    return TESTANY(INSTR_OPERANDS_VALID, instr->flags);
 }
 
 INSTR_INLINE
 bool
 instr_raw_bits_valid(instr_t *instr)
 {
-    return TEST(INSTR_RAW_BITS_VALID, instr->flags);
+    return TESTANY(INSTR_RAW_BITS_VALID, instr->flags);
 }
 
 INSTR_INLINE
 bool
 instr_has_allocated_bits(instr_t *instr)
 {
-    return TEST(INSTR_RAW_BITS_ALLOCATED, instr->flags);
+    return TESTANY(INSTR_RAW_BITS_ALLOCATED, instr->flags);
 }
 
 INSTR_INLINE
 bool
 instr_needs_encoding(instr_t *instr)
 {
-    return !TEST(INSTR_RAW_BITS_VALID, instr->flags);
+    return !TESTANY(INSTR_RAW_BITS_VALID, instr->flags);
 }
 
 INSTR_INLINE

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -129,7 +129,7 @@ instr_clone(void *drcontext, instr_t *orig)
     /* We could heap-allocate an instr_noalloc_t but it's intended for use in a
      * signal handler or other places where we don't want any heap allocation.
      */
-    CLIENT_ASSERT(!TEST(INSTR_IS_NOALLOC_STRUCT, orig->flags),
+    CLIENT_ASSERT(!TESTANY(INSTR_IS_NOALLOC_STRUCT, orig->flags),
                   "Cloning an instr_noalloc_t is not supported.");
 
     instr_t *instr = (instr_t *)heap_alloc(dcontext, sizeof(instr_t) HEAPACCT(ACCT_IR));
@@ -213,9 +213,9 @@ instr_free(void *drcontext, instr_t *instr)
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     if (instr_is_label(instr) && instr_get_label_callback(instr) != NULL)
         (*instr->label_cb)(dcontext, instr);
-    if (TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags))
+    if (TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags))
         return;
-    if (TEST(INSTR_RAW_BITS_ALLOCATED, instr->flags)) {
+    if (TESTANY(INSTR_RAW_BITS_ALLOCATED, instr->flags)) {
         instr_free_raw_bits(dcontext, instr);
     }
     if (instr->num_dsts > 0) { /* checking num_dsts, not dsts, b/c of label data */
@@ -236,7 +236,7 @@ instr_free(void *drcontext, instr_t *instr)
 int
 instr_mem_usage(instr_t *instr)
 {
-    if (TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags))
+    if (TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags))
         return sizeof(instr_noalloc_t);
     int usage = 0;
     if ((instr->flags & INSTR_RAW_BITS_ALLOCATED) != 0) {
@@ -262,7 +262,7 @@ instr_reset(void *drcontext, instr_t *instr)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     instr_free(dcontext, instr);
-    if (TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
+    if (TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
         instr_init(dcontext, instr);
         instr->flags |= INSTR_IS_NOALLOC_STRUCT;
     } else {
@@ -356,7 +356,7 @@ private_instr_encode(dcontext_t *dcontext, instr_t *instr, bool always_cache)
 {
     byte *buf;
     byte stack_buf[MAX_INSTR_LENGTH];
-    if (TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
+    if (TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
         /* We have no choice: we live with no persistent caching if the stack is
          * too far away, because the instr's raw bits will be on the stack.
          * (We can't use encode_buf here bc the re-rel below does not support
@@ -394,7 +394,7 @@ private_instr_encode(dcontext_t *dcontext, instr_t *instr, bool always_cache)
                                                                 _IF_ARM(false))
                                         ->name);
 #endif
-            if (!TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags))
+            if (!TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags))
                 heap_reachable_free(dcontext, buf, MAX_INSTR_LENGTH HEAPACCT(ACCT_IR));
             return 0;
         }
@@ -424,7 +424,7 @@ private_instr_encode(dcontext_t *dcontext, instr_t *instr, bool always_cache)
          * we rely on the INSTR_RIP_REL_VALID flag being invalidated whenever
          * the raw bits are.
          */
-        bool rip_rel_valid = TEST(INSTR_RIP_REL_VALID, instr->flags);
+        bool rip_rel_valid = TESTANY(INSTR_RIP_REL_VALID, instr->flags);
 #endif
         byte *tmp;
         CLIENT_ASSERT(!instr_raw_bits_valid(instr),
@@ -443,7 +443,7 @@ private_instr_encode(dcontext_t *dcontext, instr_t *instr, bool always_cache)
         instr->bytes = tmp;
         instr_set_operands_valid(instr, valid);
     }
-    if (!TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags))
+    if (!TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags))
         heap_reachable_free(dcontext, buf, MAX_INSTR_LENGTH HEAPACCT(ACCT_IR));
     return len;
 }
@@ -637,7 +637,7 @@ instr_set_num_opnds(void *drcontext, instr_t *instr, int instr_num_dsts,
         CLIENT_ASSERT_TRUNCATE(instr->num_dsts, byte, instr_num_dsts,
                                "instr_set_num_opnds: too many dsts");
         instr->num_dsts = (byte)instr_num_dsts;
-        if (TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
+        if (TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
             instr_noalloc_t *noalloc = (instr_noalloc_t *)instr;
             noalloc->instr.dsts = noalloc->dsts;
         } else {
@@ -650,7 +650,7 @@ instr_set_num_opnds(void *drcontext, instr_t *instr, int instr_num_dsts,
         if (instr_num_srcs > 1) {
             CLIENT_ASSERT(instr->num_srcs <= 1 && instr->srcs == NULL,
                           "instr_set_num_opnds: srcs are already set");
-            if (TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
+            if (TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
                 instr_noalloc_t *noalloc = (instr_noalloc_t *)instr;
                 noalloc->instr.srcs = noalloc->srcs;
             } else {
@@ -701,7 +701,7 @@ instr_remove_srcs(void *drcontext, instr_t *instr, uint start, uint end)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     opnd_t *new_srcs;
-    CLIENT_ASSERT(!TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags),
+    CLIENT_ASSERT(!TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags),
                   /* We could implement, but it does not seem an important use case. */
                   "instr_remove_srcs not supported for instr_noalloc_t");
     CLIENT_ASSERT(start >= 0 && end <= instr->num_srcs && start < end,
@@ -734,7 +734,7 @@ instr_remove_dsts(void *drcontext, instr_t *instr, uint start, uint end)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     opnd_t *new_dsts;
-    CLIENT_ASSERT(!TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags),
+    CLIENT_ASSERT(!TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags),
                   /* We could implement, but it does not seem an important use case. */
                   "instr_remove_srcs not supported for instr_noalloc_t");
     CLIENT_ASSERT(start >= 0 && end <= instr->num_dsts && start < end,
@@ -929,7 +929,7 @@ instr_set_predicate(instr_t *instr, dr_pred_type_t pred)
 bool
 instr_branch_is_padded(instr_t *instr)
 {
-    return TEST(INSTR_BRANCH_PADDED, instr->flags);
+    return TESTANY(INSTR_BRANCH_PADDED, instr->flags);
 }
 
 void
@@ -945,7 +945,7 @@ instr_branch_set_padded(instr_t *instr, bool val)
 bool
 instr_branch_special_exit(instr_t *instr)
 {
-    return TEST(INSTR_BRANCH_SPECIAL_EXIT, instr->flags);
+    return TESTANY(INSTR_BRANCH_SPECIAL_EXIT, instr->flags);
 }
 
 /* If val is true, indicates that instr is a special exit cti.
@@ -1038,12 +1038,12 @@ uint
 instr_eflags_conditionally(uint full_eflags, dr_pred_type_t pred,
                            dr_opnd_query_flags_t flags)
 {
-    if (!TEST(DR_QUERY_INCLUDE_COND_SRCS, flags) && instr_predicate_is_cond(pred) &&
+    if (!TESTANY(DR_QUERY_INCLUDE_COND_SRCS, flags) && instr_predicate_is_cond(pred) &&
         !instr_predicate_reads_srcs(pred)) {
         /* i#1836: the predicate itself reads some flags */
         full_eflags &= ~EFLAGS_READ_NON_PRED;
     }
-    if (!TEST(DR_QUERY_INCLUDE_COND_DSTS, flags) && instr_predicate_is_cond(pred) &&
+    if (!TESTANY(DR_QUERY_INCLUDE_COND_DSTS, flags) && instr_predicate_is_cond(pred) &&
         !instr_predicate_writes_eflags(pred))
         full_eflags &= ~EFLAGS_WRITE_ALL;
     return full_eflags;
@@ -1217,7 +1217,7 @@ instr_free_raw_bits(void *drcontext, instr_t *instr)
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     if ((instr->flags & INSTR_RAW_BITS_ALLOCATED) == 0)
         return;
-    if (!TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags))
+    if (!TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags))
         heap_reachable_free(dcontext, instr->bytes, instr->length HEAPACCT(ACCT_IR));
     instr->bytes = NULL;
     instr->flags &= ~INSTR_RAW_BITS_VALID;
@@ -1233,11 +1233,11 @@ instr_allocate_raw_bits(void *drcontext, instr_t *instr, uint num_bytes)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     byte *original_bits = NULL;
-    if (TEST(INSTR_RAW_BITS_VALID, instr->flags))
+    if (TESTANY(INSTR_RAW_BITS_VALID, instr->flags))
         original_bits = instr->bytes;
-    if (!TEST(INSTR_RAW_BITS_ALLOCATED, instr->flags) || instr->length != num_bytes) {
+    if (!TESTANY(INSTR_RAW_BITS_ALLOCATED, instr->flags) || instr->length != num_bytes) {
         byte *new_bits;
-        if (TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
+        if (TESTANY(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
             /* This may not be reachable, so re-relativization is limited. */
             instr_noalloc_t *noalloc = (instr_noalloc_t *)instr;
             CLIENT_ASSERT(num_bytes <= sizeof(noalloc->encode_buf),
@@ -1276,7 +1276,7 @@ instr_set_label_callback(instr_t *instr, instr_label_callback_t cb)
     CLIENT_ASSERT(instr_is_label(instr),
                   "only set callback functions for label instructions");
     CLIENT_ASSERT(instr->label_cb == NULL, "label callback function is already set");
-    CLIENT_ASSERT(!TEST(INSTR_RAW_BITS_ALLOCATED, instr->flags),
+    CLIENT_ASSERT(!TESTANY(INSTR_RAW_BITS_ALLOCATED, instr->flags),
                   "instruction's raw bits occupying label callback memory");
     instr->label_cb = cb;
 }
@@ -1287,7 +1287,7 @@ instr_clear_label_callback(instr_t *instr)
     CLIENT_ASSERT(instr_is_label(instr),
                   "only set callback functions for label instructions");
     CLIENT_ASSERT(instr->label_cb != NULL, "label callback function not set");
-    CLIENT_ASSERT(!TEST(INSTR_RAW_BITS_ALLOCATED, instr->flags),
+    CLIENT_ASSERT(!TESTANY(INSTR_RAW_BITS_ALLOCATED, instr->flags),
                   "instruction's raw bits occupying label callback memory");
     instr->label_cb = NULL;
 }
@@ -1297,7 +1297,7 @@ instr_get_label_callback(instr_t *instr)
 {
     CLIENT_ASSERT(instr_is_label(instr),
                   "only label instructions have a callback function");
-    CLIENT_ASSERT(!TEST(INSTR_RAW_BITS_ALLOCATED, instr->flags),
+    CLIENT_ASSERT(!TESTANY(INSTR_RAW_BITS_ALLOCATED, instr->flags),
                   "instruction's raw bits occupying label callback memory");
     return instr->label_cb;
 }
@@ -1446,7 +1446,7 @@ instr_set_encoding_hint(instr_t *instr, dr_encoding_hint_type_t hint)
 bool
 instr_has_encoding_hint(instr_t *instr, dr_encoding_hint_type_t hint)
 {
-    return TEST(hint, instr->encoding_hints);
+    return TESTANY(hint, instr->encoding_hints);
 }
 
 /***********************************************************************/
@@ -2029,7 +2029,7 @@ instr_reads_from_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
     int i;
     opnd_t opnd;
 
-    if (!TEST(DR_QUERY_INCLUDE_COND_SRCS, flags) && instr_is_predicated(instr) &&
+    if (!TESTANY(DR_QUERY_INCLUDE_COND_SRCS, flags) && instr_is_predicated(instr) &&
         !instr_predicate_reads_srcs(instr_get_predicate(instr)))
         return false;
 
@@ -2055,7 +2055,7 @@ instr_reads_from_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t f
     int i;
     opnd_t opnd;
 
-    if (!TEST(DR_QUERY_INCLUDE_COND_SRCS, flags) && instr_is_predicated(instr) &&
+    if (!TESTANY(DR_QUERY_INCLUDE_COND_SRCS, flags) && instr_is_predicated(instr) &&
         !instr_predicate_reads_srcs(instr_get_predicate(instr)))
         return false;
 
@@ -2094,7 +2094,7 @@ instr_writes_to_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
     int i;
     opnd_t opnd;
 
-    if (!TEST(DR_QUERY_INCLUDE_COND_DSTS, flags) && instr_is_predicated(instr))
+    if (!TESTANY(DR_QUERY_INCLUDE_COND_DSTS, flags) && instr_is_predicated(instr))
         return false;
 
     for (i = 0; i < instr_num_dsts(instr); i++) {
@@ -2112,7 +2112,7 @@ instr_writes_to_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t fl
     int i;
     opnd_t opnd;
 
-    if (!TEST(DR_QUERY_INCLUDE_COND_DSTS, flags) && instr_is_predicated(instr))
+    if (!TESTANY(DR_QUERY_INCLUDE_COND_DSTS, flags) && instr_is_predicated(instr))
         return false;
 
     for (i = 0; i < instr_num_dsts(instr); i++) {
@@ -2263,7 +2263,7 @@ instr_zeroes_ymmh(instr_t *instr)
      * Moreover, EVEX encoded instructions clear upper ZMM bits, but also
      * YMM bits if an XMM reg is used.
      */
-    if (!TEST(REQUIRES_VEX, info->flags) && !TEST(REQUIRES_EVEX, info->flags))
+    if (!TESTANY(REQUIRES_VEX, info->flags) && !TESTANY(REQUIRES_EVEX, info->flags))
         return false;
 
     /* Handle zeroall special case. */
@@ -2286,7 +2286,7 @@ instr_zeroes_zmmh(instr_t *instr)
     const instr_info_t *info = get_encoding_info(instr);
     if (info == NULL)
         return false;
-    if (!TEST(REQUIRES_VEX, info->flags) && !TEST(REQUIRES_EVEX, info->flags))
+    if (!TESTANY(REQUIRES_VEX, info->flags) && !TESTANY(REQUIRES_EVEX, info->flags))
         return false;
     /* Handle special cases, namely zeroupper and zeroall. */
     /* XXX: DR ir should actually have these two instructions have all SIMD vector regs
@@ -2350,7 +2350,7 @@ instr_is_xrstor(instr_t *instr)
 bool
 instr_rip_rel_valid(instr_t *instr)
 {
-    return instr_raw_bits_valid(instr) && TEST(INSTR_RIP_REL_VALID, instr->flags);
+    return instr_raw_bits_valid(instr) && TESTANY(INSTR_RIP_REL_VALID, instr->flags);
 }
 
 void
@@ -2582,7 +2582,7 @@ instr_get_rel_addr_src_idx(instr_t *instr)
 bool
 instr_is_our_mangling(instr_t *instr)
 {
-    return TEST(INSTR_OUR_MANGLING, instr->flags);
+    return TESTANY(INSTR_OUR_MANGLING, instr->flags);
 }
 
 void
@@ -2597,9 +2597,9 @@ instr_set_our_mangling(instr_t *instr, bool ours)
 bool
 instr_is_our_mangling_epilogue(instr_t *instr)
 {
-    ASSERT(!TEST(INSTR_OUR_MANGLING_EPILOGUE, instr->flags) ||
+    ASSERT(!TESTANY(INSTR_OUR_MANGLING_EPILOGUE, instr->flags) ||
            instr_is_our_mangling(instr));
-    return TEST(INSTR_OUR_MANGLING_EPILOGUE, instr->flags);
+    return TESTANY(INSTR_OUR_MANGLING_EPILOGUE, instr->flags);
 }
 
 void

--- a/core/ir/instrlist.c
+++ b/core/ir/instrlist.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -199,7 +199,7 @@ instrlist_get_auto_predicate(instrlist_t *ilist)
 bool
 instrlist_get_our_mangling(instrlist_t *ilist)
 {
-    return TEST(INSTR_OUR_MANGLING, ilist->flags);
+    return TESTANY(INSTR_OUR_MANGLING, ilist->flags);
 }
 
 /* returns the first inst in the list */
@@ -546,7 +546,7 @@ instrlist_encode_to_copy(void *drcontext, instrlist_t *ilist, byte *copy_pc,
     DOCHECK(2, {
         if (!has_instr_jmp_targets) {
             for (inst = instrlist_first(ilist); inst; inst = instr_get_next(inst)) {
-                if (TEST(INSTR_OPERANDS_VALID, (inst)->flags)) {
+                if (TESTANY(INSTR_OPERANDS_VALID, (inst)->flags)) {
                     int i;
                     for (i = 0; i < instr_num_srcs(inst); ++i) {
                         CLIENT_ASSERT(!opnd_is_instr(instr_get_src(inst, i)),

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -342,7 +342,7 @@ enum {
 opnd_size_t
 opnd_get_vector_element_size(opnd_t opnd)
 {
-    if (!TEST(DR_OPND_IS_VECTOR, opnd.aux.flags))
+    if (!TESTANY(DR_OPND_IS_VECTOR, opnd.aux.flags))
         return OPSZ_NA;
 
     switch (opnd.kind) {
@@ -440,7 +440,7 @@ opnd_invert_immed_int(opnd_t opnd)
 bool
 opnd_is_immed_int64(opnd_t opnd)
 {
-    return (opnd_is_immed_int(opnd) && TEST(DR_OPND_MULTI_PART, opnd_get_flags(opnd)));
+    return (opnd_is_immed_int(opnd) && TESTANY(DR_OPND_MULTI_PART, opnd_get_flags(opnd)));
 }
 
 /* NOTE: requires caller to be under PRESERVE_FLOATING_POINT_STATE */
@@ -2211,19 +2211,19 @@ reg_get_value_ex(reg_id_t reg, dr_mcontext_t *mc, DR_PARAM_OUT byte *val)
     if (reg >= DR_REG_START_MMX && reg <= DR_REG_STOP_MMX) {
         get_mmx_val((uint64 *)val, reg - DR_REG_START_MMX);
     } else if (reg >= DR_REG_START_XMM && reg <= DR_REG_STOP_XMM) {
-        if (!TEST(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
+        if (!TESTANY(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
             return false;
         memcpy(val, &mc->simd[reg - DR_REG_START_XMM], XMM_REG_SIZE);
     } else if (reg >= DR_REG_START_YMM && reg <= DR_REG_STOP_YMM) {
-        if (!TEST(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
+        if (!TESTANY(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
             return false;
         memcpy(val, &mc->simd[reg - DR_REG_START_YMM], YMM_REG_SIZE);
     } else if (reg >= DR_REG_START_ZMM && reg <= DR_REG_STOP_ZMM) {
-        if (!TEST(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
+        if (!TESTANY(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
             return false;
         memcpy(val, &mc->simd[reg - DR_REG_START_ZMM], ZMM_REG_SIZE);
     } else if (reg >= DR_REG_START_OPMASK && reg <= DR_REG_STOP_OPMASK) {
-        if (!TEST(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
+        if (!TESTANY(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
             return false;
         memcpy(val, &mc->opmask[reg - DR_REG_START_OPMASK], OPMASK_AVX512BW_REG_SIZE);
     } else {
@@ -2232,12 +2232,12 @@ reg_get_value_ex(reg_id_t reg, dr_mcontext_t *mc, DR_PARAM_OUT byte *val)
     }
 #elif defined(AARCH64)
     if (reg >= DR_REG_START_Z && reg <= DR_REG_STOP_Z) {
-        if (!TEST(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
+        if (!TESTANY(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
             return false;
         memcpy(val, &mc->simd[reg - DR_REG_START_Z],
                opnd_size_in_bytes(reg_get_size(reg)));
     } else if (reg >= DR_REG_START_P && reg <= DR_REG_STOP_P) {
-        if (!TEST(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
+        if (!TESTANY(DR_MC_MULTIMEDIA, mc->flags) || mc->size != sizeof(dr_mcontext_t))
             return false;
         memcpy(val, &mc->svep[reg - DR_REG_START_P],
                opnd_size_in_bytes(reg_get_size(reg)));
@@ -2396,7 +2396,7 @@ opnd_compute_address_priv(opnd_t opnd, priv_mcontext_t *mc)
             break;
         case DR_SHIFT_RRX:
             scaled_index = (index_val >> 1) |
-                (TEST(EFLAGS_C, mc->cpsr) ? (1 << (sizeof(reg_t) * 8 - 1)) : 0);
+                (TESTANY(EFLAGS_C, mc->cpsr) ? (1 << (sizeof(reg_t) * 8 - 1)) : 0);
             break;
         default: scaled_index = index_val;
         }
@@ -2915,7 +2915,7 @@ dcontext_opnd_common(dcontext_t *dcontext, bool absolute, reg_id_t basereg, int 
     /* offs is not raw offset, but includes upcontext size, so we
      * can tell unprotected from normal
      */
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask) &&
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask) &&
         offs < sizeof(unprotected_context_t)) {
         return opnd_create_base_disp(
             absolute ? REG_NULL : (basereg == REG_NULL ? REG_DCXT_PROT : basereg),
@@ -2984,7 +2984,7 @@ update_dcontext_address(opnd_t op, dcontext_t *old_dcontext, dcontext_t *new_dco
     }
     /* some fields are in a separate memory region! */
     else {
-        CLIENT_ASSERT(TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask),
+        CLIENT_ASSERT(TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask),
                       "update_dcontext_address: inconsistent layout");
         IF_X64(ASSERT_NOT_IMPLEMENTED(false));
         offs = opnd_get_disp(op) -

--- a/core/ir/riscv64/disassemble.c
+++ b/core/ir/riscv64/disassemble.c
@@ -75,7 +75,7 @@ opnd_disassemble_arch(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT, opn
         /* Immediates are sign-extended at the decode time. */
         ptr_int_t val = opnd_get_immed_int(opnd);
         const char *fmt =
-            TEST(opnd_get_flags(opnd), DR_OPND_IMM_PRINT_DECIMAL) ? "%d" : "0x%x";
+            TESTANY(opnd_get_flags(opnd), DR_OPND_IMM_PRINT_DECIMAL) ? "%d" : "0x%x";
         print_to_buffer(buf, bufsz, sofar, fmt, val);
         return true;
     }

--- a/core/ir/x86/decode.c
+++ b/core/ir/x86/decode.c
@@ -222,51 +222,53 @@ resolve_variable_size(decode_info_t *di /*IN: x86_mode, prefixes*/, opnd_size_t 
                       bool is_reg)
 {
     switch (sz) {
-    case OPSZ_2_short1: return (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_1 : OPSZ_2);
-    case OPSZ_4_short2: return (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_4);
+    case OPSZ_2_short1: return (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_1 : OPSZ_2);
+    case OPSZ_4_short2: return (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_4);
     case OPSZ_4x8: return (X64_MODE(di) ? OPSZ_8 : OPSZ_4);
     case OPSZ_4x8_short2:
-        return (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_2
-                                                : (X64_MODE(di) ? OPSZ_8 : OPSZ_4));
+        return (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_2
+                                                   : (X64_MODE(di) ? OPSZ_8 : OPSZ_4));
     case OPSZ_4x8_short2xi8:
-        return (X64_MODE(di) ? (proc_get_vendor() == VENDOR_INTEL
-                                    ? OPSZ_8
-                                    : (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_8))
-                             : (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_4));
+        return (X64_MODE(di)
+                    ? (proc_get_vendor() == VENDOR_INTEL
+                           ? OPSZ_8
+                           : (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_8))
+                    : (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_4));
     case OPSZ_4_short2xi4:
         return ((X64_MODE(di) && proc_get_vendor() == VENDOR_INTEL)
                     ? OPSZ_4
-                    : (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_4));
+                    : (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_4));
     case OPSZ_4_rex8_short2: /* rex.w trumps data prefix */
-        return (TEST(PREFIX_REX_W, di->prefixes)
+        return (TESTANY(PREFIX_REX_W, di->prefixes)
                     ? OPSZ_8
-                    : (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_4));
-    case OPSZ_4_rex8: return (TEST(PREFIX_REX_W, di->prefixes) ? OPSZ_8 : OPSZ_4);
+                    : (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_4));
+    case OPSZ_4_rex8: return (TESTANY(PREFIX_REX_W, di->prefixes) ? OPSZ_8 : OPSZ_4);
     case OPSZ_6_irex10_short4: /* rex.w trumps data prefix, but is ignored on AMD */
         DODEBUG({
             /* less annoying than a CURIOSITY assert when testing */
-            if (TEST(PREFIX_REX_W, di->prefixes))
+            if (TESTANY(PREFIX_REX_W, di->prefixes))
                 SYSLOG_INTERNAL_INFO_ONCE("curiosity: rex.w on OPSZ_6_irex10_short4!");
         });
-        return ((TEST(PREFIX_REX_W, di->prefixes) && proc_get_vendor() != VENDOR_AMD)
+        return ((TESTANY(PREFIX_REX_W, di->prefixes) && proc_get_vendor() != VENDOR_AMD)
                     ? OPSZ_10
-                    : (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_4 : OPSZ_6));
+                    : (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_4 : OPSZ_6));
     case OPSZ_6x10: return (X64_MODE(di) ? OPSZ_10 : OPSZ_6);
-    case OPSZ_8_short2: return (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_8);
-    case OPSZ_8_short4: return (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_4 : OPSZ_8);
-    case OPSZ_8_rex16: return (TEST(PREFIX_REX_W, di->prefixes) ? OPSZ_16 : OPSZ_8);
+    case OPSZ_8_short2: return (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_2 : OPSZ_8);
+    case OPSZ_8_short4: return (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_4 : OPSZ_8);
+    case OPSZ_8_rex16: return (TESTANY(PREFIX_REX_W, di->prefixes) ? OPSZ_16 : OPSZ_8);
     case OPSZ_8_rex16_short4: /* rex.w trumps data prefix */
-        return (TEST(PREFIX_REX_W, di->prefixes)
+        return (TESTANY(PREFIX_REX_W, di->prefixes)
                     ? OPSZ_16
-                    : (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_4 : OPSZ_8));
+                    : (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_4 : OPSZ_8));
     case OPSZ_12_rex40_short6: /* rex.w trumps data prefix */
-        return (TEST(PREFIX_REX_W, di->prefixes)
+        return (TESTANY(PREFIX_REX_W, di->prefixes)
                     ? OPSZ_40
-                    : (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_6 : OPSZ_12));
-    case OPSZ_16_vex32: return (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_32 : OPSZ_16);
-    case OPSZ_32_short16: return (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_16 : OPSZ_32);
-    case OPSZ_28_short14: return (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_14 : OPSZ_28);
-    case OPSZ_108_short94: return (TEST(PREFIX_DATA, di->prefixes) ? OPSZ_94 : OPSZ_108);
+                    : (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_6 : OPSZ_12));
+    case OPSZ_16_vex32: return (TESTANY(PREFIX_VEX_L, di->prefixes) ? OPSZ_32 : OPSZ_16);
+    case OPSZ_32_short16: return (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_16 : OPSZ_32);
+    case OPSZ_28_short14: return (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_14 : OPSZ_28);
+    case OPSZ_108_short94:
+        return (TESTANY(PREFIX_DATA, di->prefixes) ? OPSZ_94 : OPSZ_108);
     case OPSZ_1_reg4:
     case OPSZ_2_reg4:
     case OPSZ_4_reg16: return resolve_var_reg_size(sz, is_reg);
@@ -276,10 +278,12 @@ resolve_variable_size(decode_info_t *di /*IN: x86_mode, prefixes*/, opnd_size_t 
     case OPSZ_2_of_16: return OPSZ_2;
     case OPSZ_4_of_8:
     case OPSZ_4_of_16: return OPSZ_4;
-    case OPSZ_4_rex8_of_16: return (TEST(PREFIX_REX_W, di->prefixes) ? OPSZ_8 : OPSZ_4);
+    case OPSZ_4_rex8_of_16:
+        return (TESTANY(PREFIX_REX_W, di->prefixes) ? OPSZ_8 : OPSZ_4);
     case OPSZ_8_of_16: return OPSZ_8;
     case OPSZ_12_of_16: return OPSZ_12;
-    case OPSZ_12_rex8_of_16: return (TEST(PREFIX_REX_W, di->prefixes) ? OPSZ_8 : OPSZ_12);
+    case OPSZ_12_rex8_of_16:
+        return (TESTANY(PREFIX_REX_W, di->prefixes) ? OPSZ_8 : OPSZ_12);
     case OPSZ_14_of_16: return OPSZ_14;
     case OPSZ_15_of_16: return OPSZ_15;
     case OPSZ_16_of_32:
@@ -291,35 +295,36 @@ resolve_variable_size(decode_info_t *di /*IN: x86_mode, prefixes*/, opnd_size_t 
         /* XXX i#1312: There may be a conflict since LL' is also used for rounding
          * control in AVX-512 if used in combination.
          */
-        return (TEST(PREFIX_EVEX_LL, di->prefixes)
+        return (TESTANY(PREFIX_EVEX_LL, di->prefixes)
                     ? OPSZ_64
-                    : (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_32 : OPSZ_16));
+                    : (TESTANY(PREFIX_VEX_L, di->prefixes) ? OPSZ_32 : OPSZ_16));
     case OPSZ_vex32_evex64:
         /* XXX i#1312: There may be a conflict since LL' is also used for rounding
          * control in AVX-512 if used in combination.
          */
-        return (TEST(PREFIX_EVEX_LL, di->prefixes) ? OPSZ_64 : OPSZ_32);
-    case OPSZ_half_16_vex32: return (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_16 : OPSZ_8);
+        return (TESTANY(PREFIX_EVEX_LL, di->prefixes) ? OPSZ_64 : OPSZ_32);
+    case OPSZ_half_16_vex32:
+        return (TESTANY(PREFIX_VEX_L, di->prefixes) ? OPSZ_16 : OPSZ_8);
     case OPSZ_half_16_vex32_evex64:
-        return (TEST(PREFIX_EVEX_LL, di->prefixes)
+        return (TESTANY(PREFIX_EVEX_LL, di->prefixes)
                     ? OPSZ_32
-                    : (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_16 : OPSZ_8));
+                    : (TESTANY(PREFIX_VEX_L, di->prefixes) ? OPSZ_16 : OPSZ_8));
     case OPSZ_quarter_16_vex32:
-        return (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_8 : OPSZ_4);
+        return (TESTANY(PREFIX_VEX_L, di->prefixes) ? OPSZ_8 : OPSZ_4);
     case OPSZ_quarter_16_vex32_evex64:
-        return (TEST(PREFIX_EVEX_LL, di->prefixes)
+        return (TESTANY(PREFIX_EVEX_LL, di->prefixes)
                     ? OPSZ_16
-                    : (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_8 : OPSZ_4));
+                    : (TESTANY(PREFIX_VEX_L, di->prefixes) ? OPSZ_8 : OPSZ_4));
     case OPSZ_eighth_16_vex32:
-        return (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_4 : OPSZ_2);
+        return (TESTANY(PREFIX_VEX_L, di->prefixes) ? OPSZ_4 : OPSZ_2);
     case OPSZ_eighth_16_vex32_evex64:
-        return (TEST(PREFIX_EVEX_LL, di->prefixes)
+        return (TESTANY(PREFIX_EVEX_LL, di->prefixes)
                     ? OPSZ_8
-                    : (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_4 : OPSZ_2));
+                    : (TESTANY(PREFIX_VEX_L, di->prefixes) ? OPSZ_4 : OPSZ_2));
     case OPSZ_8x16: return IF_X64_ELSE(OPSZ_16, OPSZ_8);
     case OPSZ_addr:
-        return (TEST(PREFIX_ADDR, di->prefixes) ? (X64_MODE(di) ? OPSZ_4 : OPSZ_2)
-                                                : (X64_MODE(di) ? OPSZ_8 : OPSZ_4));
+        return (TESTANY(PREFIX_ADDR, di->prefixes) ? (X64_MODE(di) ? OPSZ_4 : OPSZ_2)
+                                                   : (X64_MODE(di) ? OPSZ_8 : OPSZ_4));
     }
 
     return sz;
@@ -369,7 +374,7 @@ resolve_variable_size_dc(dcontext_t *dcontext, uint prefixes, opnd_size_t sz, bo
 opnd_size_t
 resolve_addr_size(decode_info_t *di /*IN: x86_mode, prefixes*/)
 {
-    if (TEST(PREFIX_ADDR, di->prefixes))
+    if (TESTANY(PREFIX_ADDR, di->prefixes))
         return (X64_MODE(di) ? OPSZ_4 : OPSZ_2);
     else
         return (X64_MODE(di) ? OPSZ_8 : OPSZ_4);
@@ -488,7 +493,7 @@ read_operand(byte *pc, decode_info_t *di, byte optype, opnd_size_t opsize)
         CLIENT_ASSERT(!X64_MODE(di), "x64 has no type A instructions");
         /* ok b/c only instr_info_t fields passed */
         CLIENT_ASSERT(opsize == OPSZ_6_irex10_short4, "decode A operand error");
-        if (TEST(PREFIX_DATA, di->prefixes)) {
+        if (TESTANY(PREFIX_DATA, di->prefixes)) {
             /* 4-byte immed */
             pc = read_immed(pc, di, OPSZ_4, &val);
 #ifdef X64
@@ -543,7 +548,7 @@ read_operand(byte *pc, decode_info_t *di, byte optype, opnd_size_t opsize)
         /* convert from relative offset to absolute target pc */
         val = ((ptr_int_t)end_pc) + val;
         if ((!X64_MODE(di) || proc_get_vendor() != VENDOR_INTEL) &&
-            TEST(PREFIX_DATA, di->prefixes)) {
+            TESTANY(PREFIX_DATA, di->prefixes)) {
             /* need to clear upper 16 bits */
             val &= (ptr_int_t)0x0000ffff;
         } /* for x64 Intel, always 64-bit addr ("f64" in Intel table) */
@@ -559,7 +564,7 @@ read_operand(byte *pc, decode_info_t *di, byte optype, opnd_size_t opsize)
          * so 64-bit for x64, and addr prefix affects it. */
         size = resolve_addr_size(di);
         pc = read_immed(pc, di, size, &val);
-        if (TEST(PREFIX_ADDR, di->prefixes)) {
+        if (TESTANY(PREFIX_ADDR, di->prefixes)) {
             /* need to clear upper bits */
             if (X64_MODE(di))
                 val &= (ptr_int_t)0xffffffff;
@@ -600,7 +605,7 @@ read_modrm(byte *pc, decode_info_t *di)
     di->rm = (byte)(modrm & 0x7);         /* bottom 3 bits */
 
     /* addr16 displacement */
-    if (!X64_MODE(di) && TEST(PREFIX_ADDR, di->prefixes)) {
+    if (!X64_MODE(di) && TESTANY(PREFIX_ADDR, di->prefixes)) {
         di->has_sib = false;
         if ((di->mod == 0 && di->rm == 6) || di->mod == 2) {
             /* 2-byte disp */
@@ -711,7 +716,7 @@ read_vex(byte *pc, decode_info_t *di, byte instr_byte,
         CLIENT_ASSERT(info->type == PREFIX, "internal vex decoding error");
         /* fields are: R, vvvv, L, PP.  R is inverted. */
         vex_last = instr_byte;
-        if (!TEST(0x80, vex_last))
+        if (!TESTANY(0x80, vex_last))
             di->prefixes |= PREFIX_REX_R;
         /* 2-byte vex implies leading 0x0f */
         *ret_info = &escape_instr;
@@ -720,11 +725,11 @@ read_vex(byte *pc, decode_info_t *di, byte instr_byte,
         byte vex_mm;
         CLIENT_ASSERT(info->type == PREFIX, "internal vex decoding error");
         /* fields are: R, X, B, m-mmmm.  R, X, and B are inverted. */
-        if (!TEST(0x80, instr_byte))
+        if (!TESTANY(0x80, instr_byte))
             di->prefixes |= PREFIX_REX_R;
-        if (!TEST(0x40, instr_byte))
+        if (!TESTANY(0x40, instr_byte))
             di->prefixes |= PREFIX_REX_X;
-        if (!TEST(0x20, instr_byte))
+        if (!TESTANY(0x20, instr_byte))
             di->prefixes |= PREFIX_REX_B;
         vex_mm = instr_byte & 0x1f;
         /* our strategy is to decode through the regular tables w/ a vex-encoded
@@ -764,7 +769,7 @@ read_vex(byte *pc, decode_info_t *di, byte instr_byte,
         /* Intel docs say vex.W1 behaves just like rex.w except in cases
          * where rex.w is ignored, so no need for a PREFIX_VEX_W flag
          */
-        if (TEST(0x80, vex_last))
+        if (TESTANY(0x80, vex_last))
             di->prefixes |= PREFIX_REX_W;
         /* rest are shared w/ 2-byte form's final byte */
     } else
@@ -773,7 +778,7 @@ read_vex(byte *pc, decode_info_t *di, byte instr_byte,
     /* shared vex fields */
     vex_pp = vex_last & 0x03;
     di->vex_vvvv = (vex_last & 0x78) >> 3;
-    if (TEST(0x04, vex_last))
+    if (TESTANY(0x04, vex_last))
         di->prefixes |= PREFIX_VEX_L;
     if (vex_pp == 0x1)
         di->data_prefix = true;
@@ -803,7 +808,7 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
     /* If 32-bit mode and mod selects for memory, this is not evex */
     if (X64_MODE(di) || TESTALL(MODRM_BYTE(3, 0, 0), *pc)) {
         /* P[3:2] must be 0 and P[10] must be 1, otherwise #UD */
-        if (TEST(0xC, *pc) || !TEST(0x04, *(pc + 1))) {
+        if (TESTANY(0xC, *pc) || !TESTANY(0x04, *(pc + 1))) {
             *ret_info = &invalid_instr;
             return pc;
         }
@@ -837,13 +842,13 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
      * distinct from the bound instruction in 32-bit mode. We experimentally
      * confirmed.
      */
-    if (!TEST(0x80, prefix_byte))
+    if (!TESTANY(0x80, prefix_byte))
         di->prefixes |= PREFIX_REX_R;
-    if (!TEST(0x40, prefix_byte))
+    if (!TESTANY(0x40, prefix_byte))
         di->prefixes |= PREFIX_REX_X;
-    if (!TEST(0x20, prefix_byte))
+    if (!TESTANY(0x20, prefix_byte))
         di->prefixes |= PREFIX_REX_B;
-    if (!TEST(0x10, prefix_byte))
+    if (!TESTANY(0x10, prefix_byte))
         di->prefixes |= PREFIX_EVEX_RR;
 
     byte evex_mm = instr_byte & 0x3;
@@ -865,7 +870,7 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
     pc++;
 
     /* fields are: W, vvvv, 1, PP */
-    if (TEST(0x80, prefix_byte)) {
+    if (TESTANY(0x80, prefix_byte)) {
         di->prefixes |= PREFIX_REX_W;
     }
 
@@ -884,15 +889,15 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
     pc++;
 
     /* fields are: z, L', L, b, V' and aaa */
-    if (TEST(0x80, prefix_byte))
+    if (TESTANY(0x80, prefix_byte))
         di->prefixes |= PREFIX_EVEX_z;
-    if (TEST(0x40, prefix_byte))
+    if (TESTANY(0x40, prefix_byte))
         di->prefixes |= PREFIX_EVEX_LL;
-    if (TEST(0x20, prefix_byte))
+    if (TESTANY(0x20, prefix_byte))
         di->prefixes |= PREFIX_VEX_L;
-    if (TEST(0x10, prefix_byte))
+    if (TESTANY(0x10, prefix_byte))
         di->prefixes |= PREFIX_EVEX_b;
-    if (!TEST(0x08, prefix_byte))
+    if (!TESTANY(0x08, prefix_byte))
         di->prefixes |= PREFIX_EVEX_VV;
 
     di->evex_aaa = prefix_byte & 0x07;
@@ -950,7 +955,7 @@ read_prefix_ext(const instr_info_t *info, decode_info_t *di)
     if (info->type == REX_B_EXT) {
         /* discard old info, get new one */
         code = (int)info->code;
-        idx = (TEST(PREFIX_REX_B, di->prefixes) ? 1 : 0);
+        idx = (TESTANY(PREFIX_REX_B, di->prefixes) ? 1 : 0);
         info = &rex_b_extensions[code][idx];
     }
     return info;
@@ -1140,25 +1145,25 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
          * a suffix byte where an immed would be (yes, ugly!).
          * We should have already read in the modrm (+ sib).
          */
-        CLIENT_ASSERT(TEST(HAS_MODRM, info->flags), "decode error on 3DNow instr");
+        CLIENT_ASSERT(TESTANY(HAS_MODRM, info->flags), "decode error on 3DNow instr");
         info = &suffix_extensions[suffix_index[*pc]];
         pc++;
         DEBUG_DECLARE(post_suffix_pc = pc;)
     } else if (info->type == VEX_L_EXT) {
         /* discard old info, get new one */
         int code = (int)info->code;
-        int idx = (di->vex_encoded) ? (TEST(PREFIX_VEX_L, di->prefixes) ? 2 : 1) : 0;
+        int idx = (di->vex_encoded) ? (TESTANY(PREFIX_VEX_L, di->prefixes) ? 2 : 1) : 0;
         info = &vex_L_extensions[code][idx];
     } else if (info->type == VEX_W_EXT) {
         /* discard old info, get new one */
         int code = (int)info->code;
-        int idx = (TEST(PREFIX_REX_W, di->prefixes) ? 1 : 0);
+        int idx = (TESTANY(PREFIX_REX_W, di->prefixes) ? 1 : 0);
         info = &vex_W_extensions[code][idx];
     } else if (info->type == EVEX_Wb_EXT) {
         /* discard old info, get new one */
         int code = (int)info->code;
-        int idx = (TEST(PREFIX_REX_W, di->prefixes) ? 2 : 0) +
-            (TEST(PREFIX_EVEX_b, di->prefixes) ? 1 : 0);
+        int idx = (TESTANY(PREFIX_REX_W, di->prefixes) ? 2 : 0) +
+            (TESTANY(PREFIX_EVEX_b, di->prefixes) ? 1 : 0);
         info = &evex_Wb_extensions[code][idx];
     }
 
@@ -1205,23 +1210,23 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
     if (info->type == REX_W_EXT) {
         /* discard old info, get new one */
         int code = (int)info->code;
-        int idx = (TEST(PREFIX_REX_W, di->prefixes) ? 1 : 0);
+        int idx = (TESTANY(PREFIX_REX_W, di->prefixes) ? 1 : 0);
         info = &rex_w_extensions[code][idx];
     } else if (info->type == VEX_L_EXT) {
         /* discard old info, get new one */
         int code = (int)info->code;
-        int idx = (di->vex_encoded) ? (TEST(PREFIX_VEX_L, di->prefixes) ? 2 : 1) : 0;
+        int idx = (di->vex_encoded) ? (TESTANY(PREFIX_VEX_L, di->prefixes) ? 2 : 1) : 0;
         info = &vex_L_extensions[code][idx];
     } else if (info->type == VEX_W_EXT) {
         /* discard old info, get new one */
         int code = (int)info->code;
-        int idx = (TEST(PREFIX_REX_W, di->prefixes) ? 1 : 0);
+        int idx = (TESTANY(PREFIX_REX_W, di->prefixes) ? 1 : 0);
         info = &vex_W_extensions[code][idx];
     } else if (info->type == EVEX_Wb_EXT) {
         /* discard old info, get new one */
         int code = (int)info->code;
-        int idx = (TEST(PREFIX_REX_W, di->prefixes) ? 2 : 0) +
-            (TEST(PREFIX_EVEX_b, di->prefixes) ? 1 : 0);
+        int idx = (TESTANY(PREFIX_REX_W, di->prefixes) ? 2 : 0) +
+            (TESTANY(PREFIX_EVEX_b, di->prefixes) ? 1 : 0);
         info = &evex_Wb_extensions[code][idx];
     }
 
@@ -1230,7 +1235,7 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
         info = &mod_extensions[info->code][(di->mod == 3) ? 1 : 0];
     }
 
-    if (TEST(REQUIRES_PREFIX, info->flags)) {
+    if (TESTANY(REQUIRES_PREFIX, info->flags)) {
         byte required = (byte)(info->opcode >> 24);
         bool *prefix_var = NULL;
         if (required == 0) { /* cannot have a prefix */
@@ -1260,25 +1265,28 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
 
     /* we go through regular tables for vex but only some are valid w/ vex */
     if (info != NULL && di->vex_encoded) {
-        if (!TEST(REQUIRES_VEX, info->flags))
+        if (!TESTANY(REQUIRES_VEX, info->flags))
             info = NULL; /* invalid encoding */
-        else if (TEST(REQUIRES_VEX_L_0, info->flags) && TEST(PREFIX_VEX_L, di->prefixes))
+        else if (TESTANY(REQUIRES_VEX_L_0, info->flags) &&
+                 TESTANY(PREFIX_VEX_L, di->prefixes))
             info = NULL; /* invalid encoding */
-        else if (TEST(REQUIRES_VEX_L_1, info->flags) && !TEST(PREFIX_VEX_L, di->prefixes))
+        else if (TESTANY(REQUIRES_VEX_L_1, info->flags) &&
+                 !TESTANY(PREFIX_VEX_L, di->prefixes))
             info = NULL; /* invalid encoding */
-    } else if (info != NULL && !di->vex_encoded && TEST(REQUIRES_VEX, info->flags)) {
+    } else if (info != NULL && !di->vex_encoded && TESTANY(REQUIRES_VEX, info->flags)) {
         info = NULL; /* invalid encoding */
     } else if (info != NULL && di->evex_encoded) {
-        if (!TEST(REQUIRES_EVEX, info->flags))
+        if (!TESTANY(REQUIRES_EVEX, info->flags))
             info = NULL; /* invalid encoding */
-        else if (TEST(REQUIRES_VEX_L_0, info->flags) && TEST(PREFIX_VEX_L, di->prefixes))
+        else if (TESTANY(REQUIRES_VEX_L_0, info->flags) &&
+                 TESTANY(PREFIX_VEX_L, di->prefixes))
             info = NULL; /* invalid encoding */
-        else if (TEST(REQUIRES_EVEX_LL_0, info->flags) &&
-                 TEST(PREFIX_EVEX_LL, di->prefixes))
+        else if (TESTANY(REQUIRES_EVEX_LL_0, info->flags) &&
+                 TESTANY(PREFIX_EVEX_LL, di->prefixes))
             info = NULL; /* invalid encoding */
-        else if (TEST(REQUIRES_NOT_K0, info->flags) && di->evex_aaa == 0)
+        else if (TESTANY(REQUIRES_NOT_K0, info->flags) && di->evex_aaa == 0)
             info = NULL; /* invalid encoding */
-    } else if (info != NULL && !di->evex_encoded && TEST(REQUIRES_EVEX, info->flags))
+    } else if (info != NULL && !di->evex_encoded && TESTANY(REQUIRES_EVEX, info->flags))
         info = NULL; /* invalid encoding */
     /* XXX: not currently marking these cases as invalid instructions:
      * - if no TYPE_H:
@@ -1290,8 +1298,8 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
 
     /* at this point should be an instruction, so type should be an OP_ constant */
     if (info == NULL || info == &invalid_instr || info->type < OP_FIRST ||
-        info->type > OP_LAST || (X64_MODE(di) && TEST(X64_INVALID, info->flags)) ||
-        (!X64_MODE(di) && TEST(X86_INVALID, info->flags))) {
+        info->type > OP_LAST || (X64_MODE(di) && TESTANY(X64_INVALID, info->flags)) ||
+        (!X64_MODE(di) && TESTANY(X86_INVALID, info->flags))) {
         /* invalid instruction: up to caller to decide what to do with it */
         /* XXX case 10672: provide a runtime option to specify new
          * instruction formats */
@@ -1383,7 +1391,7 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
          * Note that this means we could assert or remove some of
          * the "rex.w trumps data prefix" logic elsewhere in this file.
          */
-        if (TEST(PREFIX_REX_W, di->prefixes)) {
+        if (TESTANY(PREFIX_REX_W, di->prefixes)) {
             LOG(THREAD_GET, LOG_ALL, 3, "Ignoring 0x66 in presence of rex.w @" PFX "\n",
                 di->start_pc);
         } else {
@@ -1391,7 +1399,7 @@ read_instruction(dcontext_t *dcontext, byte *pc, byte *orig_pc,
         }
     }
     if ((di->repne_prefix || di->rep_prefix) &&
-        (TEST(PREFIX_LOCK, di->prefixes) ||
+        (TESTANY(PREFIX_LOCK, di->prefixes) ||
          /* xrelease can go on non-0xa3 mov_st w/o lock prefix */
          (di->repne_prefix && info->type == OP_mov_st &&
           (info->opcode & 0xa30000) != 0xa30000))) {
@@ -1466,23 +1474,23 @@ decode_reg(decode_reg_t which_reg, decode_info_t *di, byte optype, opnd_size_t o
     switch (which_reg) {
     case DECODE_REG_REG:
         reg = di->reg;
-        extend = X64_MODE(di) && TEST(PREFIX_REX_R, di->prefixes);
-        avx512_extend = TEST(PREFIX_EVEX_RR, di->prefixes);
+        extend = X64_MODE(di) && TESTANY(PREFIX_REX_R, di->prefixes);
+        avx512_extend = TESTANY(PREFIX_EVEX_RR, di->prefixes);
         break;
     case DECODE_REG_BASE:
         reg = di->base;
-        extend = X64_MODE(di) && TEST(PREFIX_REX_B, di->prefixes);
+        extend = X64_MODE(di) && TESTANY(PREFIX_REX_B, di->prefixes);
         break;
     case DECODE_REG_INDEX:
         reg = di->index;
-        extend = X64_MODE(di) && TEST(PREFIX_REX_X, di->prefixes);
-        avx512_extend = TEST(PREFIX_EVEX_VV, di->prefixes);
+        extend = X64_MODE(di) && TESTANY(PREFIX_REX_X, di->prefixes);
+        avx512_extend = TESTANY(PREFIX_EVEX_VV, di->prefixes);
         break;
     case DECODE_REG_RM:
         reg = di->rm;
-        extend = X64_MODE(di) && TEST(PREFIX_REX_B, di->prefixes);
+        extend = X64_MODE(di) && TESTANY(PREFIX_REX_B, di->prefixes);
         if (di->evex_encoded)
-            avx512_extend = TEST(PREFIX_REX_X, di->prefixes);
+            avx512_extend = TESTANY(PREFIX_REX_X, di->prefixes);
         break;
     case DECODE_REG_VEX:
         /* Part of XOP/AVX: vex.vvvv selects general-purpose register.
@@ -1501,7 +1509,7 @@ decode_reg(decode_reg_t which_reg, decode_info_t *di, byte optype, opnd_size_t o
          */
         reg = (~di->evex_vvvv) & 0xf; /* bit-inverted */
         extend = false;
-        avx512_extend = TEST(PREFIX_EVEX_VV, di->prefixes); /* bit-inverted */
+        avx512_extend = TESTANY(PREFIX_EVEX_VV, di->prefixes); /* bit-inverted */
         break;
     case DECODE_REG_OPMASK:
         /* Part of AVX-512: evex.aaa selects opmask register. */
@@ -1525,7 +1533,7 @@ decode_reg(decode_reg_t which_reg, decode_info_t *di, byte optype, opnd_size_t o
          * repurpose PREFIX_EVEX_LL for other things and only come in a 64 byte
          * variant.
          */
-        bool operand_is_zmm = (TEST(PREFIX_EVEX_LL, di->prefixes) &&
+        bool operand_is_zmm = (TESTANY(PREFIX_EVEX_LL, di->prefixes) &&
                                expand_subreg_size(opsize) != OPSZ_16 &&
                                expand_subreg_size(opsize) != OPSZ_32) ||
             opsize == OPSZ_64;
@@ -1542,9 +1550,10 @@ decode_reg(decode_reg_t which_reg, decode_info_t *di, byte optype, opnd_size_t o
          * As above PREFIX_EVEX_LL may be repurposed for embedded rounding control, so
          * honor opsizes of exactly OPSZ_32.
          */
-        bool operand_is_ymm = (TEST(PREFIX_EVEX_LL, di->prefixes) &&
+        bool operand_is_ymm = (TESTANY(PREFIX_EVEX_LL, di->prefixes) &&
                                expand_subreg_size(opsize) == OPSZ_32) ||
-            (TEST(PREFIX_VEX_L, di->prefixes) && expand_subreg_size(opsize) != OPSZ_16 &&
+            (TESTANY(PREFIX_VEX_L, di->prefixes) &&
+             expand_subreg_size(opsize) != OPSZ_16 &&
              expand_subreg_size(opsize) != OPSZ_64) ||
             opsize == OPSZ_32;
         if (operand_is_ymm && operand_is_zmm) {
@@ -1631,7 +1640,7 @@ decode_modrm(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *reg_opn
     /* for x64, addr prefix affects only base/index and truncates final addr:
      * modrm + sib table is the same
      */
-    bool addr16 = !X64_MODE(di) && TEST(PREFIX_ADDR, di->prefixes);
+    bool addr16 = !X64_MODE(di) && TESTANY(PREFIX_ADDR, di->prefixes);
 
     if (reg_opnd != NULL) {
         reg_id_t reg = decode_reg(DECODE_REG_REG, di, optype, opsize);
@@ -1657,7 +1666,7 @@ decode_modrm(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *reg_opn
             CLIENT_ASSERT(!addr16, "decode error: x86 addr16 cannot have a SIB byte");
             if (di->index == 4 &&
                 /* rex.x enables r12 as index */
-                (!X64_MODE(di) || !TEST(PREFIX_REX_X, di->prefixes)) &&
+                (!X64_MODE(di) || !TESTANY(PREFIX_REX_X, di->prefixes)) &&
                 optype != TYPE_VSIB) {
                 /* no scale/index */
                 index_reg = REG_NULL;
@@ -1702,7 +1711,7 @@ decode_modrm(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *reg_opn
                         addr = di->orig_pc + di->len + di->disp;
                     else
                         addr = di->start_pc + di->len + di->disp;
-                    if (TEST(PREFIX_ADDR, di->prefixes)) {
+                    if (TESTANY(PREFIX_ADDR, di->prefixes)) {
                         /* Need to clear upper 32 bits.
                          * Debuggers do not display this truncation, though
                          * both Intel and AMD manuals describe it.
@@ -1806,7 +1815,7 @@ decode_modrm(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *reg_opn
             *rm_opnd = opnd_create_far_base_disp_ex(
                 di->seg_override, base_reg, index_reg, scale, disp,
                 resolve_variable_size(di, opsize, false), encode_zero_disp,
-                force_full_disp, TEST(PREFIX_ADDR, di->prefixes));
+                force_full_disp, TESTANY(PREFIX_ADDR, di->prefixes));
         } else {
             /* Note that OP_{jmp,call}_far_ind does NOT have a far base disp
              * operand: it is a regular base disp containing 6 bytes that
@@ -1816,7 +1825,7 @@ decode_modrm(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *reg_opn
             *rm_opnd = opnd_create_base_disp_ex(base_reg, index_reg, scale, disp,
                                                 resolve_variable_size(di, opsize, false),
                                                 encode_zero_disp, force_full_disp,
-                                                TEST(PREFIX_ADDR, di->prefixes));
+                                                TESTANY(PREFIX_ADDR, di->prefixes));
         }
     }
     return true;
@@ -1851,7 +1860,7 @@ resolve_var_reg(decode_info_t *di /*IN: x86_mode, prefixes*/, reg_id_t reg32, bo
         /* Note that Intel's table 3-1 on +r possibilities is incorrect:
          * it lists rex.r, while Table 2-4 lists rex.b which is correct.
          */
-        if (TEST(PREFIX_REX_B, di->prefixes))
+        if (TESTANY(PREFIX_REX_B, di->prefixes))
             reg32 = reg32 + 8;
         else
             reg32 = reg8_alternative(di, reg32, di->prefixes);
@@ -1862,23 +1871,23 @@ resolve_var_reg(decode_info_t *di /*IN: x86_mode, prefixes*/, reg_id_t reg32, bo
 #ifdef X64
         if (X64_MODE(di)) {
             CLIENT_ASSERT(default_64, "addr-based size must be default 64");
-            if (!can_shrink || !TEST(PREFIX_ADDR, di->prefixes))
+            if (!can_shrink || !TESTANY(PREFIX_ADDR, di->prefixes))
                 return reg_32_to_64(reg32);
             /* else leave 32 (it's addr32 not addr16) */
         } else
 #endif
-            if (can_shrink && TEST(PREFIX_ADDR, di->prefixes))
+            if (can_shrink && TESTANY(PREFIX_ADDR, di->prefixes))
             return reg_32_to_16(reg32);
     } else {
 #ifdef X64
         /* rex.w trumps data prefix */
         if (X64_MODE(di) &&
-            ((can_grow && TEST(PREFIX_REX_W, di->prefixes)) ||
-             (default_64 && (!can_shrink || !TEST(PREFIX_DATA, di->prefixes)))))
+            ((can_grow && TESTANY(PREFIX_REX_W, di->prefixes)) ||
+             (default_64 && (!can_shrink || !TESTANY(PREFIX_DATA, di->prefixes)))))
             return reg_32_to_64(reg32);
         else
 #endif
-            if (can_shrink && TEST(PREFIX_DATA, di->prefixes))
+            if (can_shrink && TESTANY(PREFIX_DATA, di->prefixes))
             return reg_32_to_16(reg32);
     }
     return reg32;
@@ -2040,7 +2049,7 @@ decode_operand(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *opnd)
         CLIENT_ASSERT(!X64_MODE(di), "x64 has no type A instructions");
         CLIENT_ASSERT(opsize == OPSZ_6_irex10_short4, "decode A operand error");
         /* just ignore segment prefixes -- don't assert */
-        if (TEST(PREFIX_DATA, di->prefixes)) {
+        if (TESTANY(PREFIX_DATA, di->prefixes)) {
             /* 4-byte immed */
             ptr_int_t val = get_immed(di, opsize);
             *opnd = opnd_create_far_pc((ushort)(((ptr_int_t)val & 0xffff0000) >> 16),
@@ -2065,10 +2074,10 @@ decode_operand(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *opnd)
     }
     case TYPE_X:
         /* this means the memory address DS:(E)SI */
-        if (!X64_MODE(di) && TEST(PREFIX_ADDR, di->prefixes)) {
+        if (!X64_MODE(di) && TESTANY(PREFIX_ADDR, di->prefixes)) {
             *opnd =
                 opnd_create_far_base_disp(ds_seg(di), REG_SI, REG_NULL, 0, 0, ressize);
-        } else if (!X64_MODE(di) || TEST(PREFIX_ADDR, di->prefixes)) {
+        } else if (!X64_MODE(di) || TESTANY(PREFIX_ADDR, di->prefixes)) {
             *opnd =
                 opnd_create_far_base_disp(ds_seg(di), REG_ESI, REG_NULL, 0, 0, ressize);
         } else {
@@ -2078,28 +2087,28 @@ decode_operand(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *opnd)
         return true;
     case TYPE_Y:
         /* this means the memory address ES:(E)DI */
-        if (!X64_MODE(di) && TEST(PREFIX_ADDR, di->prefixes))
+        if (!X64_MODE(di) && TESTANY(PREFIX_ADDR, di->prefixes))
             *opnd = opnd_create_far_base_disp(SEG_ES, REG_DI, REG_NULL, 0, 0, ressize);
-        else if (!X64_MODE(di) || TEST(PREFIX_ADDR, di->prefixes))
+        else if (!X64_MODE(di) || TESTANY(PREFIX_ADDR, di->prefixes))
             *opnd = opnd_create_far_base_disp(SEG_ES, REG_EDI, REG_NULL, 0, 0, ressize);
         else
             *opnd = opnd_create_far_base_disp(SEG_ES, REG_RDI, REG_NULL, 0, 0, ressize);
         return true;
     case TYPE_XLAT:
         /* this means the memory address DS:(E)BX+AL */
-        if (!X64_MODE(di) && TEST(PREFIX_ADDR, di->prefixes))
+        if (!X64_MODE(di) && TESTANY(PREFIX_ADDR, di->prefixes))
             *opnd = opnd_create_far_base_disp(ds_seg(di), REG_BX, REG_AL, 1, 0, ressize);
-        else if (!X64_MODE(di) || TEST(PREFIX_ADDR, di->prefixes))
+        else if (!X64_MODE(di) || TESTANY(PREFIX_ADDR, di->prefixes))
             *opnd = opnd_create_far_base_disp(ds_seg(di), REG_EBX, REG_AL, 1, 0, ressize);
         else
             *opnd = opnd_create_far_base_disp(ds_seg(di), REG_RBX, REG_AL, 1, 0, ressize);
         return true;
     case TYPE_MASKMOVQ:
         /* this means the memory address DS:(E)DI */
-        if (!X64_MODE(di) && TEST(PREFIX_ADDR, di->prefixes)) {
+        if (!X64_MODE(di) && TESTANY(PREFIX_ADDR, di->prefixes)) {
             *opnd =
                 opnd_create_far_base_disp(ds_seg(di), REG_DI, REG_NULL, 0, 0, ressize);
-        } else if (!X64_MODE(di) || TEST(PREFIX_ADDR, di->prefixes)) {
+        } else if (!X64_MODE(di) || TESTANY(PREFIX_ADDR, di->prefixes)) {
             *opnd =
                 opnd_create_far_base_disp(ds_seg(di), REG_EDI, REG_NULL, 0, 0, ressize);
         } else {
@@ -2147,11 +2156,11 @@ decode_operand(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *opnd)
          */
         return decode_operand(di, TYPE_E, opsize, opnd);
     case TYPE_L: {
-        CLIENT_ASSERT(!TEST(PREFIX_EVEX_LL, di->prefixes), "XXX i#1312: unsupported.");
+        CLIENT_ASSERT(!TESTANY(PREFIX_EVEX_LL, di->prefixes), "XXX i#1312: unsupported.");
         /* part of AVX: top 4 bits of 8-bit immed select xmm/ymm register */
         ptr_int_t immed = get_immed(di, OPSZ_1);
         reg_id_t reg = (reg_id_t)(immed & 0xf0) >> 4;
-        *opnd = opnd_create_reg(((TEST(PREFIX_VEX_L, di->prefixes) &&
+        *opnd = opnd_create_reg(((TESTANY(PREFIX_VEX_L, di->prefixes) &&
                                   /* see .LIG notes above */
                                   expand_subreg_size(opsize) != OPSZ_16)
                                      ? REG_START_YMM
@@ -2241,7 +2250,7 @@ dr_pred_type_t
 decode_predicate_from_instr_info(uint opcode, const instr_info_t *info)
 {
     if (TESTANY(HAS_PRED_CC | HAS_PRED_COMPLEX, info->flags)) {
-        if (TEST(HAS_PRED_CC, info->flags)) {
+        if (TESTANY(HAS_PRED_CC, info->flags)) {
             if (opcode >= OP_jo && opcode <= OP_jnle)
                 return DR_PRED_O + opcode - OP_jo;
             else if (opcode >= OP_jo_short && opcode <= OP_jnle_short)
@@ -2278,17 +2287,17 @@ int
 decode_get_compressed_disp_scale(decode_info_t *di)
 {
     dr_tuple_type_t tuple_type = di->tuple_type;
-    bool broadcast = TEST(PREFIX_EVEX_b, di->prefixes);
+    bool broadcast = TESTANY(PREFIX_EVEX_b, di->prefixes);
     opnd_size_t input_size = di->input_size;
     if (input_size == OPSZ_NA) {
-        if (TEST(PREFIX_REX_W, di->prefixes))
+        if (TESTANY(PREFIX_REX_W, di->prefixes))
             input_size = OPSZ_8;
         else
             input_size = OPSZ_4;
     }
 
-    opnd_size_t vl = decode_get_vector_length(TEST(di->prefixes, PREFIX_VEX_L),
-                                              TEST(di->prefixes, PREFIX_EVEX_LL));
+    opnd_size_t vl = decode_get_vector_length(TESTANY(di->prefixes, PREFIX_VEX_L),
+                                              TESTANY(di->prefixes, PREFIX_EVEX_LL));
     if (vl == OPSZ_NA)
         return -1;
     switch (tuple_type) {
@@ -2441,13 +2450,13 @@ decode_get_tuple_type_input_size(const instr_info_t *info, decode_info_t *di)
 {
     /* The upper DR_TUPLE_TYPE_BITS bits of the flags field are the evex tuple type. */
     di->tuple_type = (dr_tuple_type_t)(info->flags >> DR_TUPLE_TYPE_BITPOS);
-    if (TEST(DR_EVEX_INPUT_OPSZ_1, info->flags))
+    if (TESTANY(DR_EVEX_INPUT_OPSZ_1, info->flags))
         di->input_size = OPSZ_1;
-    else if (TEST(DR_EVEX_INPUT_OPSZ_2, info->flags))
+    else if (TESTANY(DR_EVEX_INPUT_OPSZ_2, info->flags))
         di->input_size = OPSZ_2;
-    else if (TEST(DR_EVEX_INPUT_OPSZ_4, info->flags))
+    else if (TESTANY(DR_EVEX_INPUT_OPSZ_4, info->flags))
         di->input_size = OPSZ_4;
-    else if (TEST(DR_EVEX_INPUT_OPSZ_8, info->flags))
+    else if (TESTANY(DR_EVEX_INPUT_OPSZ_8, info->flags))
         di->input_size = OPSZ_8;
     else
         di->input_size = OPSZ_NA;
@@ -2546,7 +2555,7 @@ decode_opcode(dcontext_t *dcontext, byte *pc, instr_t *instr)
      */
     read_instruction(dcontext, pc, pc, &info, &di,
                      true /* just opcode */
-                     _IF_DEBUG(!TEST(INSTR_IGNORE_INVALID, instr->flags)));
+                     _IF_DEBUG(!TESTANY(INSTR_IGNORE_INVALID, instr->flags)));
     sz = decode_sizeof_ex(dcontext, pc, NULL, &rip_rel_pos);
     IF_X64(instr_set_x86_mode(instr, get_x86_mode(dcontext)));
     instr_set_opcode(instr, info->type);
@@ -2619,7 +2628,7 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
     next_pc = read_instruction(dcontext, pc, orig_pc, &info, &di,
                                false /* not just opcode,
                                         decode operands too */
-                               _IF_DEBUG(!TEST(INSTR_IGNORE_INVALID, instr->flags)));
+                               _IF_DEBUG(!TESTANY(INSTR_IGNORE_INVALID, instr->flags)));
     instr_set_opcode(instr, info->type);
     IF_X64(instr_set_x86_mode(instr, di.x86_mode));
     /* failure up to this point handled fine -- we set opcode to OP_INVALID */
@@ -2711,7 +2720,7 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
         instr_set_predicate(instr, decode_predicate_from_instr_info(di.opcode, info));
 
     /* check for invalid prefixes that depend on operand types */
-    if (TEST(PREFIX_LOCK, di.prefixes)) {
+    if (TESTANY(PREFIX_LOCK, di.prefixes)) {
         /* check for invalid opcode, list on p3-397 of IA-32 vol 2 */
         switch (instr_get_opcode(instr)) {
         case OP_add:

--- a/core/ir/x86/decode_fast.c
+++ b/core/ir/x86/decode_fast.c
@@ -530,7 +530,7 @@ decode_sizeof_ex(void *drcontext, byte *start_pc, int *num_prefixes, uint *rip_r
                 break;
             case EVEX_PREFIX_OPCODE: {
                 /* If 64-bit mode or EVEX.R' bit is flipped, this is evex */
-                if (X64_MODE_DC(dcontext) || TEST(0x10, *(pc + 1))) {
+                if (X64_MODE_DC(dcontext) || TESTANY(0x10, *(pc + 1))) {
                     evex_prefix = true;
                 }
                 /* Fall-through is deliberate, EVEX is handled through VEX below */

--- a/core/ir/x86/disassemble.c
+++ b/core/ir/x86/disassemble.c
@@ -110,7 +110,7 @@ opnd_base_disp_scale_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM
 {
     int scale = opnd_get_scale(opnd);
     if (scale > 1) {
-        if (TEST(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask)))
+        if (TESTANY(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask)))
             print_to_buffer(buf, bufsz, sofar, "*%d", scale);
         else
             print_to_buffer(buf, bufsz, sofar, ",%d", scale);
@@ -252,7 +252,7 @@ opnd_disassemble_noimplicit(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOU
 static const char *
 instr_opcode_name(instr_t *instr)
 {
-    if (TEST(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))) {
+    if (TESTANY(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))) {
         switch (instr_get_opcode(instr)) {
         /* remove "l" prefix */
         case OP_call_far: return "call";
@@ -356,7 +356,8 @@ instr_opcode_name_suffix(instr_t *instr)
         }
         }
     }
-    if (TEST(DR_DISASM_ATT, DYNAMO_OPTION(disasm_mask)) && instr_operands_valid(instr)) {
+    if (TESTANY(DR_DISASM_ATT, DYNAMO_OPTION(disasm_mask)) &&
+        instr_operands_valid(instr)) {
         /* XXX: requiring both src and dst.  Ideally we'd wait until we
          * see if there is a register or in some cases an immed operand
          * and then go back and add the suffix.  This will do for now.
@@ -391,11 +392,11 @@ void
 print_instr_prefixes(dcontext_t *dcontext, instr_t *instr, char *buf, size_t bufsz,
                      size_t *sofar DR_PARAM_OUT)
 {
-    if (TEST(PREFIX_XACQUIRE, instr->prefixes))
+    if (TESTANY(PREFIX_XACQUIRE, instr->prefixes))
         print_to_buffer(buf, bufsz, sofar, "xacquire ");
-    if (TEST(PREFIX_XRELEASE, instr->prefixes))
+    if (TESTANY(PREFIX_XRELEASE, instr->prefixes))
         print_to_buffer(buf, bufsz, sofar, "xrelease ");
-    if (TEST(PREFIX_LOCK, instr->prefixes))
+    if (TESTANY(PREFIX_LOCK, instr->prefixes))
         print_to_buffer(buf, bufsz, sofar, "lock ");
     /* Note that we do not try to figure out data16 or addr16 prefixes
      * if they are not already set from a recent decode;
@@ -406,16 +407,16 @@ print_instr_prefixes(dcontext_t *dcontext, instr_t *instr, char *buf, size_t buf
      * REG_CX, or string ops, maskmov*, or xlat of REG_DI or REG_SI.
      * For data16, we'd look for 16-bit reg or OPSZ_2 immed or base_disp.
      */
-    if (!TEST(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))) {
-        if (TEST(PREFIX_DATA, instr->prefixes))
+    if (!TESTANY(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))) {
+        if (TESTANY(PREFIX_DATA, instr->prefixes))
             print_to_buffer(buf, bufsz, sofar, "data16 ");
-        if (TEST(PREFIX_ADDR, instr->prefixes) &&
+        if (TESTANY(PREFIX_ADDR, instr->prefixes) &&
             !suppress_memory_size_annotations(instr)) {
             print_to_buffer(buf, bufsz, sofar,
                             X64_MODE_DC(dcontext) ? "addr32 " : "addr16 ");
         }
 #if 0 /* disabling for PR 256226 */
-        if (TEST(PREFIX_REX_W, instr->prefixes))
+        if (TESTANY(PREFIX_REX_W, instr->prefixes))
             print_to_buffer(buf, bufsz, sofar, "rex.w ");
 #endif
     }
@@ -424,10 +425,10 @@ print_instr_prefixes(dcontext_t *dcontext, instr_t *instr, char *buf, size_t buf
 int
 print_opcode_suffix(instr_t *instr, char *buf, size_t bufsz, size_t *sofar DR_PARAM_OUT)
 {
-    if (TEST(PREFIX_JCC_TAKEN, instr->prefixes)) {
+    if (TESTANY(PREFIX_JCC_TAKEN, instr->prefixes)) {
         print_to_buffer(buf, bufsz, sofar, ",pt");
         return 2;
-    } else if (TEST(PREFIX_JCC_NOT_TAKEN, instr->prefixes)) {
+    } else if (TESTANY(PREFIX_JCC_NOT_TAKEN, instr->prefixes)) {
         print_to_buffer(buf, bufsz, sofar, ",pn");
         return 2;
     }

--- a/core/ir/x86/encode.c
+++ b/core/ir/x86/encode.c
@@ -715,7 +715,7 @@ size_ok_varsz(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             return true;
         }
         if (size_template == OPSZ_4_rex8_short2) {
-            if (TEST(PREFIX_REX_W, di->prefixes))
+            if (TESTANY(PREFIX_REX_W, di->prefixes))
                 return false; /* rex.w trumps data prefix */
             di->prefixes |= prefix_data_addr;
             return true;
@@ -725,13 +725,13 @@ size_ok_varsz(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
         if (size_template == OPSZ_4 || size_template == OPSZ_2)
             return true; /* will take prefix or no prefix */
         if (size_template == OPSZ_4_rex8_short2 || size_template == OPSZ_4_rex8)
-            return !TEST(PREFIX_REX_W, di->prefixes);
+            return !TESTANY(PREFIX_REX_W, di->prefixes);
         if (size_template == OPSZ_8_short2 || size_template == OPSZ_8_short4) {
             di->prefixes |= prefix_data_addr;
             return true;
         }
         if (size_template == OPSZ_6_irex10_short4 &&
-            (proc_get_vendor() == VENDOR_AMD || !TEST(PREFIX_REX_W, di->prefixes))) {
+            (proc_get_vendor() == VENDOR_AMD || !TESTANY(PREFIX_REX_W, di->prefixes))) {
             di->prefixes |= prefix_data_addr;
             return true;
         }
@@ -742,7 +742,7 @@ size_ok_varsz(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             size_template == OPSZ_2 || size_template == OPSZ_4 || size_template == OPSZ_8)
             return true; /* will take prefix or no prefix */
         if (size_template == OPSZ_6_irex10_short4 &&
-            (proc_get_vendor() == VENDOR_AMD || !TEST(PREFIX_REX_W, di->prefixes))) {
+            (proc_get_vendor() == VENDOR_AMD || !TESTANY(PREFIX_REX_W, di->prefixes))) {
             di->prefixes |= prefix_data_addr;
             return true;
         }
@@ -753,9 +753,9 @@ size_ok_varsz(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             return true; /* will take prefix or no prefix */
         if (size_template == OPSZ_4_short2 || size_template == OPSZ_4_rex8_short2 ||
             size_template == OPSZ_8_short2)
-            return !TEST(prefix_data_addr, di->prefixes);
+            return !TESTANY(prefix_data_addr, di->prefixes);
         if (size_template == OPSZ_6_irex10_short4 &&
-            (proc_get_vendor() == VENDOR_AMD || !TEST(PREFIX_REX_W, di->prefixes))) {
+            (proc_get_vendor() == VENDOR_AMD || !TESTANY(PREFIX_REX_W, di->prefixes))) {
             di->prefixes |= prefix_data_addr;
             return true;
         }
@@ -765,11 +765,11 @@ size_ok_varsz(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             (size_template == OPSZ_10 && proc_get_vendor() != VENDOR_AMD))
             return true; /* will take prefix or no prefix */
         if (size_template == OPSZ_4_short2)
-            return !TEST(prefix_data_addr, di->prefixes);
+            return !TESTANY(prefix_data_addr, di->prefixes);
         if (size_template == OPSZ_4_rex8_short2)
             return !TESTANY(prefix_data_addr | PREFIX_REX_W, di->prefixes);
         if (size_template == OPSZ_4_rex8)
-            return !TEST(PREFIX_REX_W, di->prefixes);
+            return !TESTANY(PREFIX_REX_W, di->prefixes);
         if (size_template == OPSZ_8_short4) {
             di->prefixes |= prefix_data_addr;
             return true;
@@ -783,7 +783,7 @@ size_ok_varsz(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             return true;
         }
         if (size_template == OPSZ_4_rex8_short2) {
-            if (TEST(prefix_data_addr, di->prefixes))
+            if (TESTANY(prefix_data_addr, di->prefixes))
                 return true; /* Already shrinking so ok */
             /* XXX - ambiguous on 64-bit (could widen to 8 or shrink to 2).
              * We choose to widen by default for 64-bit as that seems the more likely
@@ -800,7 +800,7 @@ size_ok_varsz(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             return true;
         }
         if (size_template == OPSZ_8_short4)
-            return !TEST(prefix_data_addr, di->prefixes);
+            return !TESTANY(prefix_data_addr, di->prefixes);
         return false;
     case OPSZ_8_short4:
         if (size_template == OPSZ_4_rex8 || size_template == OPSZ_8 ||
@@ -808,9 +808,9 @@ size_ok_varsz(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             return true; /* will take prefix or no prefix */
         if (size_template == OPSZ_4_short2 || size_template == OPSZ_4_rex8_short2 ||
             size_template == OPSZ_8_short2)
-            return !TEST(prefix_data_addr, di->prefixes);
+            return !TESTANY(prefix_data_addr, di->prefixes);
         if (size_template == OPSZ_6_irex10_short4 &&
-            (proc_get_vendor() == VENDOR_AMD || !TEST(PREFIX_REX_W, di->prefixes))) {
+            (proc_get_vendor() == VENDOR_AMD || !TESTANY(PREFIX_REX_W, di->prefixes))) {
             di->prefixes |= prefix_data_addr;
             return true;
         }
@@ -988,39 +988,40 @@ size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
                 return true;
             }
             if (size_template == OPSZ_2_short1)
-                return !TEST(prefix_data_addr, di->prefixes);
+                return !TESTANY(prefix_data_addr, di->prefixes);
             if (size_template == OPSZ_4_short2 || size_template == OPSZ_8_short2) {
                 di->prefixes |= prefix_data_addr;
                 return true;
             }
             if (size_template == OPSZ_4_rex8_short2) {
-                if (TEST(PREFIX_REX_W, di->prefixes))
+                if (TESTANY(PREFIX_REX_W, di->prefixes))
                     return false; /* rex.w trumps data prefix */
                 di->prefixes |= prefix_data_addr;
                 return true;
             }
             if (size_template == OPSZ_eighth_16_vex32)
-                return !TEST(PREFIX_VEX_L, di->prefixes);
+                return !TESTANY(PREFIX_VEX_L, di->prefixes);
             if (size_template == OPSZ_eighth_16_vex32_evex64) {
-                return !TEST(PREFIX_VEX_L, di->prefixes) &&
-                    !TEST(PREFIX_EVEX_LL, di->prefixes);
+                return !TESTANY(PREFIX_VEX_L, di->prefixes) &&
+                    !TESTANY(PREFIX_EVEX_LL, di->prefixes);
             }
             return false;
         case OPSZ_4:
             if (size_template == OPSZ_addr) {
                 if (!X64_MODE(di))
-                    return !TEST(prefix_data_addr, di->prefixes);
+                    return !TESTANY(prefix_data_addr, di->prefixes);
                 di->prefixes |= prefix_data_addr;
                 return true;
             }
             if (size_template == OPSZ_4_short2)
-                return !TEST(prefix_data_addr, di->prefixes);
+                return !TESTANY(prefix_data_addr, di->prefixes);
             if (size_template == OPSZ_4_rex8_short2)
                 return !TESTANY(prefix_data_addr | PREFIX_REX_W, di->prefixes);
             if (size_template == OPSZ_4_rex8)
-                return !TEST(PREFIX_REX_W, di->prefixes);
+                return !TESTANY(PREFIX_REX_W, di->prefixes);
             if (size_template == OPSZ_6_irex10_short4) {
-                if (TEST(PREFIX_REX_W, di->prefixes) && proc_get_vendor() != VENDOR_AMD)
+                if (TESTANY(PREFIX_REX_W, di->prefixes) &&
+                    proc_get_vendor() != VENDOR_AMD)
                     return false; /* rex.w trumps data prefix */
                 di->prefixes |= prefix_data_addr;
                 return true;
@@ -1030,27 +1031,27 @@ size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
                 return true;
             }
             if (size_template == OPSZ_4_rex8_of_16)
-                return !TEST(PREFIX_REX_W, di->prefixes);
+                return !TESTANY(PREFIX_REX_W, di->prefixes);
             if (size_template == OPSZ_quarter_16_vex32)
-                return !TEST(PREFIX_VEX_L, di->prefixes);
+                return !TESTANY(PREFIX_VEX_L, di->prefixes);
             if (size_template == OPSZ_quarter_16_vex32_evex64) {
-                return !TEST(PREFIX_VEX_L, di->prefixes) &&
-                    !TEST(PREFIX_EVEX_LL, di->prefixes);
+                return !TESTANY(PREFIX_VEX_L, di->prefixes) &&
+                    !TESTANY(PREFIX_EVEX_LL, di->prefixes);
             }
             if (size_template == OPSZ_eighth_16_vex32) {
                 di->prefixes |= PREFIX_VEX_L;
                 return true;
             }
             if (size_template == OPSZ_eighth_16_vex32_evex64) {
-                if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+                if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                     di->prefixes |= PREFIX_VEX_L;
                 return true;
             }
             return false;
         case OPSZ_6:
             if (size_template == OPSZ_6_irex10_short4) {
-                return !TEST(prefix_data_addr, di->prefixes) &&
-                    (!TEST(PREFIX_REX_W, di->prefixes) ||
+                return !TESTANY(prefix_data_addr, di->prefixes) &&
+                    (!TESTANY(PREFIX_REX_W, di->prefixes) ||
                      proc_get_vendor() == VENDOR_AMD);
             }
             if (size_template == OPSZ_12_rex40_short6) {
@@ -1068,22 +1069,22 @@ size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             }
             if ((X64_MODE(di) && size_template == OPSZ_addr) ||
                 size_template == OPSZ_8_short4 || size_template == OPSZ_8_short2)
-                return !TEST(prefix_data_addr, di->prefixes);
+                return !TESTANY(prefix_data_addr, di->prefixes);
             if (size_template == OPSZ_8_rex16 || size_template == OPSZ_8_rex16_short4)
                 return !TESTANY(prefix_data_addr | PREFIX_REX_W, di->prefixes);
             if (size_template == OPSZ_half_16_vex32)
-                return !TEST(PREFIX_VEX_L, di->prefixes);
+                return !TESTANY(PREFIX_VEX_L, di->prefixes);
             if (size_template == OPSZ_half_16_vex32_evex64) {
-                return !TEST(PREFIX_VEX_L, di->prefixes) &&
-                    !TEST(PREFIX_EVEX_LL, di->prefixes);
+                return !TESTANY(PREFIX_VEX_L, di->prefixes) &&
+                    !TESTANY(PREFIX_EVEX_LL, di->prefixes);
             }
             if (size_template == OPSZ_quarter_16_vex32) {
-                if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+                if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                     di->prefixes |= PREFIX_VEX_L;
                 return true;
             }
             if (size_template == OPSZ_quarter_16_vex32_evex64) {
-                if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+                if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                     di->prefixes |= PREFIX_VEX_L;
                 return true;
             }
@@ -1104,7 +1105,7 @@ size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             if (size_template == OPSZ_12_rex40_short6)
                 return !TESTANY(prefix_data_addr | PREFIX_REX_W, di->prefixes);
             if (size_template == OPSZ_12_rex8_of_16)
-                return !TEST(PREFIX_REX_W, di->prefixes);
+                return !TESTANY(PREFIX_REX_W, di->prefixes);
             return false;
         case OPSZ_16:
             if (X64_MODE(di) &&
@@ -1117,12 +1118,12 @@ size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
                 return true;
             }
             if (size_template == OPSZ_16_vex32)
-                return !TEST(PREFIX_VEX_L, di->prefixes);
+                return !TESTANY(PREFIX_VEX_L, di->prefixes);
             if (size_template == OPSZ_16_vex32_evex64)
                 return !TESTANY(PREFIX_EVEX_LL | PREFIX_VEX_L, di->prefixes);
             if (size_template == OPSZ_half_16_vex32 ||
                 size_template == OPSZ_half_16_vex32_evex64) {
-                if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+                if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                     di->prefixes |= PREFIX_VEX_L;
                 return true;
             }
@@ -1141,14 +1142,14 @@ size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
         case OPSZ_15: return false; /* no variable sizes match, need identical request */
         case OPSZ_28:
             if (size_template == OPSZ_28_short14)
-                return !TEST(prefix_data_addr, di->prefixes);
+                return !TESTANY(prefix_data_addr, di->prefixes);
             return false;
         case OPSZ_32:
             if (size_template == OPSZ_32_short16)
-                return !TEST(prefix_data_addr, di->prefixes);
+                return !TESTANY(prefix_data_addr, di->prefixes);
             if (size_template == OPSZ_16_vex32 || size_template == OPSZ_16_vex32_evex64 ||
                 size_template == OPSZ_vex32_evex64) {
-                if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+                if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                     di->prefixes |= PREFIX_VEX_L;
                 return true;
             }
@@ -1180,7 +1181,7 @@ size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/,
             return false;
         case OPSZ_108:
             if (size_template == OPSZ_108_short94)
-                return !TEST(prefix_data_addr, di->prefixes);
+                return !TESTANY(prefix_data_addr, di->prefixes);
             return false;
         case OPSZ_512:
             return false; /* no variable sizes match, need identical request */
@@ -1331,9 +1332,9 @@ reg_size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, reg_
         opsize == OPSZ_quarter_16_vex32_evex64 || opsize == OPSZ_eighth_16_vex32_evex64 ||
         optype == TYPE_VSIB) {
         if (reg >= REG_START_XMM && reg <= REG_STOP_XMM)
-            return !TEST(PREFIX_VEX_L, di->prefixes);
+            return !TESTANY(PREFIX_VEX_L, di->prefixes);
         if (reg >= REG_START_YMM && reg <= REG_STOP_YMM) {
-            if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+            if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                 di->prefixes |= PREFIX_VEX_L;
             return true;
         }
@@ -1347,7 +1348,7 @@ reg_size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, reg_
     if (opsize == OPSZ_16_of_32) {
         if (reg >= REG_START_YMM && reg <= REG_STOP_YMM) {
             /* Set VEX.L since required for some opcodes and the rest don't care */
-            if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+            if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                 di->prefixes |= PREFIX_VEX_L;
             return true;
         } else
@@ -1356,7 +1357,7 @@ reg_size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, reg_
     if (opsize == OPSZ_16_of_32_evex64 || opsize == OPSZ_4_of_32_evex64 ||
         opsize == OPSZ_8_of_32_evex64) {
         if (reg >= REG_START_YMM && reg <= REG_STOP_YMM) {
-            if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+            if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                 di->prefixes |= PREFIX_VEX_L;
             return true;
         } else if (reg >= DR_REG_START_ZMM && reg <= DR_REG_STOP_ZMM) {
@@ -1382,7 +1383,7 @@ reg_size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, reg_
     if (size_ok(di, reg_get_size(reg), resolve_var_reg_size(opsize, true), addr)) {
         if (reg >= REG_START_YMM && reg <= REG_STOP_YMM) {
             /* Set VEX.L since required for some opcodes and the rest don't care */
-            if (!TEST(di->prefixes, PREFIX_EVEX_LL))
+            if (!TESTANY(di->prefixes, PREFIX_EVEX_LL))
                 di->prefixes |= PREFIX_VEX_L;
         } else if (reg >= DR_REG_START_ZMM && reg <= DR_REG_STOP_ZMM) {
             di->prefixes |= PREFIX_EVEX_LL;
@@ -1552,13 +1553,13 @@ opnd_type_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, opn
                                     _IF_X64(true /*extendable*/)));
     case TYPE_VSIB:
 #ifndef X64
-        if (TEST(PREFIX_ADDR, di->prefixes))
+        if (TESTANY(PREFIX_ADDR, di->prefixes))
             return false; /* VSIB invalid w/ 16-bit addressing */
 #endif
-        if (TEST(REQUIRES_VSIB_YMM, flags)) {
+        if (TESTANY(REQUIRES_VSIB_YMM, flags)) {
             if (!reg_is_strictly_ymm(opnd_get_index(opnd)))
                 return false;
-        } else if (TEST(REQUIRES_VSIB_ZMM, flags)) {
+        } else if (TESTANY(REQUIRES_VSIB_ZMM, flags)) {
             if (!reg_is_strictly_zmm(opnd_get_index(opnd)))
                 return false;
         }
@@ -1836,8 +1837,8 @@ opnd_type_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, opn
 const instr_info_t *
 instr_info_extra_opnds(const instr_info_t *info)
 {
-    if (TEST(HAS_EXTRA_OPERANDS, info->flags)) {
-        if (TEST(EXTRAS_IN_CODE_FIELD, info->flags))
+    if (TESTANY(HAS_EXTRA_OPERANDS, info->flags)) {
+        if (TESTANY(EXTRAS_IN_CODE_FIELD, info->flags))
             return (const instr_info_t *)(info->code);
         else /* extra operands are in next entry */
             return (info + 1);
@@ -1853,7 +1854,7 @@ instr_info_extra_opnds(const instr_info_t *info)
         if (!opnd_type_ok(di, get_op, iitype, iisize, flags))                            \
             return false;                                                                \
         if (opnd_needs_evex(get_op)) {                                                   \
-            if (!TEST(REQUIRES_EVEX, flags))                                             \
+            if (!TESTANY(REQUIRES_EVEX, flags))                                          \
                 return false;                                                            \
         }                                                                                \
         if (type_instr_uses_reg_bits(iitype)) {                                          \
@@ -1871,7 +1872,7 @@ instr_info_extra_opnds(const instr_info_t *info)
         } else if (type_uses_evex_aaa_bits(iitype)) {                                    \
             if (!opnd_is_null(using_aaa_bits) && !opnd_same(using_aaa_bits, get_op))     \
                 return false;                                                            \
-            if (TEST(REQUIRES_NOT_K0, flags) && opnd_get_reg(get_op) == DR_REG_K0)       \
+            if (TESTANY(REQUIRES_NOT_K0, flags) && opnd_get_reg(get_op) == DR_REG_K0)    \
                 return false;                                                            \
             using_aaa_bits = get_op;                                                     \
         }                                                                                \
@@ -1882,7 +1883,7 @@ static bool
 encoding_meets_hints(instr_t *instr, const instr_info_t *info)
 {
     return !instr_has_encoding_hint(instr, DR_ENCODING_HINT_X86_EVEX) ||
-        TEST(REQUIRES_EVEX, info->flags);
+        TESTANY(REQUIRES_EVEX, info->flags);
 }
 
 /* May be called a 2nd time to check size prefix consistency.
@@ -1915,7 +1916,7 @@ encoding_possible_pass(decode_info_t *di, instr_t *in, const instr_info_t *ii)
     TEST_OPND(di, ii->src3_type, ii->src3_size, 3, in->num_srcs, instr_get_src(in, 2),
               ii->flags);
 
-    if (TEST(HAS_EXTRA_OPERANDS, ii->flags)) {
+    if (TESTANY(HAS_EXTRA_OPERANDS, ii->flags)) {
         /* extra operands to test! */
         int offs = 1;
         ii = instr_info_extra_opnds(ii);
@@ -1957,7 +1958,7 @@ encoding_possible(decode_info_t *di, instr_t *in, const instr_info_t *ii)
         return false;
     LOG(THREAD, LOG_EMIT, ENC_LEVEL, "\nencoding_possible on " PFX "\n", ii->opcode);
 
-    if (TEST(X64_MODE(di) ? X64_INVALID : X86_INVALID, ii->flags))
+    if (TESTANY(X64_MODE(di) ? X64_INVALID : X86_INVALID, ii->flags))
         return false;
 
     /* For size prefixes we use the di prefix field since that's what
@@ -2072,9 +2073,10 @@ encode_immed(decode_info_t *di, byte *pc)
              * the offset, but wants to hold the absolute pc.
              */
             size = di->size_immed; /* TYPE_I put real size there */
-            CLIENT_ASSERT((size == OPSZ_4_short2 && !TEST(PREFIX_DATA, di->prefixes)) ||
-                              (size == OPSZ_4) || IF_X64_ELSE((size == OPSZ_8), false),
-                          "encode error: immediate has invalid size");
+            CLIENT_ASSERT(
+                (size == OPSZ_4_short2 && !TESTANY(PREFIX_DATA, di->prefixes)) ||
+                    (size == OPSZ_4) || IF_X64_ELSE((size == OPSZ_8), false),
+                "encode error: immediate has invalid size");
             /* we want val to be pc of target instr
              * immed is the difference between us and target
              * HACK: di->modrm was set with the number of instruction bytes
@@ -2202,7 +2204,7 @@ encode_base_disp(decode_info_t *di, opnd_t opnd)
     reg_id_t base, index;
     int scale, disp;
     /* in 64-bit mode, addr prefix simply truncates registers and final address */
-    bool addr16 = !X64_MODE(di) && TEST(PREFIX_ADDR, di->prefixes);
+    bool addr16 = !X64_MODE(di) && TESTANY(PREFIX_ADDR, di->prefixes);
 
     /* user can use opnd_create_abs_addr() but it will internally be a base-disp
      * if its disp is 32-bit: if it's larger it has to be TYPE_O and not get here!
@@ -2257,7 +2259,7 @@ encode_base_disp(decode_info_t *di, opnd_t opnd)
             di->has_disp = true;
             di->disp = disp;
             /* if rex.x is set we'll have r12 instead of no base */
-            CLIENT_ASSERT(!TEST(PREFIX_REX_X, di->prefixes),
+            CLIENT_ASSERT(!TESTANY(PREFIX_REX_X, di->prefixes),
                           "encode error: for x64 cannot encode abs addr w/ rex.x");
         } else {
             di->has_sib = false;
@@ -2380,7 +2382,7 @@ encode_base_disp(decode_info_t *di, opnd_t opnd)
                 if (X64_MODE(di) && reg_is_32bit(base)) {
                     CLIENT_ASSERT(
                         index == REG_NULL ||
-                            (reg_is_32bit(index) && TEST(PREFIX_ADDR, di->prefixes)),
+                            (reg_is_32bit(index) && TESTANY(PREFIX_ADDR, di->prefixes)),
                         "encode error: index and base must be same width");
                     di->prefixes |= PREFIX_ADDR;
                 }
@@ -2774,9 +2776,9 @@ encode_operand(decode_info_t *di, int optype, opnd_size_t opsize, opnd_t opnd)
 static byte
 encode_vex_final_prefix_byte(byte cur_byte, decode_info_t *di, const instr_info_t *info)
 {
-    cur_byte |= (di->vex_vvvv << 3) | (TEST(PREFIX_VEX_L, di->prefixes) ? 0x04 : 0x00);
+    cur_byte |= (di->vex_vvvv << 3) | (TESTANY(PREFIX_VEX_L, di->prefixes) ? 0x04 : 0x00);
     /* we override OPCODE_SUFFIX for vex to mean "requires vex.L" */
-    if (TEST(OPCODE_SUFFIX, info->opcode))
+    if (TESTANY(OPCODE_SUFFIX, info->opcode))
         cur_byte |= 0x04;
     /* OPCODE_{MODRM,SUFFIX} mean something else for vex */
     if (info->opcode > 0xffffff) {
@@ -2805,11 +2807,11 @@ encode_evex_prefixes(byte *field_ptr, decode_info_t *di, const instr_info_t *inf
     field_ptr++;
     /* second evex byte */
     val = /* these are negated */
-        (TEST(PREFIX_REX_R, di->prefixes) ? 0x00 : 0x80) |
-        (TEST(PREFIX_REX_X, di->prefixes) ? 0x00 : 0x40) |
-        (TEST(PREFIX_REX_B, di->prefixes) ? 0x00 : 0x20) |
-        (TEST(PREFIX_EVEX_RR, di->prefixes) ? 0x00 : 0x10);
-    if (TEST(OPCODE_THREEBYTES, info->opcode)) {
+        (TESTANY(PREFIX_REX_R, di->prefixes) ? 0x00 : 0x80) |
+        (TESTANY(PREFIX_REX_X, di->prefixes) ? 0x00 : 0x40) |
+        (TESTANY(PREFIX_REX_B, di->prefixes) ? 0x00 : 0x20) |
+        (TESTANY(PREFIX_EVEX_RR, di->prefixes) ? 0x00 : 0x10);
+    if (TESTANY(OPCODE_THREEBYTES, info->opcode)) {
         byte op3 = (byte)((info->opcode & 0x00ff0000) >> 16);
         if (op3 == 0x38)
             val |= 0x02;
@@ -2825,9 +2827,9 @@ encode_evex_prefixes(byte *field_ptr, decode_info_t *di, const instr_info_t *inf
     *field_ptr = val;
     field_ptr++;
     /* third evex byte */
-    val = (TEST(PREFIX_REX_W, di->prefixes) ? 0x80 : 0x00);
+    val = (TESTANY(PREFIX_REX_W, di->prefixes) ? 0x80 : 0x00);
     /* we override OPCODE_MODRM for evex to mean "requires evex.W" */
-    if (TEST(OPCODE_MODRM, info->opcode))
+    if (TESTANY(OPCODE_MODRM, info->opcode))
         val = 0x80;
     /* evex fixed bit always 1. */
     val |= 0x4;
@@ -2847,17 +2849,17 @@ encode_evex_prefixes(byte *field_ptr, decode_info_t *di, const instr_info_t *inf
     *field_ptr = val;
     field_ptr++;
     /* fourth evex byte */
-    val = (TEST(PREFIX_EVEX_z, di->prefixes) ? 0x80 : 0x00) |
-        (TEST(PREFIX_EVEX_LL, di->prefixes) ? 0x40 : 0x00) |
-        (TEST(PREFIX_VEX_L, di->prefixes) ? 0x20 : 0x00) |
-        (TEST(PREFIX_EVEX_b, di->prefixes) ? 0x10 : 0x00) |
-        (TEST(PREFIX_EVEX_VV, di->prefixes) ? 0x00 : 0x08);
+    val = (TESTANY(PREFIX_EVEX_z, di->prefixes) ? 0x80 : 0x00) |
+        (TESTANY(PREFIX_EVEX_LL, di->prefixes) ? 0x40 : 0x00) |
+        (TESTANY(PREFIX_VEX_L, di->prefixes) ? 0x20 : 0x00) |
+        (TESTANY(PREFIX_EVEX_b, di->prefixes) ? 0x10 : 0x00) |
+        (TESTANY(PREFIX_EVEX_VV, di->prefixes) ? 0x00 : 0x08);
     /* we override OPCODE_SUFFIX for evex to mean "requires evex.L" */
     /* XXX i#1312: what about evex.L'? */
-    if (TEST(OPCODE_SUFFIX, info->opcode))
+    if (TESTANY(OPCODE_SUFFIX, info->opcode))
         val |= 0x20;
     /* we override OPCODE_TWOBYTES for evex to mean "requires evex.b" */
-    if (TEST(OPCODE_TWOBYTES, info->opcode))
+    if (TESTANY(OPCODE_TWOBYTES, info->opcode))
         val |= 0x10;
     val |= di->evex_aaa;
     *field_ptr = val;
@@ -2880,7 +2882,7 @@ encode_vex_prefixes(byte *field_ptr, decode_info_t *di, const instr_info_t *info
         /* 3-byte vex shortest encoding for 0x0f 0x3[8a], and the same
          * size but I'm assuming faster decode in processor for 0x0f
          */
-        TEST(OPCODE_THREEBYTES, info->opcode) ||
+        TESTANY(OPCODE_THREEBYTES, info->opcode) ||
         /* XOP is always 3 bytes */
         xop ||
         /* 2-byte requires leading 0x0f */
@@ -2897,16 +2899,17 @@ encode_vex_prefixes(byte *field_ptr, decode_info_t *di, const instr_info_t *info
         field_ptr++;
         /* second vex byte */
         val = /* these are negated */
-            (TEST(PREFIX_REX_R, di->prefixes) ? 0x00 : 0x80) |
-            (TEST(PREFIX_REX_X, di->prefixes) ? 0x00 : 0x40) |
-            (TEST(PREFIX_REX_B, di->prefixes) ? 0x00 : 0x20);
+            (TESTANY(PREFIX_REX_R, di->prefixes) ? 0x00 : 0x80) |
+            (TESTANY(PREFIX_REX_X, di->prefixes) ? 0x00 : 0x40) |
+            (TESTANY(PREFIX_REX_B, di->prefixes) ? 0x00 : 0x20);
         if (xop) {
             byte map_select = (byte)((info->opcode & 0x00ff0000) >> 16);
-            CLIENT_ASSERT(TEST(OPCODE_THREEBYTES, info->opcode), "internal invalid XOP");
+            CLIENT_ASSERT(TESTANY(OPCODE_THREEBYTES, info->opcode),
+                          "internal invalid XOP");
             CLIENT_ASSERT(map_select < 0x20, "XOP.map_select only has 5 bits");
             val |= map_select;
         } else {
-            if (TEST(OPCODE_THREEBYTES, info->opcode)) {
+            if (TESTANY(OPCODE_THREEBYTES, info->opcode)) {
                 byte op3 = (byte)((info->opcode & 0x00ff0000) >> 16);
                 if (op3 == 0x38)
                     val |= 0x02;
@@ -2923,9 +2926,9 @@ encode_vex_prefixes(byte *field_ptr, decode_info_t *di, const instr_info_t *info
         *field_ptr = val;
         field_ptr++;
         /* third vex byte */
-        val = (TEST(PREFIX_REX_W, di->prefixes) ? 0x80 : 0x00);
+        val = (TESTANY(PREFIX_REX_W, di->prefixes) ? 0x80 : 0x00);
         /* we override OPCODE_MODRM for vex to mean "requires vex.W" */
-        if (TEST(OPCODE_MODRM, info->opcode))
+        if (TESTANY(OPCODE_MODRM, info->opcode))
             val = 0x80;
         val = encode_vex_final_prefix_byte(val, di, info);
         *field_ptr = val;
@@ -2937,7 +2940,7 @@ encode_vex_prefixes(byte *field_ptr, decode_info_t *di, const instr_info_t *info
         di->vex_encoded = true;
         field_ptr++;
         /* second vex byte */
-        val = (TEST(PREFIX_REX_R, di->prefixes) ? 0x00 : 0x80); /* negated */
+        val = (TESTANY(PREFIX_REX_R, di->prefixes) ? 0x00 : 0x80); /* negated */
         val = encode_vex_final_prefix_byte(val, di, info);
         *field_ptr = val;
         field_ptr++;
@@ -2967,10 +2970,10 @@ encode_cti(instr_t *instr, byte *copy_pc, byte *final_pc,
     }
 
     if (instr->prefixes != 0) {
-        if (TEST(PREFIX_JCC_TAKEN, instr->prefixes)) {
+        if (TESTANY(PREFIX_JCC_TAKEN, instr->prefixes)) {
             *pc = RAW_PREFIX_jcc_taken;
             pc++;
-        } else if (TEST(PREFIX_JCC_NOT_TAKEN, instr->prefixes)) {
+        } else if (TESTANY(PREFIX_JCC_NOT_TAKEN, instr->prefixes)) {
             *pc = RAW_PREFIX_jcc_not_taken;
             pc++;
         }
@@ -2986,11 +2989,11 @@ encode_cti(instr_t *instr, byte *copy_pc, byte *final_pc,
     *pc = (byte)((info->opcode & 0x00ff0000) >> 16);
     pc++;
     /* second opcode byte, if there is one */
-    if (TEST(OPCODE_TWOBYTES, info->opcode)) {
+    if (TESTANY(OPCODE_TWOBYTES, info->opcode)) {
         *pc = (byte)((info->opcode & 0x0000ff00) >> 8);
         pc++;
     }
-    ASSERT(!TEST(OPCODE_THREEBYTES, info->opcode)); /* no cti has 3 opcode bytes */
+    ASSERT(!TESTANY(OPCODE_THREEBYTES, info->opcode)); /* no cti has 3 opcode bytes */
 
     /* we assume only one operand: 1st src == jump target, but we do
      * not check that, for speed
@@ -3252,8 +3255,8 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
     /* instr_t* operand support */
     di.cur_offs = (ptr_int_t)instr->offset;
 
-    di.vex_encoded = TEST(REQUIRES_VEX, info->flags);
-    di.evex_encoded = TEST(REQUIRES_EVEX, info->flags);
+    di.vex_encoded = TESTANY(REQUIRES_VEX, info->flags);
+    di.evex_encoded = TESTANY(REQUIRES_EVEX, info->flags);
     CLIENT_ASSERT(!di.vex_encoded || !di.evex_encoded,
                   "instr_encode error: flags can't be both vex and evex.");
 
@@ -3262,12 +3265,12 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
          * always at least two bytes) to indicate EVEX.b=1. We need to
          * do this now to make sure we calculate the correct tuple size.
          */
-        if (TEST(OPCODE_TWOBYTES, info->opcode))
+        if (TESTANY(OPCODE_TWOBYTES, info->opcode))
             di.prefixes |= PREFIX_EVEX_b;
         decode_get_tuple_type_input_size(info, &di);
     }
     if (di.vex_encoded || di.evex_encoded) {
-        if (TEST(OPCODE_MODRM, info->opcode))
+        if (TESTANY(OPCODE_MODRM, info->opcode))
             di.prefixes |= PREFIX_REX_W;
     }
 
@@ -3295,7 +3298,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
                            instr_get_src(instr, offs * 3 + 2));
         }
         offs++;
-        if (TEST(HAS_EXTRA_OPERANDS, ii->flags))
+        if (TESTANY(HAS_EXTRA_OPERANDS, ii->flags))
             ii = instr_info_extra_opnds(ii);
         else
             ii = NULL;
@@ -3312,34 +3315,34 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
 
     /* output the prefix byte(s) */
     if (di.prefixes != 0) {
-        if (TEST(PREFIX_LOCK, di.prefixes)) {
+        if (TESTANY(PREFIX_LOCK, di.prefixes)) {
             *field_ptr = RAW_PREFIX_lock;
             field_ptr++;
         }
-        if (TEST(PREFIX_XACQUIRE, di.prefixes)) {
+        if (TESTANY(PREFIX_XACQUIRE, di.prefixes)) {
             *field_ptr = RAW_PREFIX_xacquire;
             field_ptr++;
         }
-        if (TEST(PREFIX_XRELEASE, di.prefixes)) {
+        if (TESTANY(PREFIX_XRELEASE, di.prefixes)) {
             *field_ptr = RAW_PREFIX_xrelease;
             field_ptr++;
         }
-        if (TEST(PREFIX_JCC_TAKEN, di.prefixes)) {
+        if (TESTANY(PREFIX_JCC_TAKEN, di.prefixes)) {
             *field_ptr = RAW_PREFIX_jcc_taken;
             field_ptr++;
-        } else if (TEST(PREFIX_JCC_NOT_TAKEN, di.prefixes)) {
+        } else if (TESTANY(PREFIX_JCC_NOT_TAKEN, di.prefixes)) {
             *field_ptr = RAW_PREFIX_jcc_not_taken;
             field_ptr++;
         }
     }
-    if (TEST(PREFIX_DATA, di.prefixes)) {
+    if (TESTANY(PREFIX_DATA, di.prefixes)) {
         *field_ptr = DATA_PREFIX_OPCODE;
         field_ptr++;
     }
     /* N.B.: we assume the order of 0x67 <seg> in coarse_is_indirect_stub()
      * and instr_is_tls_xcx_spill()
      */
-    if (TEST(PREFIX_ADDR, di.prefixes)) {
+    if (TESTANY(PREFIX_ADDR, di.prefixes)) {
         *field_ptr = ADDR_PREFIX_OPCODE;
         field_ptr++;
     }
@@ -3360,15 +3363,16 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
      * flags, and some opcode bytes.
      */
     if (di.vex_encoded) {
-        if (TEST(REQUIRES_VEX_L_1, info->flags)) {
+        if (TESTANY(REQUIRES_VEX_L_1, info->flags)) {
             di.prefixes |= PREFIX_VEX_L;
         }
         field_ptr = encode_vex_prefixes(field_ptr, &di, info, &output_initial_opcode);
     } else if (di.evex_encoded) {
         field_ptr = encode_evex_prefixes(field_ptr, &di, info, &output_initial_opcode);
     } else {
-        CLIENT_ASSERT(!TEST(PREFIX_VEX_L, di.prefixes), "internal encode vex error");
-        CLIENT_ASSERT(!TEST(PREFIX_EVEX_LL, di.prefixes), "internal encode evex error");
+        CLIENT_ASSERT(!TESTANY(PREFIX_VEX_L, di.prefixes), "internal encode vex error");
+        CLIENT_ASSERT(!TESTANY(PREFIX_EVEX_LL, di.prefixes),
+                      "internal encode evex error");
 
         /* output the opcode required prefix byte (if needed) */
         if (info->opcode > 0xffffff &&
@@ -3379,7 +3383,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
             field_ptr++;
         }
 
-        if (TEST(REQUIRES_REX, info->flags)) {
+        if (TESTANY(REQUIRES_REX, info->flags)) {
             /* We could add other rex flags by overloading OPCODE_SUFFIX or
              * possibly OPCODE_MODRM (but the latter only for instrs that
              * aren't in mod_ext).  For now this flag implies rex.w.
@@ -3391,13 +3395,13 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
          * part of the opcode). Xref PR 271878. */
         if (TESTANY(PREFIX_REX_ALL, di.prefixes)) {
             byte rexval = REX_PREFIX_BASE_OPCODE;
-            if (TEST(PREFIX_REX_W, di.prefixes))
+            if (TESTANY(PREFIX_REX_W, di.prefixes))
                 rexval |= REX_PREFIX_W_OPFLAG;
-            if (TEST(PREFIX_REX_R, di.prefixes))
+            if (TESTANY(PREFIX_REX_R, di.prefixes))
                 rexval |= REX_PREFIX_R_OPFLAG;
-            if (TEST(PREFIX_REX_X, di.prefixes))
+            if (TESTANY(PREFIX_REX_X, di.prefixes))
                 rexval |= REX_PREFIX_X_OPFLAG;
-            if (TEST(PREFIX_REX_B, di.prefixes))
+            if (TESTANY(PREFIX_REX_B, di.prefixes))
                 rexval |= REX_PREFIX_B_OPFLAG;
             *field_ptr = rexval;
             field_ptr++;
@@ -3406,7 +3410,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
 
     if (!output_initial_opcode) {
         /* output the opcode byte(s) (opcode required prefixes are handled above) */
-        if (TEST(OPCODE_THREEBYTES, info->opcode)) {
+        if (TESTANY(OPCODE_THREEBYTES, info->opcode)) {
             /* implied initial opcode byte */
             *field_ptr = 0x0f;
             field_ptr++;
@@ -3417,14 +3421,14 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
     }
 
     /* second opcode byte, if there is one */
-    if (TEST(REQUIRES_EVEX, info->flags) || TEST(OPCODE_TWOBYTES, info->opcode) ||
-        TEST(OPCODE_THREEBYTES, info->opcode)) {
+    if (TESTANY(REQUIRES_EVEX, info->flags) || TESTANY(OPCODE_TWOBYTES, info->opcode) ||
+        TESTANY(OPCODE_THREEBYTES, info->opcode)) {
         *field_ptr = (byte)((info->opcode & 0x0000ff00) >> 8);
         field_ptr++;
     }
 
     /* /n: part of opcode is in reg of modrm byte */
-    if (TEST(OPCODE_REG, info->opcode)) {
+    if (TESTANY(OPCODE_REG, info->opcode)) {
         CLIENT_ASSERT(di.reg == 8,
                       "instr_encode error: /n opcode inconsistency"); /* unset */
         di.reg = (byte)(info->opcode & 0x00000007);
@@ -3438,7 +3442,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
     }
     /* opcode depends on entire modrm byte */
     if (!TESTANY(REQUIRES_VEX | REQUIRES_EVEX, info->flags) &&
-        TEST(OPCODE_MODRM, info->opcode)) {
+        TESTANY(OPCODE_MODRM, info->opcode)) {
         /* modrm is encoded in prefix byte */
         *field_ptr = (byte)(info->opcode >> 24);
         field_ptr++;
@@ -3466,7 +3470,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
             if (di.mod == 1) {
                 *field_ptr = (byte)di.disp;
                 field_ptr++;
-            } else if (!X64_MODE(&di) && TEST(PREFIX_ADDR, di.prefixes)) {
+            } else if (!X64_MODE(&di) && TESTANY(PREFIX_ADDR, di.prefixes)) {
                 CLIENT_ASSERT_TRUNCATE(*((short *)field_ptr), ushort, di.disp,
                                        "encode error: modrm disp too large for 16-bit");
                 *((short *)field_ptr) = (ushort)di.disp;
@@ -3497,7 +3501,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
 
     /* suffix opcode */
     if (!TESTANY(REQUIRES_VEX | REQUIRES_EVEX, info->flags) &&
-        TEST(OPCODE_SUFFIX, info->opcode)) {
+        TESTANY(OPCODE_SUFFIX, info->opcode)) {
         /* none of these have immeds, currently (and presumably never will have) */
         ASSERT_CURIOSITY(di.size_immed == OPSZ_NA && di.size_immed2 == OPSZ_NA);
         /* modrm is encoded in prefix byte */
@@ -3509,7 +3513,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
         if (check_reachable &&
             !CHECK_TRUNCATE_TYPE_int(di.disp_abs - (field_ptr - copy_pc + final_pc)) &&
             /* PR 253327: we auto-add addr prefix for out-of-reach low tgt */
-            (!TEST(PREFIX_ADDR, di.prefixes) || (ptr_uint_t)di.disp_abs > INT_MAX)) {
+            (!TESTANY(PREFIX_ADDR, di.prefixes) || (ptr_uint_t)di.disp_abs > INT_MAX)) {
             CLIENT_ASSERT(!assert_reachable,
                           "encode error: rip-relative reference out of 32-bit reach");
             return NULL;

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -116,8 +116,8 @@ instr_length_arch(dcontext_t *dcontext, instr_t *instr)
     case OP_jnz:
         /* XXX i#1315: we should support 2-byte immeds => length 4+ */
         return 6 +
-            ((TEST(PREFIX_JCC_TAKEN, instr_get_prefixes(instr)) ||
-              TEST(PREFIX_JCC_NOT_TAKEN, instr_get_prefixes(instr)))
+            ((TESTANY(PREFIX_JCC_TAKEN, instr_get_prefixes(instr)) ||
+              TESTANY(PREFIX_JCC_NOT_TAKEN, instr_get_prefixes(instr)))
                  ? 1
                  : 0);
     case OP_jb_short:
@@ -137,8 +137,8 @@ instr_length_arch(dcontext_t *dcontext, instr_t *instr)
     case OP_jz_short:
     case OP_jnz_short:
         return 2 +
-            ((TEST(PREFIX_JCC_TAKEN, instr_get_prefixes(instr)) ||
-              TEST(PREFIX_JCC_NOT_TAKEN, instr_get_prefixes(instr)))
+            ((TESTANY(PREFIX_JCC_TAKEN, instr_get_prefixes(instr)) ||
+              TESTANY(PREFIX_JCC_NOT_TAKEN, instr_get_prefixes(instr)))
                  ? 1
                  : 0);
         /* alternative names (e.g., OP_jae_short) are equivalent,
@@ -199,7 +199,7 @@ instr_compute_VSIB_index(bool *selected DR_PARAM_OUT, app_pc *result DR_PARAM_OU
 {
     CLIENT_ASSERT(selected != NULL && result != NULL && mc != NULL,
                   "vsib address computation: invalid args");
-    CLIENT_ASSERT(TEST(DR_MC_MULTIMEDIA, mc_flags),
+    CLIENT_ASSERT(TESTANY(DR_MC_MULTIMEDIA, mc_flags),
                   "dr_mcontext_t.flags must include DR_MC_MULTIMEDIA");
     opnd_t src0 = instr_get_src(instr, 0);
     /* We detect whether the instruction is EVEX by looking at its potential mask operand.
@@ -938,7 +938,7 @@ bool
 instr_is_floating_type(instr_t *instr, dr_instr_category_t *type DR_PARAM_OUT)
 {
     uint cat = instr_get_category(instr);
-    if (!TEST(DR_INSTR_CATEGORY_FP, cat))
+    if (!TESTANY(DR_INSTR_CATEGORY_FP, cat))
         return false;
     if (type != NULL)
         *type = cat;
@@ -950,21 +950,21 @@ instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type DR_PARAM_OUT)
 {
     uint cat = instr_get_category(instr);
 
-    if (!TEST(DR_INSTR_CATEGORY_FP, cat))
+    if (!TESTANY(DR_INSTR_CATEGORY_FP, cat))
         return false;
-    else if (TEST(DR_INSTR_CATEGORY_MATH, cat)) {
+    else if (TESTANY(DR_INSTR_CATEGORY_MATH, cat)) {
         if (type != NULL)
             *type = DR_FP_MATH;
         return true;
-    } else if (TEST(DR_INSTR_CATEGORY_CONVERT, cat)) {
+    } else if (TESTANY(DR_INSTR_CATEGORY_CONVERT, cat)) {
         if (type != NULL)
             *type = DR_FP_CONVERT;
         return true;
-    } else if (TEST(DR_INSTR_CATEGORY_STATE, cat)) {
+    } else if (TESTANY(DR_INSTR_CATEGORY_STATE, cat)) {
         if (type != NULL)
             *type = DR_FP_STATE;
         return true;
-    } else if (TEST(DR_INSTR_CATEGORY_MOVE, cat)) {
+    } else if (TESTANY(DR_INSTR_CATEGORY_MOVE, cat)) {
         if (type != NULL)
             *type = DR_FP_MOVE;
         return true;
@@ -1506,10 +1506,10 @@ instr_invert_cbr(instr_t *instr)
         }
         instr_set_opcode(instr, opc);
         /* reverse any branch hint */
-        if (TEST(PREFIX_JCC_TAKEN, instr_get_prefixes(instr))) {
+        if (TESTANY(PREFIX_JCC_TAKEN, instr_get_prefixes(instr))) {
             instr->prefixes &= ~PREFIX_JCC_TAKEN;
             instr->prefixes |= PREFIX_JCC_NOT_TAKEN;
-        } else if (TEST(PREFIX_JCC_NOT_TAKEN, instr_get_prefixes(instr))) {
+        } else if (TESTANY(PREFIX_JCC_NOT_TAKEN, instr_get_prefixes(instr))) {
             instr->prefixes &= ~PREFIX_JCC_NOT_TAKEN;
             instr->prefixes |= PREFIX_JCC_TAKEN;
         }
@@ -1529,10 +1529,10 @@ instr_cbr_taken(instr_t *instr, priv_mcontext_t *mcontext, bool pre)
         switch (opc) {
         case OP_loop: return (mcontext->xcx != (pre ? 1U : 0U));
         case OP_loope:
-            return (TEST(EFLAGS_ZF, mcontext->xflags) &&
+            return (TESTANY(EFLAGS_ZF, mcontext->xflags) &&
                     mcontext->xcx != (pre ? 1U : 0U));
         case OP_loopne:
-            return (!TEST(EFLAGS_ZF, mcontext->xflags) &&
+            return (!TESTANY(EFLAGS_ZF, mcontext->xflags) &&
                     mcontext->xcx != (pre ? 1U : 0U));
         case OP_jecxz: return (mcontext->xcx == 0U);
         default: CLIENT_ASSERT(false, "instr_cbr_taken: unknown opcode"); return false;
@@ -1547,41 +1547,41 @@ opc_jcc_taken(int opc, reg_t eflags)
 {
     switch (opc) {
     case OP_jo:
-    case OP_jo_short: return TEST(EFLAGS_OF, eflags);
+    case OP_jo_short: return TESTANY(EFLAGS_OF, eflags);
     case OP_jno:
-    case OP_jno_short: return !TEST(EFLAGS_OF, eflags);
+    case OP_jno_short: return !TESTANY(EFLAGS_OF, eflags);
     case OP_jb:
-    case OP_jb_short: return TEST(EFLAGS_CF, eflags);
+    case OP_jb_short: return TESTANY(EFLAGS_CF, eflags);
     case OP_jnb:
-    case OP_jnb_short: return !TEST(EFLAGS_CF, eflags);
+    case OP_jnb_short: return !TESTANY(EFLAGS_CF, eflags);
     case OP_jz:
-    case OP_jz_short: return TEST(EFLAGS_ZF, eflags);
+    case OP_jz_short: return TESTANY(EFLAGS_ZF, eflags);
     case OP_jnz:
-    case OP_jnz_short: return !TEST(EFLAGS_ZF, eflags);
+    case OP_jnz_short: return !TESTANY(EFLAGS_ZF, eflags);
     case OP_jbe:
     case OP_jbe_short: return TESTANY(EFLAGS_CF | EFLAGS_ZF, eflags);
     case OP_jnbe:
     case OP_jnbe_short: return !TESTANY(EFLAGS_CF | EFLAGS_ZF, eflags);
     case OP_js:
-    case OP_js_short: return TEST(EFLAGS_SF, eflags);
+    case OP_js_short: return TESTANY(EFLAGS_SF, eflags);
     case OP_jns:
-    case OP_jns_short: return !TEST(EFLAGS_SF, eflags);
+    case OP_jns_short: return !TESTANY(EFLAGS_SF, eflags);
     case OP_jp:
-    case OP_jp_short: return TEST(EFLAGS_PF, eflags);
+    case OP_jp_short: return TESTANY(EFLAGS_PF, eflags);
     case OP_jnp:
-    case OP_jnp_short: return !TEST(EFLAGS_PF, eflags);
+    case OP_jnp_short: return !TESTANY(EFLAGS_PF, eflags);
     case OP_jl:
-    case OP_jl_short: return (TEST(EFLAGS_SF, eflags) != TEST(EFLAGS_OF, eflags));
+    case OP_jl_short: return (TESTANY(EFLAGS_SF, eflags) != TESTANY(EFLAGS_OF, eflags));
     case OP_jnl:
-    case OP_jnl_short: return (TEST(EFLAGS_SF, eflags) == TEST(EFLAGS_OF, eflags));
+    case OP_jnl_short: return (TESTANY(EFLAGS_SF, eflags) == TESTANY(EFLAGS_OF, eflags));
     case OP_jle:
     case OP_jle_short:
-        return (TEST(EFLAGS_ZF, eflags) ||
-                TEST(EFLAGS_SF, eflags) != TEST(EFLAGS_OF, eflags));
+        return (TESTANY(EFLAGS_ZF, eflags) ||
+                TESTANY(EFLAGS_SF, eflags) != TESTANY(EFLAGS_OF, eflags));
     case OP_jnle:
     case OP_jnle_short:
-        return (!TEST(EFLAGS_ZF, eflags) &&
-                TEST(EFLAGS_SF, eflags) == TEST(EFLAGS_OF, eflags));
+        return (!TESTANY(EFLAGS_ZF, eflags) &&
+                TESTANY(EFLAGS_SF, eflags) == TESTANY(EFLAGS_OF, eflags));
     default: CLIENT_ASSERT(false, "instr_jcc_taken: unknown opcode"); return false;
     }
 }

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -112,8 +112,6 @@
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 /* check if any bit in mask is set in var */
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
-/* check if a single bit is set in var */
-#define TEST TESTANY
 
 #define BOOLS_MATCH(a, b) (!!(a) == !!(b))
 

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1867,7 +1867,7 @@ instrument_fragment_deleted(dcontext_t *dcontext, app_pc tag, uint flags)
      * are jumps to the interception buffer, so we'll hide them here
      * as well.
      */
-    if (!TEST(FRAG_IS_TRACE, flags) && hide_tag_from_client(tag))
+    if (!TESTANY(FRAG_IS_TRACE, flags) && hide_tag_from_client(tag))
         return;
 #endif
 
@@ -1981,7 +1981,7 @@ instrument_module_load_trigger(app_pc pc)
         module_data_t *client_data = NULL;
         os_get_module_info_lock();
         ma = module_pc_lookup(pc);
-        if (ma != NULL && !TEST(MODULE_LOAD_EVENT, ma->flags)) {
+        if (ma != NULL && !TESTANY(MODULE_LOAD_EVENT, ma->flags)) {
             /* switch to write lock */
             os_get_module_info_unlock();
 #ifdef LINUX
@@ -1999,7 +1999,7 @@ instrument_module_load_trigger(app_pc pc)
 #endif
             os_get_module_info_write_lock();
             ma = module_pc_lookup(pc);
-            if (ma != NULL && !TEST(MODULE_LOAD_EVENT, ma->flags)) {
+            if (ma != NULL && !TESTANY(MODULE_LOAD_EVENT, ma->flags)) {
                 ma->flags |= MODULE_LOAD_EVENT;
                 client_data = copy_module_area_to_module_data(ma);
                 os_get_module_info_write_unlock();
@@ -2244,7 +2244,7 @@ instrument_security_violation(dcontext_t *dcontext, app_pc target_pc,
      * should be okay since we already have the overhead of calling
      * into the client. */
     last = dcontext->last_fragment;
-    if (!TEST(FRAG_FAKE, last->flags)) {
+    if (!TESTANY(FRAG_FAKE, last->flags)) {
         cache_pc pc = EXIT_CTI_PC(last, dcontext->last_exit);
         source_pc = recreate_app_pc(dcontext, pc, last);
     }
@@ -2472,7 +2472,7 @@ DR_API
 void
 dr_abort(void)
 {
-    if (TEST(DUMPCORE_DR_ABORT, dynamo_options.dumpcore_mask))
+    if (TESTANY(DUMPCORE_DR_ABORT, dynamo_options.dumpcore_mask))
         os_dump_core("dr_abort");
     os_terminate(NULL, TERMINATE_PROCESS);
 }
@@ -2481,7 +2481,7 @@ DR_API
 void
 dr_abort_with_code(int exit_code)
 {
-    if (TEST(DUMPCORE_DR_ABORT, dynamo_options.dumpcore_mask))
+    if (TESTANY(DUMPCORE_DR_ABORT, dynamo_options.dumpcore_mask))
         os_dump_core("dr_abort");
     os_terminate_with_code(NULL, TERMINATE_PROCESS, exit_code);
 }
@@ -2528,12 +2528,12 @@ dr_create_memory_dump(dr_memory_dump_spec_t *spec)
     if (spec->size != sizeof(dr_memory_dump_spec_t))
         return false;
 #ifdef WINDOWS
-    if (TEST(DR_MEMORY_DUMP_LDMP, spec->flags))
+    if (TESTANY(DR_MEMORY_DUMP_LDMP, spec->flags))
         return os_dump_core_live(spec->label, spec->ldmp_path, spec->ldmp_path_size);
 /* XXX i#2154: Add Android AArch64 support. */
 #elif defined(LINUX) && \
     ((defined(X64) && defined(X86)) || (defined(AARCH64) && !defined(ANDROID64)))
-    if (TEST(DR_MEMORY_DUMP_ELF, spec->flags)) {
+    if (TESTANY(DR_MEMORY_DUMP_ELF, spec->flags)) {
         return os_dump_core_live(get_thread_private_dcontext(),
                                  spec->elf_output_directory, spec->elf_path,
                                  spec->elf_path_size);
@@ -2569,18 +2569,19 @@ DR_API
 void
 dr_set_process_exit_behavior(dr_exit_flags_t flags)
 {
-    if ((!DYNAMO_OPTION(multi_thread_exit) && TEST(DR_EXIT_MULTI_THREAD, flags)) ||
-        (DYNAMO_OPTION(multi_thread_exit) && !TEST(DR_EXIT_MULTI_THREAD, flags))) {
+    if ((!DYNAMO_OPTION(multi_thread_exit) && TESTANY(DR_EXIT_MULTI_THREAD, flags)) ||
+        (DYNAMO_OPTION(multi_thread_exit) && !TESTANY(DR_EXIT_MULTI_THREAD, flags))) {
         options_make_writable();
-        dynamo_options.multi_thread_exit = TEST(DR_EXIT_MULTI_THREAD, flags);
+        dynamo_options.multi_thread_exit = TESTANY(DR_EXIT_MULTI_THREAD, flags);
         options_restore_readonly();
     }
     if ((!DYNAMO_OPTION(skip_thread_exit_at_exit) &&
-         TEST(DR_EXIT_SKIP_THREAD_EXIT, flags)) ||
+         TESTANY(DR_EXIT_SKIP_THREAD_EXIT, flags)) ||
         (DYNAMO_OPTION(skip_thread_exit_at_exit) &&
-         !TEST(DR_EXIT_SKIP_THREAD_EXIT, flags))) {
+         !TESTANY(DR_EXIT_SKIP_THREAD_EXIT, flags))) {
         options_make_writable();
-        dynamo_options.skip_thread_exit_at_exit = TEST(DR_EXIT_SKIP_THREAD_EXIT, flags);
+        dynamo_options.skip_thread_exit_at_exit =
+            TESTANY(DR_EXIT_SKIP_THREAD_EXIT, flags);
         options_restore_readonly();
     }
 }
@@ -3013,19 +3014,19 @@ raw_mem_alloc(size_t size, uint prot, void *addr, dr_alloc_flags_t flags)
     heap_error_code_t error_code;
 
     CLIENT_ASSERT(ALIGNED(addr, PAGE_SIZE), "addr is not page size aligned");
-    if (!TEST(DR_ALLOC_NON_DR, flags)) {
+    if (!TESTANY(DR_ALLOC_NON_DR, flags)) {
         /* memory alloc/dealloc and updating DR list must be atomic */
         dynamo_vm_areas_lock(); /* if already hold lock this is a nop */
     }
     addr = (void *)ALIGN_BACKWARD(addr, PAGE_SIZE);
     size = ALIGN_FORWARD(size, PAGE_SIZE);
 #ifdef WINDOWS
-    if (TEST(DR_ALLOC_LOW_2GB, flags)) {
-        CLIENT_ASSERT(!TEST(DR_ALLOC_COMMIT_ONLY, flags),
+    if (TESTANY(DR_ALLOC_LOW_2GB, flags)) {
+        CLIENT_ASSERT(!TESTANY(DR_ALLOC_COMMIT_ONLY, flags),
                       "cannot combine commit-only and low-2GB");
         p = os_heap_reserve_in_region(NULL, (byte *)(ptr_uint_t)0x80000000, size,
-                                      &error_code, TEST(DR_MEMPROT_EXEC, flags));
-        if (p != NULL && !TEST(DR_ALLOC_RESERVE_ONLY, flags)) {
+                                      &error_code, TESTANY(DR_MEMPROT_EXEC, flags));
+        if (p != NULL && !TESTANY(DR_ALLOC_RESERVE_ONLY, flags)) {
             if (!os_heap_commit(p, size, prot, &error_code)) {
                 os_heap_free(p, size, &error_code);
                 p = NULL;
@@ -3038,13 +3039,13 @@ raw_mem_alloc(size_t size, uint prot, void *addr, dr_alloc_flags_t flags)
          * ok that the Linux kernel will ignore MAP_32BIT for 32-bit.
          */
 #ifdef UNIX
-        uint os_flags = TEST(DR_ALLOC_LOW_2GB, flags) ? RAW_ALLOC_32BIT : 0;
+        uint os_flags = TESTANY(DR_ALLOC_LOW_2GB, flags) ? RAW_ALLOC_32BIT : 0;
 #else
-        uint os_flags = TEST(DR_ALLOC_RESERVE_ONLY, flags)
+        uint os_flags = TESTANY(DR_ALLOC_RESERVE_ONLY, flags)
             ? RAW_ALLOC_RESERVE_ONLY
-            : (TEST(DR_ALLOC_COMMIT_ONLY, flags) ? RAW_ALLOC_COMMIT_ONLY : 0);
+            : (TESTANY(DR_ALLOC_COMMIT_ONLY, flags) ? RAW_ALLOC_COMMIT_ONLY : 0);
 #endif
-        if (IF_WINDOWS(TEST(DR_ALLOC_COMMIT_ONLY, flags) &&) addr != NULL &&
+        if (IF_WINDOWS(TESTANY(DR_ALLOC_COMMIT_ONLY, flags) &&) addr != NULL &&
             !app_memory_pre_alloc(get_thread_private_dcontext(), addr, size, prot, false,
                                   true /*update*/, false /*!image*/)) {
             p = NULL;
@@ -3054,7 +3055,7 @@ raw_mem_alloc(size_t size, uint prot, void *addr, dr_alloc_flags_t flags)
     }
 
     if (p != NULL) {
-        if (TEST(DR_ALLOC_NON_DR, flags)) {
+        if (TESTANY(DR_ALLOC_NON_DR, flags)) {
             all_memory_areas_lock();
             update_all_memory_areas(p, p + size, prot, DR_MEMTYPE_DATA);
             all_memory_areas_unlock();
@@ -3065,7 +3066,7 @@ raw_mem_alloc(size_t size, uint prot, void *addr, dr_alloc_flags_t flags)
         }
         RSTATS_ADD_PEAK(client_raw_mmap_size, size);
     }
-    if (!TEST(DR_ALLOC_NON_DR, flags))
+    if (!TESTANY(DR_ALLOC_NON_DR, flags))
         dynamo_vm_areas_unlock();
     return p;
 }
@@ -3077,14 +3078,14 @@ raw_mem_free(void *addr, size_t size, dr_alloc_flags_t flags)
     heap_error_code_t error_code;
     byte *p = addr;
 #ifdef UNIX
-    uint os_flags = TEST(DR_ALLOC_LOW_2GB, flags) ? RAW_ALLOC_32BIT : 0;
+    uint os_flags = TESTANY(DR_ALLOC_LOW_2GB, flags) ? RAW_ALLOC_32BIT : 0;
 #else
-    uint os_flags = TEST(DR_ALLOC_RESERVE_ONLY, flags)
+    uint os_flags = TESTANY(DR_ALLOC_RESERVE_ONLY, flags)
         ? RAW_ALLOC_RESERVE_ONLY
-        : (TEST(DR_ALLOC_COMMIT_ONLY, flags) ? RAW_ALLOC_COMMIT_ONLY : 0);
+        : (TESTANY(DR_ALLOC_COMMIT_ONLY, flags) ? RAW_ALLOC_COMMIT_ONLY : 0);
 #endif
     size = ALIGN_FORWARD(size, PAGE_SIZE);
-    if (TEST(DR_ALLOC_NON_DR, flags)) {
+    if (TESTANY(DR_ALLOC_NON_DR, flags)) {
         /* use lock to avoid racy update on parallel memory allocation,
          * e.g. allocation from another thread at p happens after os_heap_free
          * but before remove_from_all_memory_areas
@@ -3095,14 +3096,14 @@ raw_mem_free(void *addr, size_t size, dr_alloc_flags_t flags)
         dynamo_vm_areas_lock(); /* if already hold lock this is a nop */
     }
     res = os_raw_mem_free(p, size, os_flags, &error_code);
-    if (TEST(DR_ALLOC_NON_DR, flags)) {
+    if (TESTANY(DR_ALLOC_NON_DR, flags)) {
         remove_from_all_memory_areas(p, p + size);
         all_memory_areas_unlock();
     } else {
         /* this routine updates allmem for us: */
         remove_dynamo_vm_area((app_pc)addr, ((app_pc)addr) + size);
     }
-    if (!TEST(DR_ALLOC_NON_DR, flags))
+    if (!TESTANY(DR_ALLOC_NON_DR, flags))
         dynamo_vm_areas_unlock();
     if (res)
         RSTATS_SUB(client_raw_mmap_size, size);
@@ -3132,34 +3133,34 @@ custom_memory_shared(bool alloc, void *drcontext, dr_alloc_flags_t flags, size_t
     CLIENT_ASSERT(alloc || addr != NULL, "cannot free NULL");
     CLIENT_ASSERT(!TESTALL(DR_ALLOC_NON_DR | DR_ALLOC_CACHE_REACHABLE, flags),
                   "dr_custom_alloc: cannot combine non-DR and cache-reachable");
-    CLIENT_ASSERT(!alloc || TEST(DR_ALLOC_FIXED_LOCATION, flags) || addr == NULL,
+    CLIENT_ASSERT(!alloc || TESTANY(DR_ALLOC_FIXED_LOCATION, flags) || addr == NULL,
                   "dr_custom_alloc: address only honored for fixed location");
 #ifdef WINDOWS
     CLIENT_ASSERT(!TESTANY(DR_ALLOC_RESERVE_ONLY | DR_ALLOC_COMMIT_ONLY, flags) ||
                       TESTALL(DR_ALLOC_NON_HEAP | DR_ALLOC_NON_DR, flags),
                   "dr_custom_alloc: reserve/commit-only are only for non-DR non-heap");
-    CLIENT_ASSERT(!TEST(DR_ALLOC_RESERVE_ONLY, flags) ||
-                      !TEST(DR_ALLOC_COMMIT_ONLY, flags),
+    CLIENT_ASSERT(!TESTANY(DR_ALLOC_RESERVE_ONLY, flags) ||
+                      !TESTANY(DR_ALLOC_COMMIT_ONLY, flags),
                   "dr_custom_alloc: cannot combine reserve-only + commit-only");
 #endif
-    CLIENT_ASSERT(!TEST(DR_ALLOC_CACHE_REACHABLE, flags) ||
+    CLIENT_ASSERT(!TESTANY(DR_ALLOC_CACHE_REACHABLE, flags) ||
                       !DYNAMO_OPTION(satisfy_w_xor_x),
                   "dr_custom_alloc: DR_ALLOC_CACHE_REACHABLE memory is not "
                   "supported with -satisfy_w_xor_x");
-    if (TEST(DR_ALLOC_NON_HEAP, flags)) {
+    if (TESTANY(DR_ALLOC_NON_HEAP, flags)) {
         CLIENT_ASSERT(drcontext == NULL,
                       "dr_custom_alloc: drcontext must be NULL for non-heap");
-        CLIENT_ASSERT(!TEST(DR_ALLOC_THREAD_PRIVATE, flags),
+        CLIENT_ASSERT(!TESTANY(DR_ALLOC_THREAD_PRIVATE, flags),
                       "dr_custom_alloc: non-heap cannot be thread-private");
         CLIENT_ASSERT(!TESTALL(DR_ALLOC_CACHE_REACHABLE | DR_ALLOC_LOW_2GB, flags),
                       "dr_custom_alloc: cannot combine low-2GB and cache-reachable");
 #ifdef WINDOWS
-        CLIENT_ASSERT(addr != NULL || !TEST(DR_ALLOC_COMMIT_ONLY, flags),
+        CLIENT_ASSERT(addr != NULL || !TESTANY(DR_ALLOC_COMMIT_ONLY, flags),
                       "dr_custom_alloc: commit-only requires non-NULL addr");
 #endif
-        if (TEST(DR_ALLOC_LOW_2GB, flags)) {
+        if (TESTANY(DR_ALLOC_LOW_2GB, flags)) {
 #ifdef WINDOWS
-            CLIENT_ASSERT(!TEST(DR_ALLOC_COMMIT_ONLY, flags),
+            CLIENT_ASSERT(!TESTANY(DR_ALLOC_COMMIT_ONLY, flags),
                           "dr_custom_alloc: cannot combine commit-only and low-2GB");
 #endif
             CLIENT_ASSERT(!alloc || addr == NULL,
@@ -3169,20 +3170,20 @@ custom_memory_shared(bool alloc, void *drcontext, dr_alloc_flags_t flags, size_t
                 return raw_mem_alloc(size, prot, addr, flags);
             else
                 *free_res = raw_mem_free(addr, size, flags);
-        } else if (TEST(DR_ALLOC_NON_DR, flags)) {
+        } else if (TESTANY(DR_ALLOC_NON_DR, flags)) {
             /* ok for addr to be NULL */
             if (alloc)
                 return raw_mem_alloc(size, prot, addr, flags);
             else
                 *free_res = raw_mem_free(addr, size, flags);
         } else { /* including DR_ALLOC_CACHE_REACHABLE */
-            CLIENT_ASSERT(!alloc || !TEST(DR_ALLOC_CACHE_REACHABLE, flags) ||
+            CLIENT_ASSERT(!alloc || !TESTANY(DR_ALLOC_CACHE_REACHABLE, flags) ||
                               addr == NULL,
                           "dr_custom_alloc: cannot ask for addr and cache-reachable");
             /* This flag is here solely so we know which version of free to call */
-            if (TEST(DR_ALLOC_FIXED_LOCATION, flags) ||
-                !TEST(DR_ALLOC_CACHE_REACHABLE, flags)) {
-                CLIENT_ASSERT(addr != NULL || !TEST(DR_ALLOC_FIXED_LOCATION, flags),
+            if (TESTANY(DR_ALLOC_FIXED_LOCATION, flags) ||
+                !TESTANY(DR_ALLOC_CACHE_REACHABLE, flags)) {
+                CLIENT_ASSERT(addr != NULL || !TESTANY(DR_ALLOC_FIXED_LOCATION, flags),
                               "dr_custom_alloc: fixed location requires an address");
                 if (alloc)
                     return raw_mem_alloc(size, prot, addr, 0);
@@ -3202,14 +3203,14 @@ custom_memory_shared(bool alloc, void *drcontext, dr_alloc_flags_t flags, size_t
             *free_res = true;
         CLIENT_ASSERT(!alloc || addr == NULL,
                       "dr_custom_alloc: cannot pass an addr for heap memory");
-        CLIENT_ASSERT(drcontext == NULL || TEST(DR_ALLOC_THREAD_PRIVATE, flags),
+        CLIENT_ASSERT(drcontext == NULL || TESTANY(DR_ALLOC_THREAD_PRIVATE, flags),
                       "dr_custom_alloc: drcontext must be NULL for global heap");
-        CLIENT_ASSERT(!TEST(DR_ALLOC_LOW_2GB, flags),
+        CLIENT_ASSERT(!TESTANY(DR_ALLOC_LOW_2GB, flags),
                       "dr_custom_alloc: cannot ask for heap in low 2GB");
-        CLIENT_ASSERT(!TEST(DR_ALLOC_NON_DR, flags),
+        CLIENT_ASSERT(!TESTANY(DR_ALLOC_NON_DR, flags),
                       "dr_custom_alloc: cannot ask for non-DR heap memory");
-        if (TEST(DR_ALLOC_CACHE_REACHABLE, flags)) {
-            if (TEST(DR_ALLOC_THREAD_PRIVATE, flags)) {
+        if (TESTANY(DR_ALLOC_CACHE_REACHABLE, flags)) {
+            if (TESTANY(DR_ALLOC_THREAD_PRIVATE, flags)) {
                 if (alloc)
                     return dr_thread_alloc(drcontext, size);
                 else
@@ -3221,7 +3222,7 @@ custom_memory_shared(bool alloc, void *drcontext, dr_alloc_flags_t flags, size_t
                     dr_global_free(addr, size);
             }
         } else {
-            if (TEST(DR_ALLOC_THREAD_PRIVATE, flags)) {
+            if (TESTANY(DR_ALLOC_THREAD_PRIVATE, flags)) {
                 if (alloc)
                     return heap_alloc(dcontext, size HEAPACCT(ACCT_CLIENT));
                 else
@@ -3992,7 +3993,7 @@ dr_map_executable_file(const char *filename, dr_map_executable_flags_t flags,
     return NULL;
 #else
     modload_flags_t mflags = MODLOAD_NOT_PRIVLIB;
-    if (TEST(DR_MAPEXE_SKIP_WRITABLE, flags))
+    if (TESTANY(DR_MAPEXE_SKIP_WRITABLE, flags))
         mflags |= MODLOAD_SKIP_WRITABLE;
     if (filename == NULL)
         return NULL;
@@ -4058,29 +4059,29 @@ dr_open_file(const char *fname, uint mode_flags)
 {
     uint flags = 0;
 
-    if (TEST(DR_FILE_WRITE_REQUIRE_NEW, mode_flags)) {
+    if (TESTANY(DR_FILE_WRITE_REQUIRE_NEW, mode_flags)) {
         flags |= OS_OPEN_WRITE | OS_OPEN_REQUIRE_NEW;
     }
-    if (TEST(DR_FILE_WRITE_APPEND, mode_flags)) {
+    if (TESTANY(DR_FILE_WRITE_APPEND, mode_flags)) {
         CLIENT_ASSERT((flags == 0), "dr_open_file: multiple write modes selected");
         flags |= OS_OPEN_WRITE | OS_OPEN_APPEND;
     }
-    if (TEST(DR_FILE_WRITE_OVERWRITE, mode_flags)) {
+    if (TESTANY(DR_FILE_WRITE_OVERWRITE, mode_flags)) {
         CLIENT_ASSERT((flags == 0), "dr_open_file: multiple write modes selected");
         flags |= OS_OPEN_WRITE;
     }
-    if (TEST(DR_FILE_WRITE_ONLY, mode_flags)) {
+    if (TESTANY(DR_FILE_WRITE_ONLY, mode_flags)) {
         CLIENT_ASSERT((flags == 0), "dr_open_file: multiple write modes selected");
         flags |= OS_OPEN_WRITE_ONLY;
     }
-    if (TEST(DR_FILE_READ, mode_flags))
+    if (TESTANY(DR_FILE_READ, mode_flags))
         flags |= OS_OPEN_READ;
     CLIENT_ASSERT((flags != 0), "dr_open_file: no mode selected");
 
-    if (TEST(DR_FILE_ALLOW_LARGE, mode_flags))
+    if (TESTANY(DR_FILE_ALLOW_LARGE, mode_flags))
         flags |= OS_OPEN_ALLOW_LARGE;
 
-    if (TEST(DR_FILE_CLOSE_ON_FORK, mode_flags))
+    if (TESTANY(DR_FILE_CLOSE_ON_FORK, mode_flags))
         flags |= OS_OPEN_CLOSE_ON_FORK;
 
     /* all client-opened files are protected */
@@ -4202,10 +4203,10 @@ dr_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc addr, uin
 {
     return (void *)d_r_map_file(
         f, size, offs, addr, prot,
-        (TEST(DR_MAP_PRIVATE, flags) ? MAP_FILE_COPY_ON_WRITE : 0) |
-            IF_WINDOWS((TEST(DR_MAP_IMAGE, flags) ? MAP_FILE_IMAGE : 0) |)
-                IF_UNIX((TEST(DR_MAP_FIXED, flags) ? MAP_FILE_FIXED : 0) |)(
-                    TEST(DR_MAP_CACHE_REACHABLE, flags) ? MAP_FILE_REACHABLE : 0));
+        (TESTANY(DR_MAP_PRIVATE, flags) ? MAP_FILE_COPY_ON_WRITE : 0) |
+            IF_WINDOWS((TESTANY(DR_MAP_IMAGE, flags) ? MAP_FILE_IMAGE : 0) |)
+                IF_UNIX((TESTANY(DR_MAP_FIXED, flags) ? MAP_FILE_FIXED : 0) |)(
+                    TESTANY(DR_MAP_CACHE_REACHABLE, flags) ? MAP_FILE_REACHABLE : 0));
 }
 
 DR_API
@@ -4884,7 +4885,7 @@ dr_suspend_all_other_threads_ex(DR_PARAM_OUT void ***drcontexts,
                 if (!thread_synch_successful(threads[i])) {
                     out_unsuspended++;
                 } else if (is_thread_currently_native(threads[i]) &&
-                           !TEST(DR_SUSPEND_NATIVE, flags)) {
+                           !TESTANY(DR_SUSPEND_NATIVE, flags)) {
                     out_unsuspended++;
                 } else if (thread_synch_state_no_xfer(dcontext)) {
                     /* XXX: for all other synchall callers, the app
@@ -5253,7 +5254,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
     uint dstack_offs, pad = 0;
     size_t buf_sz = 0;
     clean_call_info_t cci; /* information for clean call insertion. */
-    bool save_fpstate = TEST(DR_CLEANCALL_SAVE_FLOAT, save_flags);
+    bool save_fpstate = TESTANY(DR_CLEANCALL_SAVE_FLOAT, save_flags);
     meta_call_flags_t call_flags = META_CALL_CLEAN | META_CALL_RETURNS;
     byte *encode_pc;
     instr_t *label = INSTR_CREATE_label(drcontext);
@@ -5294,9 +5295,9 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
 #endif
     /* analyze the clean call, return true if clean call can be inlined. */
     if (analyze_clean_call(dcontext, &cci, insert_at, callee, save_fpstate,
-                           TEST(DR_CLEANCALL_ALWAYS_OUT_OF_LINE, save_flags), num_args,
+                           TESTANY(DR_CLEANCALL_ALWAYS_OUT_OF_LINE, save_flags), num_args,
                            args) &&
-        !TEST(DR_CLEANCALL_ALWAYS_OUT_OF_LINE, save_flags)) {
+        !TESTANY(DR_CLEANCALL_ALWAYS_OUT_OF_LINE, save_flags)) {
         /* we can perform the inline optimization and return. */
         STATS_INC(cleancall_inlined);
         LOG(THREAD, LOG_CLEANCALL, 2, "CLEANCALL: inlined callee " PFX "\n", callee);
@@ -5306,7 +5307,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
         return;
     }
     /* honor requests from caller */
-    if (TEST(DR_CLEANCALL_NOSAVE_FLAGS, save_flags)) {
+    if (TESTANY(DR_CLEANCALL_NOSAVE_FLAGS, save_flags)) {
         /* even if we remove flag saves we want to keep mcontext shape */
         cci.preserve_mcontext = true;
         cci.skip_save_flags = true;
@@ -5338,13 +5339,13 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
 #endif
         /* now remove those used for param/retval */
 #ifdef X64
-        if (TEST(DR_CLEANCALL_NOSAVE_XMM_NONPARAM, save_flags)) {
+        if (TESTANY(DR_CLEANCALL_NOSAVE_XMM_NONPARAM, save_flags)) {
             /* xmm0-3 (-7 for linux) are used for params */
             for (i = 0; i < IF_UNIX_ELSE(7, 3); i++)
                 cci.simd_skip[i] = false;
             cci.num_simd_skip -= i;
         }
-        if (TEST(DR_CLEANCALL_NOSAVE_XMM_NONRET, save_flags)) {
+        if (TESTANY(DR_CLEANCALL_NOSAVE_XMM_NONRET, save_flags)) {
             /* xmm0 (and xmm1 for linux) are used for retvals */
             cci.simd_skip[0] = false;
             cci.num_simd_skip--;
@@ -5355,7 +5356,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
         }
 #endif
     }
-    if (TEST(DR_CLEANCALL_INDIRECT, save_flags))
+    if (TESTANY(DR_CLEANCALL_INDIRECT, save_flags))
         encode_pc = vmcode_unreachable_pc();
     else
         encode_pc = vmcode_get_start();
@@ -5389,7 +5390,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
      * flag will disappear and translation will fail.
      */
     instrlist_set_our_mangling(ilist, true);
-    if (TEST(DR_CLEANCALL_RETURNS_TO_NATIVE, save_flags))
+    if (TESTANY(DR_CLEANCALL_RETURNS_TO_NATIVE, save_flags))
         call_flags |= META_CALL_RETURNS_TO_NATIVE;
     insert_meta_call_vargs(dcontext, ilist, insert_at, call_flags, encode_pc, callee,
                            num_args, args);
@@ -5494,7 +5495,7 @@ dr_swap_to_clean_stack(void *drcontext, instrlist_t *ilist, instr_t *where)
         /* DSTACK_OFFSET isn't within the upcontext so if it's separate this won't
          * work right.  XXX - the dcontext accessing routines are a mess of shared
          * vs. no shared support, separate context vs. no separate context support etc. */
-        ASSERT_NOT_IMPLEMENTED(!TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
+        ASSERT_NOT_IMPLEMENTED(!TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask));
         MINSERT(ilist, where,
                 instr_create_restore_from_dc_via_reg(dcontext, SCRATCH_REG0, REG_XSP,
                                                      DSTACK_OFFSET));
@@ -5937,7 +5938,7 @@ dr_merge_arith_flags(reg_t cur_xflags, reg_t saved_xflag)
     uint sahf = (saved_xflag & 0xff00) >> 8;
     cur_xflags &= ~(EFLAGS_ARITH);
     cur_xflags |= sahf;
-    if (TEST(1, saved_xflag)) /* seto */
+    if (TESTANY(1, saved_xflag)) /* seto */
         cur_xflags |= EFLAGS_OF;
 #endif
 
@@ -6641,7 +6642,7 @@ bool
 dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *mc)
 {
     priv_mcontext_t *state;
-    CLIENT_ASSERT(!TEST(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)),
+    CLIENT_ASSERT(!TESTANY(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)),
                   "DR context protection NYI");
     if (mc == NULL) {
         CLIENT_ASSERT(dmc != NULL, "invalid context");
@@ -6729,11 +6730,11 @@ dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *
     /* esp is a dstack value -- get the app stack's esp from the dcontext */
     if (mc != NULL)
         mc->xsp = get_mcontext(dcontext)->xsp;
-    else if (TEST(DR_MC_CONTROL, dmc->flags))
+    else if (TESTANY(DR_MC_CONTROL, dmc->flags))
         dmc->xsp = get_mcontext(dcontext)->xsp;
 
 #if defined(AARCHXX) || defined(RISCV64)
-    if (mc != NULL || TEST(DR_MC_INTEGER, dmc->flags)) {
+    if (mc != NULL || TESTANY(DR_MC_INTEGER, dmc->flags)) {
         /* get the stolen register's app value */
         if (mc != NULL) {
             set_stolen_reg_val(mc,
@@ -6774,7 +6775,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     IF_AARCHXX_OR_RISCV64(reg_t stolen_reg_val = 0 /* silence the compiler warning */;)
     IF_RISCV64(reg_t tp_reg_val = 0;)
-    CLIENT_ASSERT(!TEST(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)),
+    CLIENT_ASSERT(!TESTANY(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)),
                   "DR context protection NYI");
     CLIENT_ASSERT(context != NULL, "invalid context");
     CLIENT_ASSERT(context->flags != 0 && (context->flags & ~(DR_MC_ALL)) == 0,
@@ -6805,7 +6806,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
      */
     state = get_priv_mcontext_from_dstack(dcontext);
 #if defined(AARCHXX) || defined(RISCV64)
-    if (TEST(DR_MC_INTEGER, context->flags)) {
+    if (TESTANY(DR_MC_INTEGER, context->flags)) {
         /* Set the stolen register's app value in TLS, not on stack (we rely
          * on our stolen reg retaining its value on the stack)
          */
@@ -6821,7 +6822,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
     if (!dr_mcontext_to_priv_mcontext(state, context))
         return false;
 #if defined(AARCHXX) || defined(RISCV64)
-    if (TEST(DR_MC_INTEGER, context->flags)) {
+    if (TESTANY(DR_MC_INTEGER, context->flags)) {
         /* restore the reg val on the stack clobbered by the copy above */
         set_stolen_reg_val(state, stolen_reg_val);
 #    ifdef RISCV64
@@ -6830,7 +6831,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
     }
 #endif
 
-    if (TEST(DR_MC_CONTROL, context->flags)) {
+    if (TESTANY(DR_MC_CONTROL, context->flags)) {
         /* esp will be restored from a field in the dcontext */
         get_mcontext(dcontext)->xsp = context->xsp;
     }
@@ -7282,7 +7283,7 @@ dr_bb_exists_at(void *drcontext, void *tag)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     fragment_t *f = fragment_lookup(dcontext, tag);
-    if (f != NULL && !TEST(FRAG_IS_TRACE, f->flags)) {
+    if (f != NULL && !TESTANY(FRAG_IS_TRACE, f->flags)) {
         return true;
     }
 
@@ -7484,11 +7485,11 @@ dr_mark_trace_head(void *drcontext, void *tag)
         }
     } else {
         /* check precluding conditions */
-        if (TEST(FRAG_IS_TRACE, f->flags)) {
+        if (TESTANY(FRAG_IS_TRACE, f->flags)) {
             success = false;
-        } else if (TEST(FRAG_CANNOT_BE_TRACE, f->flags)) {
+        } else if (TESTANY(FRAG_CANNOT_BE_TRACE, f->flags)) {
             success = false;
-        } else if (TEST(FRAG_IS_TRACE_HEAD, f->flags)) {
+        } else if (TESTANY(FRAG_IS_TRACE_HEAD, f->flags)) {
             success = true;
         } else {
             mark_trace_head(dcontext, f, NULL, NULL);

--- a/core/lib/module_api.c
+++ b/core/lib/module_api.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -432,7 +432,7 @@ dr_module_should_instrument(module_handle_t handle)
     ma = module_pc_lookup((byte *)handle);
     CLIENT_ASSERT(ma != NULL, "invalid module handle");
     if (ma != NULL) {
-        should_instrument = !TEST(MODULE_NULL_INSTRUMENT, ma->flags);
+        should_instrument = !TESTANY(MODULE_NULL_INSTRUMENT, ma->flags);
     }
     os_get_module_info_unlock();
     return should_instrument;

--- a/core/link.c
+++ b/core/link.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -51,9 +51,9 @@
 /* fragment_t and future_fragment_t are guaranteed to have flags field at same offset,
  * so we use it to find incoming_stubs offset
  */
-#define FRAG_INCOMING_ADDR(f)                                        \
-    ((common_direct_linkstub_t **)(!TEST(FRAG_IS_FUTURE, f->flags)   \
-                                       ? &f->in_xlate.incoming_stubs \
+#define FRAG_INCOMING_ADDR(f)                                         \
+    ((common_direct_linkstub_t **)(!TESTANY(FRAG_IS_FUTURE, f->flags) \
+                                       ? &f->in_xlate.incoming_stubs  \
                                        : &((future_fragment_t *)f)->incoming_stubs))
 
 /* forward decl */
@@ -390,7 +390,7 @@ linkstub_propagatable_flags(uint flags)
 bool
 linkstub_frag_offs_at_end(uint flags, int direct_exits, int indirect_exits)
 {
-    ASSERT((direct_exits + indirect_exits > 0) || TEST(FRAG_COARSE_GRAIN, flags));
+    ASSERT((direct_exits + indirect_exits > 0) || TESTANY(FRAG_COARSE_GRAIN, flags));
     /* common bb types do not have an offset at the end:
      * 1) single indirect exit
      * 2) two direct exits
@@ -402,21 +402,21 @@ linkstub_frag_offs_at_end(uint flags, int direct_exits, int indirect_exits)
      * XXX: make the sizeof calculation dynamic such that the dominant
      * type of bb fragment is the one w/o the post_linkstub_t.
      */
-    return !(!TEST(FRAG_IS_TRACE, flags) && TEST(FRAG_SHARED, flags) &&
+    return !(!TESTANY(FRAG_IS_TRACE, flags) && TESTANY(FRAG_SHARED, flags) &&
              /* We can't tell from the linkstub_t whether there is a
               * translation field.  XXX: we could avoid this problem
               * by storing the translation field after the linkstubs.
               */
-             !TEST(FRAG_HAS_TRANSLATION_INFO, flags) &&
+             !TESTANY(FRAG_HAS_TRANSLATION_INFO, flags) &&
              ((direct_exits == 2 && indirect_exits == 0) ||
               (direct_exits == 0 && indirect_exits == 1))) &&
-        !TEST(FRAG_COARSE_GRAIN, flags);
+        !TESTANY(FRAG_COARSE_GRAIN, flags);
 }
 
 bool
 use_cbr_fallthrough_short(uint flags, int direct_exits, int indirect_exits)
 {
-    ASSERT((direct_exits + indirect_exits > 0) || TEST(FRAG_COARSE_GRAIN, flags));
+    ASSERT((direct_exits + indirect_exits > 0) || TESTANY(FRAG_COARSE_GRAIN, flags));
     if (direct_exits != 2 || indirect_exits != 0)
         return false;
     /* cannot handle instrs inserted between cbr and fall-through jmp */
@@ -428,7 +428,7 @@ uint
 linkstubs_heap_size(uint flags, int direct_exits, int indirect_exits)
 {
     uint offset_sz, linkstub_size;
-    ASSERT((direct_exits + indirect_exits > 0) || TEST(FRAG_COARSE_GRAIN, flags));
+    ASSERT((direct_exits + indirect_exits > 0) || TESTANY(FRAG_COARSE_GRAIN, flags));
     if (use_cbr_fallthrough_short(flags, direct_exits, indirect_exits)) {
         linkstub_size = sizeof(direct_linkstub_t) + sizeof(cbr_fallthrough_linkstub_t);
     } else {
@@ -479,21 +479,21 @@ linkstub_fragment(dcontext_t *dcontext, linkstub_t *l)
      * hacks to distinguish types of structs by their final fields w/o
      * adding secondary flags fields.
      */
-    if (TEST(LINK_FRAG_OFFS_AT_END, l->flags)) {
+    if (TESTANY(LINK_FRAG_OFFS_AT_END, l->flags)) {
         /* For traces and unusual bbs, we store an offset to the
          * fragment_t at the end of the linkstub_t list.
          */
         post_linkstub_t *post;
         for (; !LINKSTUB_FINAL(l); l = LINKSTUB_NEXT_EXIT(l))
             ; /* nothing */
-        ASSERT(l != NULL && TEST(LINK_END_OF_LIST, l->flags));
+        ASSERT(l != NULL && TESTANY(LINK_END_OF_LIST, l->flags));
         post = (post_linkstub_t *)(((byte *)l) + LINKSTUB_SIZE(l));
         return (fragment_t *)(((byte *)post) - post->fragment_offset);
     } else {
         /* Otherwise, we assume this is one of 2 types of basic block! */
         if (LINKSTUB_INDIRECT(l->flags)) {
             /* Option 1: a single indirect exit */
-            ASSERT(TEST(LINK_END_OF_LIST, l->flags));
+            ASSERT(TESTANY(LINK_END_OF_LIST, l->flags));
             return (fragment_t *)(((byte *)l) - sizeof(fragment_t));
         } else {
             ASSERT(LINKSTUB_DIRECT(l->flags));
@@ -502,7 +502,7 @@ linkstub_fragment(dcontext_t *dcontext, linkstub_t *l)
              * (single direct exit is very rare but if later becomes common
              * could add a LINK_ flag to distinguish)
              */
-            if (TEST(LINK_END_OF_LIST, l->flags)) {
+            if (TESTANY(LINK_END_OF_LIST, l->flags)) {
                 return (fragment_t *)(((byte *)l) - sizeof(direct_linkstub_t) -
                                       sizeof(fragment_t));
             } else {
@@ -523,13 +523,13 @@ linkstub_owned_by_fragment(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
      * on fake fragments!
      */
     if (LINKSTUB_FAKE(l)) {
-        ASSERT(TEST(FRAG_FAKE, f->flags) ||
+        ASSERT(TESTANY(FRAG_FAKE, f->flags) ||
                /* during emit, coarse-grain has real fragment_t but sometimes fake
                 * linkstubs during linking
                 */
-               TEST(FRAG_COARSE_GRAIN, f->flags));
+               TESTANY(FRAG_COARSE_GRAIN, f->flags));
         /* Coarse-grain temp fragment_t's also have temp fake linkstub_t's */
-        if (TEST(FRAG_COARSE_GRAIN, f->flags))
+        if (TESTANY(FRAG_COARSE_GRAIN, f->flags))
             return true;
         else {
             return (
@@ -616,7 +616,7 @@ last_exit_deleted(dcontext_t *dcontext)
     /* Store which exit this is, for trace building.
      * Our ordinal is the count from the end.
      */
-    if (TEST(FRAG_FAKE, dcontext->last_fragment->flags))
+    if (TESTANY(FRAG_FAKE, dcontext->last_fragment->flags))
         ldata->linkstub_deleted_ordinal = -1; /* invalid */
     else {
         ldata->linkstub_deleted_ordinal = 0;
@@ -803,15 +803,15 @@ is_ibl_sourceless_linkstub(const linkstub_t *l)
 const linkstub_t *
 get_ibl_sourceless_linkstub(uint link_flags, uint frag_flags)
 {
-    if (TEST(FRAG_IS_TRACE, frag_flags)) {
-        if (TEST(LINK_RETURN, link_flags))
+    if (TESTANY(FRAG_IS_TRACE, frag_flags)) {
+        if (TESTANY(LINK_RETURN, link_flags))
             return &linkstub_ibl_trace_ret;
         if (EXIT_IS_JMP(link_flags))
             return &linkstub_ibl_trace_jmp;
         if (EXIT_IS_CALL(link_flags))
             return &linkstub_ibl_trace_call;
     } else {
-        if (TEST(LINK_RETURN, link_flags))
+        if (TESTANY(LINK_RETURN, link_flags))
             return &linkstub_ibl_bb_ret;
         if (EXIT_IS_JMP(link_flags))
             return &linkstub_ibl_bb_jmp;
@@ -870,13 +870,13 @@ local_exit_stub_size(dcontext_t *dcontext, app_pc target, uint fragment_flags)
      */
     int sz = exit_stub_size(dcontext, target, fragment_flags);
     if (((DYNAMO_OPTION(separate_private_stubs) &&
-          !TEST(FRAG_COARSE_GRAIN, fragment_flags) &&
-          !TEST(FRAG_SHARED, fragment_flags)) ||
+          !TESTANY(FRAG_COARSE_GRAIN, fragment_flags) &&
+          !TESTANY(FRAG_SHARED, fragment_flags)) ||
          (DYNAMO_OPTION(separate_shared_stubs) &&
-          !TEST(FRAG_COARSE_GRAIN, fragment_flags) &&
-          TEST(FRAG_SHARED, fragment_flags)) ||
+          !TESTANY(FRAG_COARSE_GRAIN, fragment_flags) &&
+          TESTANY(FRAG_SHARED, fragment_flags)) ||
          /* entrance stubs are always separated */
-         (TEST(FRAG_COARSE_GRAIN, fragment_flags)
+         (TESTANY(FRAG_COARSE_GRAIN, fragment_flags)
           /* XXX: for now we inline ind stubs but eventually we want to separate.
            * We need this check only for coarse since its stubs are the same size
            * as the direct stubs.
@@ -887,7 +887,7 @@ local_exit_stub_size(dcontext_t *dcontext, app_pc target, uint fragment_flags)
          * results in the stub size
          */
         sz ==
-            (TEST(FRAG_COARSE_GRAIN, fragment_flags)
+            (TESTANY(FRAG_COARSE_GRAIN, fragment_flags)
                  ? STUB_COARSE_DIRECT_SIZE(fragment_flags)
                  : DIRECT_EXIT_STUB_SIZE(fragment_flags)))
         return 0;
@@ -911,7 +911,7 @@ separate_stub_create(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     ASSERT(LINKSTUB_DIRECT(l->flags));
     ASSERT(DYNAMO_OPTION(separate_private_stubs) || DYNAMO_OPTION(separate_shared_stubs));
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
-    ASSERT(TEST(LINK_SEPARATE_STUB, l->flags));
+    ASSERT(TESTANY(LINK_SEPARATE_STUB, l->flags));
     if (LINKSTUB_CBR_FALLTHROUGH(l->flags)) {
         /* there is no field for the fallthrough of a short cbr -- it assumes
          * the cbr and fallthrough stubs are contiguous, and calculates its
@@ -942,12 +942,12 @@ separate_stub_create(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     DOSTATS({
         size_t alloc_size = SEPARATE_STUB_ALLOC_SIZE(f->flags);
         STATS_INC(num_separate_stubs);
-        if (TEST(FRAG_SHARED, f->flags)) {
-            if (TEST(FRAG_IS_TRACE, f->flags))
+        if (TESTANY(FRAG_SHARED, f->flags)) {
+            if (TESTANY(FRAG_IS_TRACE, f->flags))
                 STATS_ADD(separate_shared_trace_direct_stubs, alloc_size);
             else
                 STATS_ADD(separate_shared_bb_direct_stubs, alloc_size);
-        } else if (TEST(FRAG_IS_TRACE, f->flags))
+        } else if (TESTANY(FRAG_IS_TRACE, f->flags))
             STATS_ADD(separate_trace_direct_stubs, alloc_size);
         else
             STATS_ADD(separate_bb_direct_stubs, alloc_size);
@@ -963,7 +963,7 @@ separate_stub_free(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, bool dele
     ASSERT(LINKSTUB_DIRECT(l->flags));
     ASSERT(DYNAMO_OPTION(separate_private_stubs) || DYNAMO_OPTION(separate_shared_stubs));
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
-    ASSERT(TEST(LINK_SEPARATE_STUB, l->flags));
+    ASSERT(TESTANY(LINK_SEPARATE_STUB, l->flags));
     ASSERT(exit_stub_size(dcontext, EXIT_TARGET_TAG(dcontext, f, l), f->flags) <=
            SEPARATE_STUB_ALLOC_SIZE(f->flags));
     if (LINKSTUB_CBR_FALLTHROUGH(l->flags)) {
@@ -990,13 +990,13 @@ separate_stub_free(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, bool dele
     }
     DOSTATS({
         size_t alloc_size = SEPARATE_STUB_ALLOC_SIZE(f->flags);
-        if (TEST(FRAG_SHARED, f->flags)) {
-            if (TEST(FRAG_IS_TRACE, f->flags)) {
+        if (TESTANY(FRAG_SHARED, f->flags)) {
+            if (TESTANY(FRAG_IS_TRACE, f->flags)) {
                 STATS_ADD(separate_shared_trace_direct_stubs, -(int)alloc_size);
             } else {
                 STATS_ADD(separate_shared_bb_direct_stubs, -(int)alloc_size);
             }
-        } else if (TEST(FRAG_IS_TRACE, f->flags))
+        } else if (TESTANY(FRAG_IS_TRACE, f->flags))
             STATS_SUB(separate_trace_direct_stubs, alloc_size);
         else
             STATS_SUB(separate_bb_direct_stubs, alloc_size);
@@ -1028,7 +1028,8 @@ linkstub_free_exitstubs(dcontext_t *dcontext, fragment_t *f)
 {
     linkstub_t *l;
     for (l = FRAGMENT_EXIT_STUBS(f); l != NULL; l = LINKSTUB_NEXT_EXIT(l)) {
-        if (TEST(LINK_SEPARATE_STUB, l->flags) && EXIT_STUB_PC(dcontext, f, l) != NULL) {
+        if (TESTANY(LINK_SEPARATE_STUB, l->flags) &&
+            EXIT_STUB_PC(dcontext, f, l) != NULL) {
             linkstub_t *nxt = linkstub_shares_next_stub(dcontext, f, l);
             if (nxt != NULL && !LINKSTUB_CBR_FALLTHROUGH(nxt->flags)) {
                 /* next linkstub shares our stub, so clear his now to avoid
@@ -1054,7 +1055,7 @@ linkstubs_shift(dcontext_t *dcontext, fragment_t *f, ssize_t shift)
          * we also don't need to shift indirect stubs as they do not store
          * an absolute pointer to their stub pc.
          */
-        if (!TEST(LINK_SEPARATE_STUB, l->flags) && LINKSTUB_NORMAL_DIRECT(l->flags)) {
+        if (!TESTANY(LINK_SEPARATE_STUB, l->flags) && LINKSTUB_NORMAL_DIRECT(l->flags)) {
             direct_linkstub_t *dl = (direct_linkstub_t *)l;
             dl->stub_pc += shift;
         } /* else, no change */
@@ -1090,17 +1091,17 @@ is_linkable(dcontext_t *dcontext, fragment_t *from_f, linkstub_t *from_l,
     if (TESTANY(LINK_NI_SYSCALL_ALL, from_l->flags))
         return false;
 #ifdef WINDOWS
-    if (TEST(LINK_CALLBACK_RETURN, from_l->flags))
+    if (TESTANY(LINK_CALLBACK_RETURN, from_l->flags))
         return false;
 #endif
     /* never link a selfmod or any other unlinkable exit branch */
-    if (TEST(LINK_SPECIAL_EXIT, from_l->flags))
+    if (TESTANY(LINK_SPECIAL_EXIT, from_l->flags))
         return false;
     /* don't link from a non-outgoing-linked fragment, or to a
      * non-incoming-linked fragment, except for self-loops
      */
-    if ((!TEST(FRAG_LINKED_OUTGOING, from_f->flags) ||
-         !TEST(FRAG_LINKED_INCOMING, to_f->flags)) &&
+    if ((!TESTANY(FRAG_LINKED_OUTGOING, from_f->flags) ||
+         !TESTANY(FRAG_LINKED_INCOMING, to_f->flags)) &&
         from_f != to_f)
         return false;
     /* rarely set so we test it last */
@@ -1108,7 +1109,7 @@ is_linkable(dcontext_t *dcontext, fragment_t *from_f, linkstub_t *from_l,
         return false;
 #if defined(UNIX) && !defined(DGC_DIAGNOSTICS)
     /* i#107, fragment having a OP_mov_seg instr cannot be linked. */
-    if (TEST(FRAG_HAS_MOV_SEG, to_f->flags))
+    if (TESTANY(FRAG_HAS_MOV_SEG, to_f->flags))
         return false;
 #endif
     return true;
@@ -1126,7 +1127,7 @@ link_branch(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, fragment_t *targ
 {
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     /* ASSUMPTION: always unlink before linking to somewhere else, so nop if linked */
-    if (INTERNAL_OPTION(nolink) || TEST(LINK_LINKED, l->flags))
+    if (INTERNAL_OPTION(nolink) || TESTANY(LINK_LINKED, l->flags))
         return;
     if (LINKSTUB_DIRECT(l->flags)) {
         LOG(THREAD, LOG_LINKS, 4,
@@ -1135,7 +1136,7 @@ link_branch(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, fragment_t *targ
 #ifdef TRACE_HEAD_CACHE_INCR
         {
             common_direct_linkstub_t *cdl = (common_direct_linkstub_t *)l;
-            if (TEST(FRAG_IS_TRACE_HEAD, targetf->flags))
+            if (TESTANY(FRAG_IS_TRACE_HEAD, targetf->flags))
                 cdl->target_fragment = targetf;
             else
                 cdl->target_fragment = NULL;
@@ -1147,11 +1148,11 @@ link_branch(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, fragment_t *targ
         } else {
             bool do_not_need_stub =
                 link_direct_exit(dcontext, f, l, targetf, hot_patch) &&
-                TEST(LINK_SEPARATE_STUB, l->flags) &&
-                ((DYNAMO_OPTION(free_private_stubs) && !TEST(FRAG_SHARED, f->flags)) ||
+                TESTANY(LINK_SEPARATE_STUB, l->flags) &&
+                ((DYNAMO_OPTION(free_private_stubs) && !TESTANY(FRAG_SHARED, f->flags)) ||
                  (DYNAMO_OPTION(unsafe_free_shared_stubs) &&
-                  TEST(FRAG_SHARED, f->flags)));
-            ASSERT(!TEST(FRAG_FAKE, f->flags) && !LINKSTUB_FAKE(l));
+                  TESTANY(FRAG_SHARED, f->flags)));
+            ASSERT(!TESTANY(FRAG_FAKE, f->flags) && !LINKSTUB_FAKE(l));
             if (do_not_need_stub)
                 separate_stub_free(dcontext, f, l, false);
         }
@@ -1197,7 +1198,7 @@ unlink_branch(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
             ASSERT(!LINKSTUB_FAKE(l));
             /* stub may already exist for TRACE_HEAD_CACHE_INCR */
             if (EXIT_STUB_PC(dcontext, f, l) == NULL &&
-                TEST(LINK_SEPARATE_STUB, l->flags))
+                TESTANY(LINK_SEPARATE_STUB, l->flags))
                 separate_stub_create(dcontext, f, l);
             unlink_direct_exit(dcontext, f, l);
         }
@@ -1236,9 +1237,9 @@ incoming_find_link(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
     common_direct_linkstub_t *dl = (common_direct_linkstub_t *)l;
     ASSERT(LINKSTUB_DIRECT(l->flags));
     ASSERT(!LINKSTUB_FAKE(l) ||
-           (LINKSTUB_COARSE_PROXY(l->flags) && TEST(FRAG_COARSE_GRAIN, f->flags) &&
+           (LINKSTUB_COARSE_PROXY(l->flags) && TESTANY(FRAG_COARSE_GRAIN, f->flags) &&
             LINKSTUB_NORMAL_DIRECT(l->flags)));
-    if (TEST(FRAG_COARSE_GRAIN, targetf->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, targetf->flags)) {
         coarse_incoming_t *e;
         coarse_info_t *info = get_fragment_coarse_info(targetf);
         ASSERT(info != NULL);
@@ -1291,7 +1292,7 @@ incoming_remove_link_nosearch(dcontext_t *dcontext, fragment_t *f, linkstub_t *l
     ASSERT(prevl == NULL || LINKSTUB_DIRECT(prevl->flags));
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     ASSERT(!LINKSTUB_FAKE(l) ||
-           (LINKSTUB_COARSE_PROXY(l->flags) && TEST(FRAG_COARSE_GRAIN, f->flags) &&
+           (LINKSTUB_COARSE_PROXY(l->flags) && TESTANY(FRAG_COARSE_GRAIN, f->flags) &&
             LINKSTUB_NORMAL_DIRECT(l->flags)));
     /* no links across caches so only checking f's sharedness is enough */
     ASSERT(!NEED_SHARED_LOCK(f->flags) || self_owns_recursive_lock(&change_linking_lock));
@@ -1309,7 +1310,7 @@ incoming_remove_link_nosearch(dcontext_t *dcontext, fragment_t *f, linkstub_t *l
          */
         if (dl->next_incoming == NULL) {
             if (TESTALL(FRAG_TEMP_PRIVATE | FRAG_IS_FUTURE, targetf->flags) &&
-                !TEST(FRAG_WAS_DELETED, targetf->flags)) {
+                !TESTANY(FRAG_WAS_DELETED, targetf->flags)) {
                 /* this is a future created only as an outgoing link of a private
                  * bb created solely for trace creation.
                  * since it never had a real fragment that was executed, we can
@@ -1352,7 +1353,7 @@ incoming_remove_link_search(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
     ASSERT(LINKSTUB_DIRECT(l->flags));
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     ASSERT(!LINKSTUB_FAKE(l) ||
-           (LINKSTUB_COARSE_PROXY(l->flags) && TEST(FRAG_COARSE_GRAIN, f->flags) &&
+           (LINKSTUB_COARSE_PROXY(l->flags) && TESTANY(FRAG_COARSE_GRAIN, f->flags) &&
             LINKSTUB_NORMAL_DIRECT(l->flags)));
     for (s = *inlist, prevs = NULL; s;
          prevs = s, s = (common_direct_linkstub_t *)s->next_incoming) {
@@ -1382,10 +1383,10 @@ incoming_remove_link(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
 {
     /* no links across caches so only checking f's sharedness is enough */
     ASSERT(!NEED_SHARED_LOCK(f->flags) || self_owns_recursive_lock(&change_linking_lock));
-    ASSERT(!LINKSTUB_COARSE_PROXY(l->flags) || TEST(FRAG_COARSE_GRAIN, f->flags));
-    ASSERT(!TEST(FRAG_COARSE_GRAIN, f->flags) ||
-           !TEST(FRAG_COARSE_GRAIN, targetf->flags));
-    if (TEST(FRAG_COARSE_GRAIN, targetf->flags)) {
+    ASSERT(!LINKSTUB_COARSE_PROXY(l->flags) || TESTANY(FRAG_COARSE_GRAIN, f->flags));
+    ASSERT(!TESTANY(FRAG_COARSE_GRAIN, f->flags) ||
+           !TESTANY(FRAG_COARSE_GRAIN, targetf->flags));
+    if (TESTANY(FRAG_COARSE_GRAIN, targetf->flags)) {
         coarse_remove_incoming(dcontext, f, l, targetf);
     } else {
         if (incoming_remove_link_search(dcontext, f, l, targetf,
@@ -1415,7 +1416,7 @@ add_to_incoming_list(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
     ASSERT(!incoming_link_exists(dcontext, f, l, targetf));
     /* no inter-cache incoming entries */
     ASSERT((f->flags & FRAG_SHARED) == (targetf->flags & FRAG_SHARED));
-    if (TEST(FRAG_COARSE_GRAIN, targetf->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, targetf->flags)) {
         coarse_info_t *info = get_fragment_coarse_info(targetf);
         prepend_new_coarse_incoming(info, NULL, l);
     } else {
@@ -1448,7 +1449,7 @@ add_private_check_shared(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     if (!SHARED_FRAGMENTS_ENABLED())
         return;
-    ASSERT(!TEST(FRAG_SHARED, f->flags));
+    ASSERT(!TESTANY(FRAG_SHARED, f->flags));
     ASSERT(!SHARED_FRAGMENTS_ENABLED() || dynamo_exited ||
            self_owns_recursive_lock(&change_linking_lock));
     targetf = fragment_link_lookup_same_sharing(dcontext, target_tag, l, FRAG_SHARED);
@@ -1459,18 +1460,18 @@ add_private_check_shared(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
                                                                FRAG_SHARED);
     }
 
-    if (!TEST(FRAG_IS_TRACE_HEAD, targetf->flags)) {
+    if (!TESTANY(FRAG_IS_TRACE_HEAD, targetf->flags)) {
         uint th = should_be_trace_head(dcontext, f, l, target_tag, targetf->flags,
                                        true /* have linking lock*/);
-        if (TEST(TRACE_HEAD_YES, th)) {
-            if (TEST(FRAG_IS_FUTURE, targetf->flags)) {
+        if (TESTANY(TRACE_HEAD_YES, th)) {
+            if (TESTANY(FRAG_IS_FUTURE, targetf->flags)) {
                 LOG(THREAD, LOG_LINKS, 4, "    marking future (" PFX ") as trace head\n",
                     target_tag);
                 targetf->flags |= FRAG_IS_TRACE_HEAD;
             } else {
                 mark_trace_head(dcontext, targetf, f, l);
             }
-            ASSERT(!TEST(TRACE_HEAD_OBTAINED_LOCK, th));
+            ASSERT(!TESTANY(TRACE_HEAD_OBTAINED_LOCK, th));
         }
     }
 }
@@ -1487,7 +1488,7 @@ add_future_incoming(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     ASSERT(!SHARED_FRAGMENTS_ENABLED() || !dynamo_exited ||
            self_owns_recursive_lock(&change_linking_lock));
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
-    if (!TEST(FRAG_SHARED, f->flags))
+    if (!TESTANY(FRAG_SHARED, f->flags))
         targetf = fragment_lookup_private_future(dcontext, target_tag);
     else
         targetf = fragment_lookup_future(dcontext, target_tag);
@@ -1505,7 +1506,7 @@ add_future_incoming(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     }
     add_to_incoming_list(dcontext, f, l, (fragment_t *)targetf, false);
 
-    if (!TEST(FRAG_SHARED, f->flags)) {
+    if (!TESTANY(FRAG_SHARED, f->flags)) {
         /* private fragments need to ensure a shared fragment/future exists,
          * and need to perform secondary trace head marking on it here!
          */
@@ -1520,13 +1521,13 @@ static void
 add_incoming(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, fragment_t *targetf,
              bool linked)
 {
-    ASSERT(TEST(FRAG_SHARED, f->flags) == TEST(FRAG_SHARED, targetf->flags));
+    ASSERT(TESTANY(FRAG_SHARED, f->flags) == TESTANY(FRAG_SHARED, targetf->flags));
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     LOG(THREAD, LOG_LINKS, 4, "    add incoming F%d(" PFX ")." PFX " -> F%d(" PFX ")\n",
         f->id, f->tag, EXIT_CTI_PC(f, l), targetf->id, targetf->tag);
     add_to_incoming_list(dcontext, f, l, targetf, linked);
 
-    if (!TEST(FRAG_SHARED, f->flags)) {
+    if (!TESTANY(FRAG_SHARED, f->flags)) {
         /* private fragments need to ensure a shared fragment/future exists,
          * and need to perform secondary trace head marking on it here!
          */
@@ -1544,7 +1545,7 @@ incoming_remove_fragment(dcontext_t *dcontext, fragment_t *f)
     /* pendel-del frags use fragment_t.in_xlate differently: they should
      * never call this routine once they're marked for deletion
      */
-    ASSERT(!TEST(FRAG_WAS_DELETED, f->flags));
+    ASSERT(!TESTANY(FRAG_WAS_DELETED, f->flags));
 
     /* link data struct change in shared fragment must be synchronized
      * no links across caches so only checking f's sharedness is enough
@@ -1554,7 +1555,7 @@ incoming_remove_fragment(dcontext_t *dcontext, fragment_t *f)
     /* if removing shared trace, move its links back to the shadowed shared trace head */
     /* flags not preserved for coarse so we have to check all coarse bbs */
     if (TESTANY(FRAG_TRACE_LINKS_SHIFTED | FRAG_COARSE_GRAIN, f->flags)) {
-        if (TEST(FRAG_IS_TRACE, f->flags)) {
+        if (TESTANY(FRAG_IS_TRACE, f->flags)) {
             fragment_t wrapper;
             /* XXX case 8600: provide single lookup routine here */
             fragment_t *bb = fragment_lookup_bb(dcontext, f->tag);
@@ -1567,14 +1568,14 @@ incoming_remove_fragment(dcontext_t *dcontext, fragment_t *f)
             }
             if (bb != NULL &&
                 (TESTANY(FRAG_TRACE_LINKS_SHIFTED | FRAG_COARSE_GRAIN, bb->flags))) {
-                ASSERT(TEST(FRAG_IS_TRACE_HEAD, bb->flags) ||
-                       TEST(FRAG_COARSE_GRAIN, bb->flags));
+                ASSERT(TESTANY(FRAG_IS_TRACE_HEAD, bb->flags) ||
+                       TESTANY(FRAG_COARSE_GRAIN, bb->flags));
                 /* XXX: this will mark trace head as FRAG_LINKED_INCOMING --
                  * but then same thing for a new bb marked as a trace head
                  * before linking via its previous future, so not a new problem.
                  * won't actually link incoming since !linkable.
                  */
-                if (TEST(FRAG_COARSE_GRAIN, bb->flags)) {
+                if (TESTANY(FRAG_COARSE_GRAIN, bb->flags)) {
                     /* We assume the coarse-grain bb is a trace head -- our method
                      * of lookup is unable to mark it so we mark it here
                      */
@@ -1585,7 +1586,7 @@ incoming_remove_fragment(dcontext_t *dcontext, fragment_t *f)
                 ASSERT(f->in_xlate.incoming_stubs == NULL);
                 return NULL;
             }
-        } else if (TEST(FRAG_IS_TRACE_HEAD, f->flags)) {
+        } else if (TESTANY(FRAG_IS_TRACE_HEAD, f->flags)) {
             fragment_t *trace = fragment_lookup_trace(dcontext, f->tag);
             /* regardless of -remove_shared_trace_heads, a shared trace will
              * at least briefly shadow and shift links from a shared trace head.
@@ -1620,7 +1621,7 @@ incoming_remove_fragment(dcontext_t *dcontext, fragment_t *f)
                      * future_fragment_t*
                      */
                     /* make sure future is in proper shared/private table */
-                    if (!TEST(FRAG_SHARED, f->flags)) {
+                    if (!TESTANY(FRAG_SHARED, f->flags)) {
                         targetf = (fragment_t *)fragment_lookup_private_future(
                             dcontext, target_tag);
                     } else {
@@ -1638,7 +1639,7 @@ incoming_remove_fragment(dcontext_t *dcontext, fragment_t *f)
         }
     }
 
-    if (TEST(FRAG_TEMP_PRIVATE, f->flags) && f->in_xlate.incoming_stubs == NULL) {
+    if (TESTANY(FRAG_TEMP_PRIVATE, f->flags) && f->in_xlate.incoming_stubs == NULL) {
         /* if there are incoming stubs, the private displaced a prior future, which
          * does need to be replaced -- if not, we don't need a future
          */
@@ -1655,7 +1656,7 @@ incoming_remove_fragment(dcontext_t *dcontext, fragment_t *f)
     LOG(THREAD, LOG_LINKS, 4, "    adding future fragment for deleted F%d(" PFX ")\n",
         f->id, f->tag);
     DOCHECK(1, {
-        if (TEST(FRAG_SHARED, f->flags))
+        if (TESTANY(FRAG_SHARED, f->flags))
             ASSERT(fragment_lookup_future(dcontext, f->tag) == NULL);
         else
             ASSERT(fragment_lookup_private_future(dcontext, f->tag) == NULL);
@@ -1700,19 +1701,19 @@ link_fragment_incoming(dcontext_t *dcontext, fragment_t *f, bool new_fragment)
     ASSERT_OWN_RECURSIVE_LOCK(NEED_SHARED_LOCK(f->flags) ||
                                   (new_fragment && SHARED_FRAGMENTS_ENABLED()),
                               &change_linking_lock);
-    ASSERT(!TEST(FRAG_LINKED_INCOMING, f->flags));
+    ASSERT(!TESTANY(FRAG_LINKED_INCOMING, f->flags));
     f->flags |= FRAG_LINKED_INCOMING;
 
     /* link incoming links */
     for (l = f->in_xlate.incoming_stubs; l != NULL; l = LINKSTUB_NEXT_INCOMING(l)) {
         bool local_trace_head = false;
         fragment_t *in_f = linkstub_fragment(dcontext, l);
-        if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
             /* Case 8907: remove trace headness markings, as each fine source
              * should only consider this a trace head considering its own
              * path to it.
              */
-            local_trace_head = TEST(FRAG_IS_TRACE_HEAD, f->flags);
+            local_trace_head = TESTANY(FRAG_IS_TRACE_HEAD, f->flags);
             f->flags &= ~FRAG_IS_TRACE_HEAD;
         }
         /* only direct branches are marked on targets' incoming */
@@ -1731,7 +1732,7 @@ link_fragment_incoming(dcontext_t *dcontext, fragment_t *f, bool new_fragment)
                 in_f->id, in_f->tag, EXIT_CTI_PC(in_f, l), f->id, f->tag);
         }
         /* Restore trace headness, if present before and not set in is_linkable */
-        if (local_trace_head && !TEST(FRAG_IS_TRACE_HEAD, f->flags))
+        if (local_trace_head && !TESTANY(FRAG_IS_TRACE_HEAD, f->flags))
             f->flags |= FRAG_IS_TRACE_HEAD;
     }
 }
@@ -1753,7 +1754,7 @@ link_fragment_outgoing(dcontext_t *dcontext, fragment_t *f, bool new_fragment)
     ASSERT_OWN_RECURSIVE_LOCK(NEED_SHARED_LOCK(f->flags) ||
                                   (new_fragment && SHARED_FRAGMENTS_ENABLED()),
                               &change_linking_lock);
-    ASSERT(!TEST(FRAG_LINKED_OUTGOING, f->flags));
+    ASSERT(!TESTANY(FRAG_LINKED_OUTGOING, f->flags));
     f->flags |= FRAG_LINKED_OUTGOING;
 
     /* new_fragment: already protected
@@ -1833,13 +1834,13 @@ unlink_fragment_incoming(dcontext_t *dcontext, fragment_t *f)
      */
     ASSERT(TESTANY(FRAG_LINKED_INCOMING | FRAG_IS_TRACE_HEAD, f->flags));
     /* unlink incoming branches */
-    ASSERT(!TEST(FRAG_COARSE_GRAIN, f->flags));
+    ASSERT(!TESTANY(FRAG_COARSE_GRAIN, f->flags));
     for (prevl = NULL, l = f->in_xlate.incoming_stubs; l != NULL; l = nextl) {
         fragment_t *in_f = linkstub_fragment(dcontext, l);
         bool keep = true;
         nextl = LINKSTUB_NEXT_INCOMING(l);
         /* not all are linked (e.g., to trace head) */
-        if (TEST(LINK_LINKED, l->flags)) {
+        if (TESTANY(LINK_LINKED, l->flags)) {
             /* unprotect on demand, caller will re-protect */
             SELF_PROTECT_CACHE(dcontext, in_f, WRITABLE);
             keep = unlink_branch(dcontext, in_f, l);
@@ -1867,7 +1868,7 @@ unlink_fragment_outgoing(dcontext_t *dcontext, fragment_t *f)
      * no links across caches so only checking f's sharedness is enough
      */
     ASSERT(!NEED_SHARED_LOCK(f->flags) || self_owns_recursive_lock(&change_linking_lock));
-    ASSERT(TEST(FRAG_LINKED_OUTGOING, f->flags));
+    ASSERT(TESTANY(FRAG_LINKED_OUTGOING, f->flags));
     /* unprotect on demand, caller will re-protect */
     SELF_PROTECT_CACHE(dcontext, f, WRITABLE);
     /* unlink outgoing direct & indirect branches */
@@ -1893,7 +1894,7 @@ void
 link_new_fragment(dcontext_t *dcontext, fragment_t *f)
 {
     future_fragment_t *future;
-    if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
         link_new_coarse_grain_fragment(dcontext, f);
         return;
     }
@@ -1904,7 +1905,7 @@ link_new_fragment(dcontext_t *dcontext, fragment_t *f)
     ASSERT(!NEED_SHARED_LOCK(f->flags) || self_owns_recursive_lock(&change_linking_lock));
 
     /* transfer existing future incoming links to this fragment */
-    if (!TEST(FRAG_SHARED, f->flags))
+    if (!TESTANY(FRAG_SHARED, f->flags))
         future = fragment_lookup_private_future(dcontext, f->tag);
     else
         future = fragment_lookup_future(dcontext, f->tag);
@@ -1923,7 +1924,7 @@ link_new_fragment(dcontext_t *dcontext, fragment_t *f)
         /* we only expect certain flags on future fragments */
         ASSERT_CURIOSITY((futflags & ~(FUTURE_FLAGS_ALLOWED)) == 0);
         /* sharedness must match */
-        ASSERT(TEST(FRAG_SHARED, f->flags) == TEST(FRAG_SHARED, futflags));
+        ASSERT(TESTANY(FRAG_SHARED, f->flags) == TESTANY(FRAG_SHARED, futflags));
         f->flags |= (futflags & (FUTURE_FLAGS_TRANSFER));
         /* make sure existing flags and flags from build are compatible */
         /* trace head and frag cannot be trace head incompatible */
@@ -1950,7 +1951,7 @@ link_new_fragment(dcontext_t *dcontext, fragment_t *f)
         fragment_delete_future(dcontext, future);
     }
     DOCHECK(1, {
-        if (TEST(FRAG_SHARED, f->flags))
+        if (TESTANY(FRAG_SHARED, f->flags))
             ASSERT(fragment_lookup_future(dcontext, f->tag) == NULL);
         else
             ASSERT(fragment_lookup_private_future(dcontext, f->tag) == NULL);
@@ -1976,7 +1977,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
 {
     linkstub_t *l;
     bool have_link_lock =
-        (TEST(FRAG_SHARED, old_f->flags) || TEST(FRAG_SHARED, new_f->flags)) &&
+        (TESTANY(FRAG_SHARED, old_f->flags) || TESTANY(FRAG_SHARED, new_f->flags)) &&
         !INTERNAL_OPTION(single_thread_in_DR);
     cache_pc old_stub = NULL;
     cache_pc old_body = NULL;
@@ -2005,7 +2006,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
     /* remove old outgoing links from others' incoming lists */
     LOG(THREAD, LOG_LINKS, 4, "  removing outgoing links for F%d(" PFX ")\n", old_f->id,
         old_f->tag);
-    if (TEST(FRAG_COARSE_GRAIN, old_f->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, old_f->flags)) {
         /* XXX: we could implement full non-fake fragment_t recovery, and
          * engineer the normal link paths to do the right thing for coarse
          * fragments, to avoid all the coarse checks in this routine
@@ -2028,7 +2029,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
          * in target incoming lists.  Plus, this means we don't have to do
          * anything if we later delete the trace.
          */
-        ASSERT(!TEST(FRAG_COARSE_GRAIN, new_f->flags)); /* ensure distinct incomings */
+        ASSERT(!TESTANY(FRAG_COARSE_GRAIN, new_f->flags)); /* ensure distinct incomings */
     } else {
         for (l = FRAGMENT_EXIT_STUBS(old_f); l; l = LINKSTUB_NEXT_EXIT(l)) {
             if (LINKSTUB_DIRECT(l->flags)) {
@@ -2041,7 +2042,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
                      * future_fragment_t*
                      */
                     /* make sure future is in proper shared/private table */
-                    if (!TEST(FRAG_SHARED, old_f->flags)) {
+                    if (!TESTANY(FRAG_SHARED, old_f->flags)) {
                         targetf = (fragment_t *)fragment_lookup_private_future(
                             dcontext, target_tag);
                     } else {
@@ -2058,7 +2059,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
                  * and leave the link there since not in incoming) we also unlink
                  * everything else.
                  */
-                if (TEST(LINK_LINKED, l->flags)) {
+                if (TESTANY(LINK_LINKED, l->flags)) {
                     DEBUG_DECLARE(keep =) unlink_branch(dcontext, old_f, l);
                     ASSERT(keep);
                 }
@@ -2068,7 +2069,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
                 incoming_remove_link(dcontext, old_f, l, targetf);
             } else {
                 ASSERT(LINKSTUB_INDIRECT(l->flags));
-                if (TEST(LINK_LINKED, l->flags)) {
+                if (TESTANY(LINK_LINKED, l->flags)) {
                     DEBUG_DECLARE(keep =) unlink_branch(dcontext, old_f, l);
                     ASSERT(keep);
                 }
@@ -2079,11 +2080,12 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
 
     /* We copy prior to link-outgoing as that can add to incoming for self-links */
     ASSERT(new_f->in_xlate.incoming_stubs == NULL);
-    ASSERT(!TEST(FRAG_COARSE_GRAIN, old_f->flags) ||
+    ASSERT(!TESTANY(FRAG_COARSE_GRAIN, old_f->flags) ||
            old_f->in_xlate.incoming_stubs == NULL);
     new_f->in_xlate.incoming_stubs = old_f->in_xlate.incoming_stubs;
     old_f->in_xlate.incoming_stubs = NULL;
-    if (TEST(FRAG_COARSE_GRAIN, new_f->flags) && new_f->in_xlate.incoming_stubs != NULL) {
+    if (TESTANY(FRAG_COARSE_GRAIN, new_f->flags) &&
+        new_f->in_xlate.incoming_stubs != NULL) {
         if (info == NULL)
             info = get_fragment_coarse_info(new_f);
         prepend_new_coarse_incoming(info, NULL, new_f->in_xlate.incoming_stubs);
@@ -2099,10 +2101,10 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
      * rather than unlinking we mark them as not linked and put the proper
      * link in with one cache write rather than two
      */
-    if (!TEST(FRAG_COARSE_GRAIN, new_f->flags)) {
-        if (TEST(FRAG_LINKED_OUTGOING, new_f->flags)) {
+    if (!TESTANY(FRAG_COARSE_GRAIN, new_f->flags)) {
+        if (TESTANY(FRAG_LINKED_OUTGOING, new_f->flags)) {
             for (l = FRAGMENT_EXIT_STUBS(new_f); l; l = LINKSTUB_NEXT_EXIT(l)) {
-                if (LINKSTUB_DIRECT(l->flags) && TEST(LINK_LINKED, l->flags)) {
+                if (LINKSTUB_DIRECT(l->flags) && TESTANY(LINK_LINKED, l->flags)) {
                     l->flags &= ~LINK_LINKED; /* leave inconsistent briefly */
                 }
             }
@@ -2115,7 +2117,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
          * a shared trace -- and that we never did unlink the trace head's outgoing
          */
     }
-    ASSERT(TEST(FRAG_LINKED_OUTGOING, new_f->flags));
+    ASSERT(TESTANY(FRAG_LINKED_OUTGOING, new_f->flags));
 
     /* now shift incoming links from old fragment to new one */
     LOG(THREAD, LOG_LINKS, 4, "  transferring incoming links from F%d to F%d\n",
@@ -2123,11 +2125,11 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
     old_f->flags &= ~FRAG_LINKED_INCOMING;
     LOG(THREAD, LOG_LINKS, 4, "  linking incoming links for F%d(" PFX ")\n", new_f->id,
         new_f->tag);
-    if (TEST(FRAG_COARSE_GRAIN, old_f->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, old_f->flags)) {
         coarse_incoming_t *e, *prev_e = NULL, *next_e;
         bool remove_entry;
         /* We don't yet support coarse to coarse shifts (see above for one reason) */
-        ASSERT(!TEST(FRAG_COARSE_GRAIN, new_f->flags));
+        ASSERT(!TESTANY(FRAG_COARSE_GRAIN, new_f->flags));
         /* Change the entrance stub to point to the trace, which redirects
          * all incoming from inside the unit.
          */
@@ -2164,7 +2166,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
                 for (l = e->in.fine_l; l != NULL; l = next_l) {
                     fragment_t *in_f = linkstub_fragment(dcontext, l);
                     next_l = LINKSTUB_NEXT_INCOMING(l);
-                    ASSERT(!TEST(LINK_FAKE, l->flags));
+                    ASSERT(!TESTANY(LINK_FAKE, l->flags));
                     if (tgt == NULL) {
                         tgt = EXIT_TARGET_TAG(dcontext, in_f, l);
                     } else {
@@ -2234,7 +2236,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
         }
         d_r_mutex_unlock(&info->incoming_lock);
 
-    } else if (TEST(FRAG_COARSE_GRAIN, new_f->flags)) {
+    } else if (TESTANY(FRAG_COARSE_GRAIN, new_f->flags)) {
         /* Change the entrance stub to point to the trace head routine again
          * (we only shift to coarse trace heads).
          */
@@ -2258,7 +2260,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
          */
         new_f->flags &= ~FRAG_LINKED_INCOMING; /* wrapper is marked as linked */
         link_fragment_incoming(dcontext, new_f, true /*new*/);
-        ASSERT(TEST(FRAG_LINKED_INCOMING, new_f->flags));
+        ASSERT(TESTANY(FRAG_LINKED_INCOMING, new_f->flags));
     } else {
         new_f->flags |= FRAG_LINKED_INCOMING;
         for (l = new_f->in_xlate.incoming_stubs; l != NULL;
@@ -2270,7 +2272,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
                 /* used to check to make sure was linked but no reason to? */
                 /* already did self-links */
                 if (in_f != new_f) {
-                    if (TEST(LINK_LINKED, l->flags))
+                    if (TESTANY(LINK_LINKED, l->flags))
                         l->flags &= ~LINK_LINKED; /* else, link_branch is a nop */
                     link_branch(dcontext, in_f, l, new_f, HOT_PATCHABLE);
                 } else {
@@ -2301,7 +2303,8 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
      * when we delete the head we don't complain that we're
      * missing links.
      */
-    if (TEST(FRAG_IS_TRACE, new_f->flags) && TEST(FRAG_IS_TRACE_HEAD, old_f->flags)) {
+    if (TESTANY(FRAG_IS_TRACE, new_f->flags) &&
+        TESTANY(FRAG_IS_TRACE_HEAD, old_f->flags)) {
         ASSERT((!NEED_SHARED_LOCK(new_f->flags) && !NEED_SHARED_LOCK(old_f->flags)) ||
                self_owns_recursive_lock(&change_linking_lock));
         LOG(THREAD, LOG_LINKS, 4, "Marking old and new as FRAG_TRACE_LINKS_SHIFTED\n");
@@ -2515,7 +2518,7 @@ entrance_stub_create(dcontext_t *dcontext, coarse_info_t *info, fragment_t *f,
     ASSERT(DYNAMO_OPTION(coarse_units));
     ASSERT(info != NULL && info->stubs != NULL);
     ASSERT(LINKSTUB_DIRECT(l->flags));
-    ASSERT(TEST(LINK_SEPARATE_STUB, l->flags));
+    ASSERT(TESTANY(LINK_SEPARATE_STUB, l->flags));
     ASSERT(exit_stub_size(dcontext, EXIT_TARGET_TAG(dcontext, f, l), f->flags) <=
            (ssize_t)stub_size);
     /* We hot-patch our stubs and we assume that aligning them to 16 is enough */
@@ -2597,7 +2600,7 @@ prepend_new_coarse_incoming(coarse_info_t *info, cache_pc coarse, linkstub_t *fi
         DOCHECK(1, {
             linkstub_t *l;
             for (l = fine; l != NULL; l = LINKSTUB_NEXT_INCOMING(l))
-                ASSERT(!TEST(LINK_FAKE, l->flags));
+                ASSERT(!TESTANY(LINK_FAKE, l->flags));
         });
     }
     ASSERT(info != NULL);
@@ -2635,7 +2638,8 @@ fragment_link_lookup_same_sharing(dcontext_t *dcontext, app_pc tag, linkstub_t *
      * Else need to grab the lock when linking private fragments
      * (in particular, temps for trace building)
      */
-    ASSERT(!TEST(FRAG_SHARED, flags) || self_owns_recursive_lock(&change_linking_lock));
+    ASSERT(!TESTANY(FRAG_SHARED, flags) ||
+           self_owns_recursive_lock(&change_linking_lock));
     return fragment_lookup_fine_and_coarse_sharing(dcontext, tag, &temp_targetf,
                                                    last_exit, flags);
 }
@@ -2714,7 +2718,7 @@ coarse_link_direct(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
     /* Since we leave shadowed trace heads visible we must first look in the
      * fine tables
      */
-    ASSERT(TEST(FRAG_SHARED, f->flags));
+    ASSERT(TESTANY(FRAG_SHARED, f->flags));
     target_f = fragment_lookup_same_sharing(dcontext, target_tag, FRAG_SHARED);
     if (target_f == NULL) {
         if (local_tgt_in == NULL) {
@@ -2736,7 +2740,7 @@ coarse_link_direct(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
         } else
             coarse_tgt = local_tgt;
     } else
-        ASSERT(!TEST(FRAG_COARSE_GRAIN, target_f->flags));
+        ASSERT(!TESTANY(FRAG_COARSE_GRAIN, target_f->flags));
     if (coarse_tgt != NULL || target_f != NULL) {
         if (target_f == NULL) {
             /* No fine-grain fragment_t so make a fake one to use for the
@@ -2756,7 +2760,7 @@ coarse_link_direct(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
                 /* Target is outside this unit, either a fine fragment_t
                  * or another unit's coarse fragment
                  */
-                if (!TEST(FRAG_COARSE_GRAIN, target_f->flags)) {
+                if (!TESTANY(FRAG_COARSE_GRAIN, target_f->flags)) {
                     if (!entrance_stub_linked(stub, src_info))
                         coarse_link_to_fine(dcontext, stub, f, target_f, true /*link*/);
                     else {
@@ -2809,9 +2813,9 @@ coarse_link_direct(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
             /* We should have converted the entrance stub to a trace head
              * stub in mark_trace_head()
              */
-            ASSERT((!TEST(FRAG_COARSE_GRAIN, target_f->flags) &&
-                    (TEST(FRAG_IS_TRACE_HEAD, target_f->flags) ||
-                     !TEST(FRAG_SHARED, target_f->flags))) ||
+            ASSERT((!TESTANY(FRAG_COARSE_GRAIN, target_f->flags) &&
+                    (TESTANY(FRAG_IS_TRACE_HEAD, target_f->flags) ||
+                     !TESTANY(FRAG_SHARED, target_f->flags))) ||
                    coarse_is_trace_head(stub));
             ASSERT(!entrance_stub_linked(stub, src_info));
             LOG(THREAD, LOG_LINKS, 4,
@@ -2856,7 +2860,7 @@ link_new_coarse_grain_fragment(dcontext_t *dcontext, fragment_t *f)
         /* we only expect certain flags on future fragments */
         ASSERT_CURIOSITY((futflags & ~(FUTURE_FLAGS_ALLOWED)) == 0);
         /* sharedness must match */
-        ASSERT(TEST(FRAG_SHARED, f->flags) == TEST(FRAG_SHARED, futflags));
+        ASSERT(TESTANY(FRAG_SHARED, f->flags) == TESTANY(FRAG_SHARED, futflags));
         /* XXX: we will discard all of these flags, which right now only include
          * secondary shared trace heads from private traces, fortunately, and
          * we'll use that by converting to a trace head below.
@@ -2864,7 +2868,7 @@ link_new_coarse_grain_fragment(dcontext_t *dcontext, fragment_t *f)
         f->flags |= (futflags & (FUTURE_FLAGS_TRANSFER));
         /* we shouldn't have any of the incompatibilites a new fine fragment does */
         ASSERT(!TESTANY(FRAG_CANNOT_BE_TRACE | FRAG_IS_TRACE, f->flags));
-        if (TEST(FRAG_IS_TRACE_HEAD, f->flags))
+        if (TESTANY(FRAG_IS_TRACE_HEAD, f->flags))
             mark_trace_head(dcontext, f, f, NULL);
 
         if (future->incoming_stubs != NULL) {
@@ -2918,7 +2922,7 @@ link_new_coarse_grain_fragment(dcontext_t *dcontext, fragment_t *f)
         self_stub = orig_stub;
     if (self_stub != NULL) {
         ASSERT(coarse_is_entrance_stub(self_stub));
-        if (TEST(FRAG_IS_TRACE_HEAD, f->flags)) { /* from future or incoming */
+        if (TESTANY(FRAG_IS_TRACE_HEAD, f->flags)) { /* from future or incoming */
             if (orig_stub == NULL) {
                 /* mark_trace_head didn't know where stub is -- so we must unlink: */
                 ASSERT(!entrance_stub_linked(self_stub, info) ||
@@ -3034,7 +3038,7 @@ link_new_coarse_grain_fragment(dcontext_t *dcontext, fragment_t *f)
             fragment_coarse_th_unlink_and_add(dcontext, f->tag, self_stub,
                                               FCACHE_ENTRY_PC(f));
         }
-        if (!TEST(FRAG_IS_TRACE_HEAD, f->flags)) {
+        if (!TESTANY(FRAG_IS_TRACE_HEAD, f->flags)) {
             LOG(THREAD, LOG_LINKS, 4,
                 "    linking coarse entrance stub to self " PFX "->" PFX "." PFX "\n",
                 self_stub, f->tag, FCACHE_ENTRY_PC(f));
@@ -3070,9 +3074,9 @@ coarse_remove_incoming(dcontext_t *dcontext, fragment_t *src_f, linkstub_t *src_
 {
     coarse_info_t *info = get_fragment_coarse_info(targetf);
     coarse_incoming_t *e, *prev_e;
-    ASSERT(!TEST(FRAG_COARSE_GRAIN, src_f->flags));
+    ASSERT(!TESTANY(FRAG_COARSE_GRAIN, src_f->flags));
     ASSERT(!LINKSTUB_FAKE(src_l));
-    ASSERT(TEST(FRAG_COARSE_GRAIN, targetf->flags));
+    ASSERT(TESTANY(FRAG_COARSE_GRAIN, targetf->flags));
     LOG(THREAD, LOG_LINKS, 4, "coarse_remove_incoming %s " PFX " to " PFX "\n",
         info->module, src_f->tag, targetf->tag);
 
@@ -3358,9 +3362,9 @@ coarse_lazy_link(dcontext_t *dcontext, fragment_t *targetf)
     ASSERT(dcontext->next_tag == targetf->tag);
     if (dcontext->last_exit == get_coarse_exit_linkstub() &&
         /* rule out !is_linkable targets now to avoid work and assert below */
-        TEST(FRAG_SHARED, targetf->flags) &&
-        (!TEST(FRAG_IS_TRACE_HEAD, targetf->flags) ||
-         TEST(FRAG_COARSE_GRAIN, targetf->flags) || DYNAMO_OPTION(disable_traces))) {
+        TESTANY(FRAG_SHARED, targetf->flags) &&
+        (!TESTANY(FRAG_IS_TRACE_HEAD, targetf->flags) ||
+         TESTANY(FRAG_COARSE_GRAIN, targetf->flags) || DYNAMO_OPTION(disable_traces))) {
         /* Source is coarse */
         fragment_t temp_sourcef;
         cache_pc stub;
@@ -3416,12 +3420,12 @@ coarse_lazy_link(dcontext_t *dcontext, fragment_t *targetf)
             }
             release_recursive_lock(&change_linking_lock);
         }
-    } else if (TEST(FRAG_COARSE_GRAIN, targetf->flags)) {
+    } else if (TESTANY(FRAG_COARSE_GRAIN, targetf->flags)) {
         /* Target is coarse */
         linkstub_t *l = dcontext->last_exit;
         fragment_t *f = dcontext->last_fragment;
         if (dcontext->next_tag != EXIT_TARGET_TAG(dcontext, f, l) ||
-            !TEST(FRAG_SHARED, f->flags)) {
+            !TESTANY(FRAG_SHARED, f->flags)) {
             /* Rule out syscall-skip and other cases where we cannot link.
              * is_linkable() should catch, but this way we avoid work and avoid
              * the incoming_link_exists() assert below.
@@ -3430,10 +3434,10 @@ coarse_lazy_link(dcontext_t *dcontext, fragment_t *targetf)
         }
         /* May already be linked (we may have just built its target) */
         if (LINKSTUB_DIRECT(l->flags) && !LINKSTUB_FAKE(l) &&
-            !TEST(FRAG_FAKE, f->flags) && !TEST(LINK_LINKED, l->flags)) {
+            !TESTANY(FRAG_FAKE, f->flags) && !TESTANY(LINK_LINKED, l->flags)) {
             acquire_recursive_lock(&change_linking_lock);
             /* XXX: provide common routine for this: dup of link_fragment_outgoing */
-            if (!TEST(LINK_LINKED, l->flags) /* case 8825: test w/ lock! */ &&
+            if (!TESTANY(LINK_LINKED, l->flags) /* case 8825: test w/ lock! */ &&
                 is_linkable(dcontext, f, l, targetf, true /*have change_linking_lock*/,
                             true /*mark new trace heads*/)) {
                 LOG(THREAD, LOG_LINKS, 4,
@@ -3752,7 +3756,7 @@ coarse_unit_shift_links(dcontext_t *dcontext, coarse_info_t *info)
             app_pc tag = NULL;
             for (l = e->in.fine_l; l != NULL; l = LINKSTUB_NEXT_INCOMING(l)) {
                 /* fine can have incoming structs yet not be linked (trace head, etc.) */
-                if (TEST(LINK_LINKED, l->flags)) {
+                if (TESTANY(LINK_LINKED, l->flags)) {
                     fragment_t *in_f = linkstub_fragment(dcontext, l);
                     if (tag == NULL) {
                         /* unprotect on demand (caller will re-protect) */

--- a/core/link.h
+++ b/core/link.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -274,22 +274,22 @@ typedef struct _coarse_incoming_t {
 } coarse_incoming_t;
 
 /* this one does not take in flags b/c historically we used other fields */
-#define LINKSTUB_FAKE(l) (TEST(LINK_FAKE, (l)->flags))
+#define LINKSTUB_FAKE(l) (TESTANY(LINK_FAKE, (l)->flags))
 /* direct includes normal direct and cbr fallthrough */
-#define LINKSTUB_DIRECT(flags) (TEST(LINK_DIRECT, (flags)))
+#define LINKSTUB_DIRECT(flags) (TESTANY(LINK_DIRECT, (flags)))
 #define LINKSTUB_NORMAL_DIRECT(flags) \
-    (TEST(LINK_DIRECT, (flags)) && !TEST(LINK_INDIRECT, (flags)))
+    (TESTANY(LINK_DIRECT, (flags)) && !TESTANY(LINK_INDIRECT, (flags)))
 #define LINKSTUB_INDIRECT(flags) \
-    (!TEST(LINK_DIRECT, (flags)) && TEST(LINK_INDIRECT, (flags)))
+    (!TESTANY(LINK_DIRECT, (flags)) && TESTANY(LINK_INDIRECT, (flags)))
 #define LINKSTUB_CBR_FALLTHROUGH(flags) \
-    (TEST(LINK_DIRECT, (flags)) && TEST(LINK_INDIRECT, (flags)))
+    (TESTANY(LINK_DIRECT, (flags)) && TESTANY(LINK_INDIRECT, (flags)))
 
 /* used with both LINK_* and INSTR_*_EXIT flags */
-#define EXIT_IS_CALL(flags) (TEST(LINK_CALL, flags) && !TEST(LINK_JMP, flags))
-#define EXIT_IS_JMP(flags) (TEST(LINK_JMP, flags) && !TEST(LINK_CALL, flags))
+#define EXIT_IS_CALL(flags) (TESTANY(LINK_CALL, flags) && !TESTANY(LINK_JMP, flags))
+#define EXIT_IS_JMP(flags) (TESTANY(LINK_JMP, flags) && !TESTANY(LINK_CALL, flags))
 #define EXIT_IS_IND_JMP_PLT(flags) (TESTALL(LINK_JMP | LINK_CALL, flags))
 
-#define LINKSTUB_FINAL(l) (TEST(LINK_END_OF_LIST, (l)->flags))
+#define LINKSTUB_FINAL(l) (TESTANY(LINK_END_OF_LIST, (l)->flags))
 
 /* We assume this combination of flags is unique for coarse proxies. */
 #define LINKSTUB_COARSE_PROXY(flags) \
@@ -357,15 +357,15 @@ typedef struct _coarse_incoming_t {
 #endif
 
 /* indirect exits w/o inlining have no stub at all for -no_indirect_stubs */
-#define EXIT_HAS_STUB(l_flags, f_flags)                                       \
-    (DYNAMO_OPTION(indirect_stubs) || !LINKSTUB_INDIRECT((l_flags)) ||        \
-     (!EXIT_TARGETS_SHARED_SYSCALL(l_flags) &&                                \
-      ((DYNAMO_OPTION(inline_trace_ibl) && TEST(FRAG_IS_TRACE, (f_flags))) || \
-       (DYNAMO_OPTION(inline_bb_ibl) && !TEST(FRAG_IS_TRACE, (f_flags))))))
+#define EXIT_HAS_STUB(l_flags, f_flags)                                          \
+    (DYNAMO_OPTION(indirect_stubs) || !LINKSTUB_INDIRECT((l_flags)) ||           \
+     (!EXIT_TARGETS_SHARED_SYSCALL(l_flags) &&                                   \
+      ((DYNAMO_OPTION(inline_trace_ibl) && TESTANY(FRAG_IS_TRACE, (f_flags))) || \
+       (DYNAMO_OPTION(inline_bb_ibl) && !TESTANY(FRAG_IS_TRACE, (f_flags))))))
 
 /* two cases with no local stub: a separate stub or no stub at all */
 #define EXIT_HAS_LOCAL_STUB(l_flags, f_flags) \
-    (EXIT_HAS_STUB(l_flags, f_flags) && !TEST(LINK_SEPARATE_STUB, (l_flags)))
+    (EXIT_HAS_STUB(l_flags, f_flags) && !TESTANY(LINK_SEPARATE_STUB, (l_flags)))
 
 void
 d_r_link_init(void);

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -948,7 +948,7 @@ redirect_malloc(size_t size)
     ASSERT(HEAP_ALIGNMENT * 2 == STANDARD_HEAP_ALIGNMENT);
 #endif
     /* Our header is the size itself, with the top bit stolen to indicate alignment. */
-    if (TEST(REDIRECT_HEADER_SHIFTED, alloc_size)) {
+    if (TESTANY(REDIRECT_HEADER_SHIFTED, alloc_size)) {
         /* We do not support the top bit being set as that conflicts with the bit in
          * our header.  This should be fine as all sytem allocators we have seen also
          * have size limits that are this size (for 32-bit) or even smaller.
@@ -964,7 +964,7 @@ redirect_malloc(size_t size)
     ptr_uint_t res =
         ALIGN_FORWARD((ptr_uint_t)mem + sizeof(size_t), STANDARD_HEAP_ALIGNMENT);
     size_t header = alloc_size;
-    ASSERT(!TEST(REDIRECT_HEADER_SHIFTED, header));
+    ASSERT(!TESTANY(REDIRECT_HEADER_SHIFTED, header));
     if (res == (ptr_uint_t)mem + sizeof(size_t)) {
         /* Already aligned. */
     } else if (res == (ptr_uint_t)mem + sizeof(size_t) * 2) {
@@ -986,7 +986,7 @@ redirect_malloc_size_and_start(void *mem, DR_PARAM_OUT void **start_out)
     size_t *size_ptr = (size_t *)((ptr_uint_t)mem - sizeof(size_t));
     size_t size = *((size_t *)size_ptr);
     void *start = size_ptr;
-    if (TEST(REDIRECT_HEADER_SHIFTED, size)) {
+    if (TESTANY(REDIRECT_HEADER_SHIFTED, size)) {
         start = size_ptr - 1;
         size &= ~REDIRECT_HEADER_SHIFTED;
     }

--- a/core/module_list.c
+++ b/core/module_list.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -315,7 +315,7 @@ module_list_remove(app_pc base, size_t view_size)
         /* don't notify for drearlyhelper* or other during-init modules */
         && dynamo_initialized
         /* don't notify for modules that were not executed (i#884) */
-        && TEST(MODULE_LOAD_EVENT, ma->flags)) {
+        && TESTANY(MODULE_LOAD_EVENT, ma->flags)) {
         client_data = copy_module_area_to_module_data(ma);
         inform_client = true;
     }

--- a/core/moduledb.c
+++ b/core/moduledb.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -106,18 +106,18 @@ moduledb_process_relaxation_flags(uint flags, const char *name, bool add)
         !TESTANY(~(MODULEDB_ALL_SECTIONS_BITS | MODULEDB_RCT_EXEMPT_TO |
                    MODULEDB_REPORT_ON_LOAD | MODULEDB_DLL2HEAP | MODULEDB_DLL2STACK),
                  flags));
-    if (TEST(MODULEDB_RCT_EXEMPT_TO, flags)) {
+    if (TESTANY(MODULEDB_RCT_EXEMPT_TO, flags)) {
         LOG(GLOBAL, LOG_MODULEDB, 1, "%s module %s to moduledb exempt rct\n",
             add ? "Adding" : "Removing", name);
         moduledb_update_exempt_list(&GET_EXEMPT_LIST(MODULEDB_EXEMPT_RCT), name, add);
     }
-    if (TEST(MODULEDB_DLL2HEAP, flags)) {
+    if (TESTANY(MODULEDB_DLL2HEAP, flags)) {
         LOG(GLOBAL, LOG_MODULEDB, 1, "%s module %s to moduledb exempt dll2heap\n",
             add ? "Adding" : "Removing", name);
         moduledb_update_exempt_list(&GET_EXEMPT_LIST(MODULEDB_EXEMPT_DLL2HEAP), name,
                                     add);
     }
-    if (TEST(MODULEDB_DLL2STACK, flags)) {
+    if (TESTANY(MODULEDB_DLL2STACK, flags)) {
         LOG(GLOBAL, LOG_MODULEDB, 1, "%s module %s to moduledb exempt dll2stack\n",
             add ? "Adding" : "Removing", name);
         moduledb_update_exempt_list(&GET_EXEMPT_LIST(MODULEDB_EXEMPT_DLL2STACK), name,
@@ -215,7 +215,7 @@ moduledb_process_image(const char *name, app_pc base, bool add)
              * usually 5 of these per process, two for logitech mouse hook
              * dlls, 1 for drpreinject and 2 for Norton av. */
             if (add &&
-                TEST(MODULEDB_REPORT_ON_LOAD, DYNAMO_OPTION(unknown_module_policy))) {
+                TESTANY(MODULEDB_REPORT_ON_LOAD, DYNAMO_OPTION(unknown_module_policy))) {
                 /* XXX - will prob. need a release version of this */
                 DODEBUG({
                     DO_THRESHOLD_SAFE(DYNAMO_OPTION(unknown_module_load_report_max),

--- a/core/moduledb.h
+++ b/core/moduledb.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -101,11 +101,12 @@ print_moduledb_exempt_lists(file_t file);
 #    define PROCESS_CONTROL_MODE_ALLOWLIST_INTEGRITY 0x4
 
 #    define IS_PROCESS_CONTROL_MODE_ALLOWLIST() \
-        (TEST(PROCESS_CONTROL_MODE_ALLOWLIST, DYNAMO_OPTION(process_control)))
+        (TESTANY(PROCESS_CONTROL_MODE_ALLOWLIST, DYNAMO_OPTION(process_control)))
 #    define IS_PROCESS_CONTROL_MODE_BLOCKLIST() \
-        (TEST(PROCESS_CONTROL_MODE_BLOCKLIST, DYNAMO_OPTION(process_control)))
-#    define IS_PROCESS_CONTROL_MODE_ALLOWLIST_INTEGRITY() \
-        (TEST(PROCESS_CONTROL_MODE_ALLOWLIST_INTEGRITY, DYNAMO_OPTION(process_control)))
+        (TESTANY(PROCESS_CONTROL_MODE_BLOCKLIST, DYNAMO_OPTION(process_control)))
+#    define IS_PROCESS_CONTROL_MODE_ALLOWLIST_INTEGRITY()  \
+        (TESTANY(PROCESS_CONTROL_MODE_ALLOWLIST_INTEGRITY, \
+                 DYNAMO_OPTION(process_control)))
 #    define IS_PROCESS_CONTROL_ON()                                                    \
         (IS_PROCESS_CONTROL_MODE_ALLOWLIST() || IS_PROCESS_CONTROL_MODE_BLOCKLIST() || \
          IS_PROCESS_CONTROL_MODE_ALLOWLIST_INTEGRITY())

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -79,13 +79,13 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md);
  * we don't support local unprotected so we use global
  */
 /* cannot use HEAPACCT here so we use ... */
-#define COUNTER_ALLOC(dc, ...)                         \
-    (TEST(SELFPROT_LOCAL, dynamo_options.protect_mask) \
-         ? global_unprotected_heap_alloc(__VA_ARGS__)  \
+#define COUNTER_ALLOC(dc, ...)                            \
+    (TESTANY(SELFPROT_LOCAL, dynamo_options.protect_mask) \
+         ? global_unprotected_heap_alloc(__VA_ARGS__)     \
          : heap_alloc(dc, __VA_ARGS__))
-#define COUNTER_FREE(dc, p, ...)                        \
-    (TEST(SELFPROT_LOCAL, dynamo_options.protect_mask)  \
-         ? global_unprotected_heap_free(p, __VA_ARGS__) \
+#define COUNTER_FREE(dc, p, ...)                          \
+    (TESTANY(SELFPROT_LOCAL, dynamo_options.protect_mask) \
+         ? global_unprotected_heap_free(p, __VA_ARGS__)   \
          : heap_free(dc, p, __VA_ARGS__))
 
 static void
@@ -115,7 +115,7 @@ delete_private_copy(dcontext_t *dcontext)
         }
         if (md->last_copy == dcontext->last_fragment)
             last_exit_deleted(dcontext);
-        if (TEST(FRAG_WAS_DELETED, md->last_copy->flags)) {
+        if (TESTANY(FRAG_WAS_DELETED, md->last_copy->flags)) {
             /* case 8083: private copy can't be deleted in trace_abort() since
              * needed for pc translation (at least until -safe_translate_flushed
              * is on by default), so if we come here later we must check
@@ -189,7 +189,7 @@ create_private_copy(dcontext_t *dcontext, fragment_t *f)
         disassemble_fragment(dcontext, md->last_fragment, d_r_stats->loglevel <= 3);
     });
     KSTOP(temp_private_bb);
-    ASSERT(!TEST(FRAG_CANNOT_BE_TRACE, md->last_fragment->flags));
+    ASSERT(!TESTANY(FRAG_CANNOT_BE_TRACE, md->last_fragment->flags));
 }
 
 static void
@@ -204,7 +204,7 @@ extend_unmangled_ilist(dcontext_t *dcontext, fragment_t *f)
          */
         linkstub_t *l;
         ASSERT(md->last_copy != NULL);
-        ASSERT(!TEST(FRAG_COARSE_GRAIN, md->last_copy->flags));
+        ASSERT(!TESTANY(FRAG_COARSE_GRAIN, md->last_copy->flags));
         for (l = FRAGMENT_EXIT_STUBS(md->last_copy); LINKSTUB_NEXT_EXIT(l) != NULL;
              l = LINKSTUB_NEXT_EXIT(l))
             ; /* nothing */
@@ -243,7 +243,7 @@ extend_unmangled_ilist(dcontext_t *dcontext, fragment_t *f)
     /* If any constituent block wants to store (or the final trace hook wants to),
      * then store for the trace.
      */
-    if (md->last_copy != NULL && TEST(FRAG_HAS_TRANSLATION_INFO, md->last_copy->flags))
+    if (md->last_copy != NULL && TESTANY(FRAG_HAS_TRANSLATION_INFO, md->last_copy->flags))
         md->trace_flags |= FRAG_HAS_TRANSLATION_INFO;
 }
 
@@ -445,7 +445,7 @@ reset_trace_state(dcontext_t *dcontext, bool grab_link_lock)
      * consistency). Unset the flag so that a trace can be built from it
      * in the future.
      */
-    if (TEST(FRAG_SHARED, md->trace_flags) && DYNAMO_OPTION(shared_bbs)) {
+    if (TESTANY(FRAG_SHARED, md->trace_flags) && DYNAMO_OPTION(shared_bbs)) {
         /* Look in the shared BB table only since we're only interested
          * if a shared BB is present. */
         fragment_t *bb = fragment_lookup_shared_bb(dcontext, md->trace_tag);
@@ -455,7 +455,7 @@ reset_trace_state(dcontext_t *dcontext, bool grab_link_lock)
          */
         if (grab_link_lock)
             acquire_recursive_lock(&change_linking_lock);
-        if (bb != NULL && TEST(FRAG_TRACE_BUILDING, bb->flags)) {
+        if (bb != NULL && TESTANY(FRAG_TRACE_BUILDING, bb->flags)) {
             /* The regenerate scenario is still racy w/respect to clearing the
              * flag. The regenerated fragment could have another thread building
              * a trace from it so the clear would be for the the wrong thread
@@ -529,7 +529,7 @@ monitor_remove_fragment(dcontext_t *dcontext, fragment_t *f)
     monitor_data_t *md;
     /* may be a global fragment -- but we still want our local trace data */
     if (dcontext == GLOBAL_DCONTEXT) {
-        ASSERT(TEST(FRAG_SHARED, f->flags));
+        ASSERT(TESTANY(FRAG_SHARED, f->flags));
         dcontext = get_thread_private_dcontext();
         /* may still be null if exiting process -- in which case a nop for us */
         if (dcontext == NULL) {
@@ -559,7 +559,7 @@ monitor_remove_fragment(dcontext_t *dcontext, fragment_t *f)
      * related.
      */
     if ((md->last_fragment == f || dcontext->last_fragment == f) &&
-        !TEST(FRAG_TEMP_PRIVATE, f->flags)) {
+        !TESTANY(FRAG_TEMP_PRIVATE, f->flags)) {
         if (md->trace_tag != NULL) {
             LOG(THREAD, LOG_MONITOR, 2, "Aborting current trace since F%d was deleted\n",
                 f->id);
@@ -579,9 +579,9 @@ monitor_remove_fragment(dcontext_t *dcontext, fragment_t *f)
 static inline void
 unlink_ibt_trace_head(dcontext_t *dcontext, fragment_t *f)
 {
-    ASSERT(TEST(FRAG_IS_TRACE_HEAD, f->flags));
+    ASSERT(TESTANY(FRAG_IS_TRACE_HEAD, f->flags));
     if (DYNAMO_OPTION(shared_bb_ibt_tables)) {
-        ASSERT(TEST(FRAG_SHARED, f->flags));
+        ASSERT(TESTANY(FRAG_SHARED, f->flags));
         if (fragment_prepare_for_removal(GLOBAL_DCONTEXT, f)) {
             LOG(THREAD, LOG_FRAGMENT, 3, "  F%d(" PFX ") removed as trace head IBT\n",
                 f->id, f->tag);
@@ -616,7 +616,7 @@ unlink_ibt_trace_head(dcontext_t *dcontext, fragment_t *f)
                 i + 1, num_threads, threads[i]->id);
             ASSERT(is_thread_known(tgt_dcontext->owning_thread));
             fragment_prepare_for_removal(
-                TEST(FRAG_SHARED, f->flags) ? GLOBAL_DCONTEXT : tgt_dcontext, f);
+                TESTANY(FRAG_SHARED, f->flags) ? GLOBAL_DCONTEXT : tgt_dcontext, f);
         }
         global_heap_free(
             threads, num_threads * sizeof(thread_record_t *) HEAPACCT(ACCT_THREAD_MGT));
@@ -642,7 +642,7 @@ mark_trace_head(dcontext_t *dcontext_in, fragment_t *f, fragment_t *src_f,
     ASSERT(dcontext != NULL);
 
     LOG(THREAD, LOG_MONITOR, 3, "marking F%d (" PFX ") as trace head\n", f->id, f->tag);
-    ASSERT(!TEST(FRAG_IS_TRACE, f->flags));
+    ASSERT(!TESTANY(FRAG_IS_TRACE, f->flags));
     ASSERT(!NEED_SHARED_LOCK(f->flags) || self_owns_recursive_lock(&change_linking_lock));
 
     if (thcounter_lookup(dcontext, f->tag) == NULL) {
@@ -667,7 +667,7 @@ mark_trace_head(dcontext_t *dcontext_in, fragment_t *f, fragment_t *src_f,
     LOG(THREAD, LOG_MONITOR, 4, "unlinking incoming for new trace head F%d (" PFX ")\n",
         f->id, f->tag);
 
-    if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
         /* For coarse trace heads, trace headness depends on the path taken
          * (more specifically, on the entrance stub taken).  If we don't have
          * any info on src_f we use f's unit.
@@ -685,8 +685,8 @@ mark_trace_head(dcontext_t *dcontext_in, fragment_t *f, fragment_t *src_f,
              * shouldn't happen, except perhaps with clients.
              */
             ASSERT(src_f != NULL || !info->frozen);
-            if (src_f != NULL && TEST(FRAG_COARSE_GRAIN, src_f->flags) && src_l != NULL &&
-                LINKSTUB_NORMAL_DIRECT(src_l->flags)) {
+            if (src_f != NULL && TESTANY(FRAG_COARSE_GRAIN, src_f->flags) &&
+                src_l != NULL && LINKSTUB_NORMAL_DIRECT(src_l->flags)) {
                 direct_linkstub_t *dl = (direct_linkstub_t *)src_l;
                 if (dl->stub_pc != NULL && coarse_is_entrance_stub(dl->stub_pc)) {
                     if (coarse_stub == NULL) {
@@ -734,7 +734,7 @@ mark_trace_head(dcontext_t *dcontext_in, fragment_t *f, fragment_t *src_f,
                 /* id comparison could have a race w/ private frag gen so a curiosity */
                 ASSERT_CURIOSITY(
                     GLOBAL_STAT(num_fragments) == f->id ||
-                    (src_f != NULL && !TEST(FRAG_COARSE_GRAIN, src_f->flags)));
+                    (src_f != NULL && !TESTANY(FRAG_COARSE_GRAIN, src_f->flags)));
             }
         }
     } else
@@ -776,8 +776,8 @@ should_be_trace_head_internal_unsafe(dcontext_t *dcontext, fragment_t *from_f,
     app_pc from_tag;
     uint from_flags;
 
-    if (DYNAMO_OPTION(disable_traces) || TEST(FRAG_IS_TRACE, to_flags) ||
-        TEST(FRAG_IS_TRACE_HEAD, to_flags) || TEST(FRAG_CANNOT_BE_TRACE, to_flags))
+    if (DYNAMO_OPTION(disable_traces) || TESTANY(FRAG_IS_TRACE, to_flags) ||
+        TESTANY(FRAG_IS_TRACE_HEAD, to_flags) || TESTANY(FRAG_CANNOT_BE_TRACE, to_flags))
         return false;
 
     /* We know that the to_flags pass the test. */
@@ -796,14 +796,14 @@ should_be_trace_head_internal_unsafe(dcontext_t *dcontext, fragment_t *from_f,
      * head and trace boundaries for custom traces.
      */
     /* trace heads can be created across private/shared cache bounds */
-    if (TEST(FRAG_IS_TRACE, from_flags) ||
+    if (TESTANY(FRAG_IS_TRACE, from_flags) ||
         (to_tag <= from_tag && LINKSTUB_DIRECT(from_l->flags)))
         return true;
 
     DOSTATS({
-        if (!DYNAMO_OPTION(disable_traces) && !TEST(FRAG_IS_TRACE, to_flags) &&
-            !TEST(FRAG_IS_TRACE_HEAD, to_flags) &&
-            !TEST(FRAG_CANNOT_BE_TRACE, to_flags)) {
+        if (!DYNAMO_OPTION(disable_traces) && !TESTANY(FRAG_IS_TRACE, to_flags) &&
+            !TESTANY(FRAG_IS_TRACE_HEAD, to_flags) &&
+            !TESTANY(FRAG_CANNOT_BE_TRACE, to_flags)) {
             STATS_INC(num_wannabe_traces);
         }
     });
@@ -892,9 +892,9 @@ check_for_trace_head(dcontext_t *dcontext, fragment_t *from_f, linkstub_t *from_
         uint th = should_be_trace_head_internal(dcontext, from_f, from_l, to_f->tag,
                                                 to_f->flags, have_link_lock,
                                                 trace_sysenter_exit);
-        if (TEST(TRACE_HEAD_YES, th)) {
+        if (TESTANY(TRACE_HEAD_YES, th)) {
             mark_trace_head(dcontext, to_f, from_f, from_l);
-            if (TEST(TRACE_HEAD_OBTAINED_LOCK, th))
+            if (TESTANY(TRACE_HEAD_OBTAINED_LOCK, th))
                 release_recursive_lock(&change_linking_lock);
             return true;
         }
@@ -913,21 +913,21 @@ monitor_is_linkable(dcontext_t *dcontext, fragment_t *from_f, linkstub_t *from_l
                     fragment_t *to_f, bool have_link_lock, bool mark_new_trace_head)
 {
     /* common case: both traces */
-    if (TEST(FRAG_IS_TRACE, from_f->flags) && TEST(FRAG_IS_TRACE, to_f->flags))
+    if (TESTANY(FRAG_IS_TRACE, from_f->flags) && TESTANY(FRAG_IS_TRACE, to_f->flags))
         return true;
     if (DYNAMO_OPTION(disable_traces))
         return true;
 #ifndef TRACE_HEAD_CACHE_INCR
     /* no link case -- block is a trace head */
-    if (TEST(FRAG_IS_TRACE_HEAD, to_f->flags) && !DYNAMO_OPTION(disable_traces))
+    if (TESTANY(FRAG_IS_TRACE_HEAD, to_f->flags) && !DYNAMO_OPTION(disable_traces))
         return false;
 #endif
     if (mark_new_trace_head) {
         uint th = should_be_trace_head(dcontext, from_f, from_l, to_f->tag, to_f->flags,
                                        have_link_lock);
-        if (TEST(TRACE_HEAD_YES, th)) {
+        if (TESTANY(TRACE_HEAD_YES, th)) {
             mark_trace_head(dcontext, to_f, from_f, from_l);
-            if (TEST(TRACE_HEAD_OBTAINED_LOCK, th))
+            if (TESTANY(TRACE_HEAD_OBTAINED_LOCK, th))
                 release_recursive_lock(&change_linking_lock);
 #ifdef TRACE_HEAD_CACHE_INCR
             /* fine to link to trace head
@@ -1083,8 +1083,8 @@ get_and_check_add_size(dcontext_t *dcontext, fragment_t *f, uint *res_add_size,
     uint total_size = md->emitted_size + add_size + prev_mangle_size;
     /* check whether adding f will push the trace over the edge */
     bool ok = (total_size <= MAX_FRAGMENT_SIZE);
-    ASSERT(!TEST(FRAG_SELFMOD_SANDBOXED, f->flags)); /* no support for selfmod */
-    ASSERT(!TEST(FRAG_IS_TRACE, f->flags));          /* no support for traces */
+    ASSERT(!TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)); /* no support for selfmod */
+    ASSERT(!TESTANY(FRAG_IS_TRACE, f->flags));          /* no support for traces */
     LOG(THREAD, LOG_MONITOR, 4,
         "checking trace size: currently %d, add estimate %d\n"
         "\t(body: %d, stubs: %d, pad: %d, mangle est: %d)\n"
@@ -1166,7 +1166,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
                     STATS_INC(num_traces_end_at_ibl_syscall);
                 else
                     STATS_INC(num_traces_end_at_ibl_ind_jump);
-            } else if (TEST(LINK_RETURN, dcontext->last_exit->flags)) {
+            } else if (TESTANY(LINK_RETURN, dcontext->last_exit->flags)) {
                 STATS_INC(num_traces_end_at_ibl_return);
             };
         }
@@ -1179,7 +1179,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
         dr_emit_flags_t emitflags =
             instrument_trace(dcontext, tag, &md->unmangled_ilist, false /*!recreating*/);
         DODEBUG(externally_mangled = true;);
-        if (TEST(DR_EMIT_STORE_TRANSLATIONS, emitflags)) {
+        if (TESTANY(DR_EMIT_STORE_TRANSLATIONS, emitflags)) {
             /* PR 214962: let client request storage instead of recreation */
             md->trace_flags |= FRAG_HAS_TRANSLATION_INFO;
         } /* else, leave translation flag if any bb requested it */
@@ -1225,7 +1225,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
          * emit_fragment_common().  That way both bb's and traces may
          * have speculation added.
          */
-        if (TEST(FRAG_MUST_END_TRACE, cur_f->flags)) {
+        if (TESTANY(FRAG_MUST_END_TRACE, cur_f->flags)) {
             /* This routine may be also reached on MUST_END_TRACE
              * and in that case we haven't executed yet the last
              * bb, so don't really know how to fix the last IBL
@@ -1331,14 +1331,14 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
      * moment and if there's a conflict the loser tosses his trace.
      * We hold the lock across the trace head removal as well to avoid races there.
      */
-    if (TEST(FRAG_SHARED, md->trace_flags)) {
+    if (TESTANY(FRAG_SHARED, md->trace_flags)) {
         ASSERT(DYNAMO_OPTION(shared_traces));
         d_r_mutex_lock(&trace_building_lock);
         /* we left the bb there, so we rely on any shared trace shadowing it */
         trace_f = fragment_lookup_trace(dcontext, tag);
         if (trace_f != NULL) {
             /* someone beat us to it!  tough luck -- throw it all away */
-            ASSERT(TEST(FRAG_IS_TRACE, trace_f->flags));
+            ASSERT(TESTANY(FRAG_IS_TRACE, trace_f->flags));
             d_r_mutex_unlock(&trace_building_lock);
             trace_abort(dcontext);
             STATS_INC(num_aborted_traces_race);
@@ -1369,7 +1369,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
      */
     if (cur_f != NULL && cur_f->tag == tag) {
         /* Optimization: could repeat for shared as well but we don't bother */
-        if (!TEST(FRAG_SHARED, cur_f->flags))
+        if (!TESTANY(FRAG_SHARED, cur_f->flags))
             trace_head_f = cur_f;
         /* Yipes, we're deleting the fragment we're supposed to execute next.
          * Set cur_f to NULL even if not deleted, since we want to
@@ -1394,7 +1394,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
          * shadow it.  If the trace is shared, we have to delete it.  We'll re-create
          * the head as a shared bb if we ever do build a custom trace through it.
          */
-        if (!TEST(FRAG_SHARED, md->trace_flags)) {
+        if (!TESTANY(FRAG_SHARED, md->trace_flags)) {
             replace_trace_head = true;
             /* we can't have our trace_head_f clobbered below */
             CLIENT_ASSERT(!DYNAMO_OPTION(shared_bbs),
@@ -1413,15 +1413,15 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
     if (DYNAMO_OPTION(shared_bbs)) {
         trace_head_f = fragment_lookup_fine_and_coarse_sharing(dcontext, tag, &wrapper,
                                                                NULL, FRAG_SHARED);
-        if (!TEST(FRAG_SHARED, md->trace_flags)) {
+        if (!TESTANY(FRAG_SHARED, md->trace_flags)) {
             /* trace is private, so we can emit as a shadow of trace head */
         } else if (trace_head_f != NULL) {
             /* we don't remove until after emitting a shared trace to avoid races
              * with trace head being re-created before the trace is visible
              */
             replace_trace_head = true;
-            if (!TEST(FRAG_IS_TRACE_HEAD, trace_head_f->flags)) {
-                ASSERT(TEST(FRAG_COARSE_GRAIN, trace_head_f->flags));
+            if (!TESTANY(FRAG_IS_TRACE_HEAD, trace_head_f->flags)) {
+                ASSERT(TESTANY(FRAG_COARSE_GRAIN, trace_head_f->flags));
                 /* local wrapper so change_linking_lock not needed to change flags */
                 trace_head_f->flags |= FRAG_IS_TRACE_HEAD;
             }
@@ -1475,7 +1475,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
     for (i = 0; i < md->num_blks; i++)
         trace_tr->bbs[i] = md->blk_info[i].info;
 
-    if (TEST(FRAG_SHARED, md->trace_flags))
+    if (TESTANY(FRAG_SHARED, md->trace_flags))
         d_r_mutex_unlock(&trace_building_lock);
 
     RSTATS_INC(num_traces);
@@ -1512,12 +1512,12 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
      */
     /* remove shared trace head fragment */
     if (trace_head_f != NULL && DYNAMO_OPTION(shared_bbs) &&
-        TEST(FRAG_SHARED, md->trace_flags) &&
+        TESTANY(FRAG_SHARED, md->trace_flags) &&
         /* We leave the head in the coarse table and let the trace shadow it.
          * If we were to remove it we would need a solution to finding it for
          * pc translation, which currently walks the htable.
          */
-        !TEST(FRAG_COARSE_GRAIN, trace_head_f->flags) &&
+        !TESTANY(FRAG_COARSE_GRAIN, trace_head_f->flags) &&
         /* if both shared only remove if option on, and no custom tracing */
         !dr_end_trace_hook_exists() && INTERNAL_OPTION(remove_shared_trace_heads)) {
         fragment_remove_shared_no_flush(dcontext, trace_head_f);
@@ -1530,7 +1530,8 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
         for (i = 1 /*skip trace head*/; i < md->num_blks; i++) {
             f = fragment_lookup_bb(dcontext, md->blk_info[i].info.tag);
             if (f != NULL) {
-                if (TEST(FRAG_SHARED, f->flags) && !TEST(FRAG_COARSE_GRAIN, f->flags)) {
+                if (TESTANY(FRAG_SHARED, f->flags) &&
+                    !TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
                     /* XXX: grab locks up front instead of on each delete */
                     fragment_remove_shared_no_flush(dcontext, f);
                     trace_head_f = NULL; /* be safe */
@@ -1555,7 +1556,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
      * to reset_trace_state() just above.
      */
     if (trace_head_f != NULL)
-        ASSERT(!TEST(FRAG_TRACE_BUILDING, trace_head_f->flags));
+        ASSERT(!TESTANY(FRAG_TRACE_BUILDING, trace_head_f->flags));
 #endif
 
 end_and_emit_trace_return:
@@ -1595,7 +1596,7 @@ internal_extend_trace(dcontext_t *dcontext, fragment_t *f, linkstub_t *prev_l,
            /* we track the ordinal of the del linkstub so it's ok */
            prev_l == get_deleted_linkstub(dcontext));
 
-    if (TEST(FRAG_SHARED, f->flags)) {
+    if (TESTANY(FRAG_SHARED, f->flags)) {
         /* Case 8419: we must hold a lock to ensure f is not
          * fragment_remove_shared_no_flush()-ed underneath us, eliminating its
          * also fields needed for vm_area_add_to_list() (plus w/ the also field
@@ -1606,7 +1607,7 @@ internal_extend_trace(dcontext_t *dcontext, fragment_t *f, linkstub_t *prev_l,
         SHARED_FLAGS_RECURSIVE_LOCK(f->flags, acquire, change_linking_lock);
         acquire_vm_areas_lock(dcontext, f->flags);
     }
-    if (TEST(FRAG_WAS_DELETED, f->flags)) {
+    if (TESTANY(FRAG_WAS_DELETED, f->flags)) {
         /* We cannot continue if f is FRAG_WAS_DELETED (case 8419) since
          * fragment_t.also is now invalid!
          */
@@ -1658,7 +1659,7 @@ internal_extend_trace(dcontext_t *dcontext, fragment_t *f, linkstub_t *prev_l,
     /* For FRAG_MUST_END_TRACE fragments emit trace immediately to prevent
      * trace aborts due to syscalls and callbacks.  See case 3541.
      */
-    if (TEST(FRAG_MUST_END_TRACE, f->flags)) {
+    if (TESTANY(FRAG_MUST_END_TRACE, f->flags)) {
         /* We don't need to unlink f, but we would need to set FRAG_CANNOT_DELETE to
          * prevent its deletion during emitting from clobbering the trace in the case
          * that last_fragment==f (requires that f targets itself, and f is
@@ -1670,8 +1671,8 @@ internal_extend_trace(dcontext_t *dcontext, fragment_t *f, linkstub_t *prev_l,
         return end_and_emit_trace(dcontext, f);
     }
 
-    ASSERT(!TEST(FRAG_SHARED, f->flags));
-    if (TEST(FRAG_TEMP_PRIVATE, f->flags)) {
+    ASSERT(!TESTANY(FRAG_SHARED, f->flags));
+    if (TESTANY(FRAG_TEMP_PRIVATE, f->flags)) {
         /* We make a private copy earlier for everything other than a normal
          * thread private fragment.
          */
@@ -1754,7 +1755,7 @@ internal_restore_last(dcontext_t *dcontext)
      * Do NOT reset last_fragment_flags as that field is needed prior to the
      * cache entry and is referenced in monitor_cache_enter().
      */
-    if (!TEST(FRAG_TEMP_PRIVATE, md->last_fragment->flags))
+    if (!TESTANY(FRAG_TEMP_PRIVATE, md->last_fragment->flags))
         md->last_fragment = NULL;
 }
 
@@ -1793,8 +1794,8 @@ monitor_cache_exit(dcontext_t *dcontext)
          * trace head marking within should_be_trace_head().
          */
         dcontext->trace_sysenter_exit =
-            (TEST(FRAG_IS_TRACE, dcontext->last_fragment->flags) &&
-             TEST(LINK_NI_SYSCALL, dcontext->last_exit->flags));
+            (TESTANY(FRAG_IS_TRACE, dcontext->last_fragment->flags) &&
+             TESTANY(LINK_NI_SYSCALL, dcontext->last_exit->flags));
     }
     dcontext->whereami = DR_WHERE_DISPATCH;
 }
@@ -1809,7 +1810,7 @@ check_fine_to_coarse_trace_head(dcontext_t *dcontext, fragment_t *f)
      * discovered at link time iff it would now be considered a trace head.
      * XXX: any cleaner way?
      */
-    if (TEST(FRAG_COARSE_GRAIN, f->flags) && !TEST(FRAG_IS_TRACE_HEAD, f->flags) &&
+    if (TESTANY(FRAG_COARSE_GRAIN, f->flags) && !TESTANY(FRAG_IS_TRACE_HEAD, f->flags) &&
         /* XXX: We rule out empty fragments -- but in so doing we rule out deleted
          * fragments.  Oh well.
          */
@@ -1868,11 +1869,11 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
         SELF_PROTECT_LOCAL(dcontext, WRITABLE);
         /* should have restored last fragment on cache exit */
         ASSERT(md->last_fragment == NULL ||
-               TEST(FRAG_TEMP_PRIVATE, md->last_fragment->flags));
+               TESTANY(FRAG_TEMP_PRIVATE, md->last_fragment->flags));
 
         /* check for trace ending conditions that can be overridden by client */
-        end_trace = (end_trace || TEST(FRAG_IS_TRACE, f->flags) ||
-                     TEST(FRAG_IS_TRACE_HEAD, f->flags));
+        end_trace = (end_trace || TESTANY(FRAG_IS_TRACE, f->flags) ||
+                     TESTANY(FRAG_IS_TRACE_HEAD, f->flags));
         if (dr_end_trace_hook_exists()) {
             client = instrument_end_trace(dcontext, md->trace_tag, f->tag);
             /* Return values:
@@ -1905,17 +1906,17 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                 client);
         }
         /* check for conditions signaling end of trace regardless of client */
-        end_trace = end_trace || TEST(FRAG_CANNOT_BE_TRACE, f->flags);
+        end_trace = end_trace || TESTANY(FRAG_CANNOT_BE_TRACE, f->flags);
 
 #if defined(X86) && defined(X64)
         /* no traces that mix 32 and 64: decode_fragment not set up for it */
-        if (TEST(FRAG_32_BIT, f->flags) != TEST(FRAG_32_BIT, md->trace_flags))
+        if (TESTANY(FRAG_32_BIT, f->flags) != TESTANY(FRAG_32_BIT, md->trace_flags))
             end_trace = true;
 #endif
 
         if (!end_trace) {
             /* we need a regular bb here, not a trace */
-            if (TEST(FRAG_IS_TRACE, f->flags)) {
+            if (TESTANY(FRAG_IS_TRACE, f->flags)) {
                 /* We create an official, shared bb (we DO want to call the client bb
                  * hook, right?).  We do not link the new, shadowed bb.
                  */
@@ -1952,7 +1953,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                      * was made then the trace should have been flushed.
                      */
                     ASSERT((head->flags & FRAG_SHARED) == (f->flags & FRAG_SHARED));
-                    if (TEST(FRAG_COARSE_GRAIN, head->flags)) {
+                    if (TESTANY(FRAG_COARSE_GRAIN, head->flags)) {
                         /* we need a local copy before releasing the lock.
                          * XXX: share this code sequence w/ d_r_dispatch().
                          */
@@ -1968,7 +1969,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                 /* use the bb from here on out */
                 f = head;
             }
-            if (TEST(FRAG_COARSE_GRAIN, f->flags) || TEST(FRAG_SHARED, f->flags) ||
+            if (TESTANY(FRAG_COARSE_GRAIN, f->flags) || TESTANY(FRAG_SHARED, f->flags) ||
                 md->pass_to_client) {
                 /* We need linkstub_t info for trace_exit_stub_size_diff() so we go
                  * ahead and make a private copy here.
@@ -2050,13 +2051,13 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
 
     /* searching for a hot trace head */
 
-    if (TEST(FRAG_IS_TRACE, f->flags)) {
+    if (TESTANY(FRAG_IS_TRACE, f->flags)) {
         /* nothing to do */
         dcontext->whereami = DR_WHERE_DISPATCH;
         return f;
     }
 
-    if (!TEST(FRAG_IS_TRACE_HEAD, f->flags)) {
+    if (!TESTANY(FRAG_IS_TRACE_HEAD, f->flags)) {
 
         bool trace_head;
 
@@ -2128,21 +2129,21 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
     if (ctr->counter >= INTERNAL_OPTION(trace_threshold)) {
         /* if cannot delete fragment, do not start trace -- wait until
          * can delete it (w/ exceptions, deletion status changes). */
-        if (!TEST(FRAG_CANNOT_DELETE, f->flags)) {
+        if (!TESTANY(FRAG_CANNOT_DELETE, f->flags)) {
             if (!DYNAMO_OPTION(shared_traces))
                 start_trace = true;
             /* XXX To detect a trace building race w/private BBs at this point,
              * we need a presence table to mark that a tag is being used for trace
              * building. Generic hashtables can help with this (case 6206).
              */
-            else if (!DYNAMO_OPTION(shared_bbs) || !TEST(FRAG_SHARED, f->flags))
+            else if (!DYNAMO_OPTION(shared_bbs) || !TESTANY(FRAG_SHARED, f->flags))
                 start_trace = true;
             else {
                 /* Check if trace building is in progress and act accordingly. */
-                ASSERT(TEST(FRAG_SHARED, f->flags));
+                ASSERT(TESTANY(FRAG_SHARED, f->flags));
                 /* Hold the change linking lock for flags changes. */
                 acquire_recursive_lock(&change_linking_lock);
-                if (TEST(FRAG_TRACE_BUILDING, f->flags)) {
+                if (TESTANY(FRAG_TRACE_BUILDING, f->flags)) {
                     /* trace_t building w/this tag is already in-progress. */
                     LOG(THREAD, LOG_MONITOR, 3,
                         "Not going to start trace with already-in-trace-progress F%d "
@@ -2172,9 +2173,9 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
         ASSERT(instrlist_first(&md->unmangled_ilist) == NULL);
     }
     if (start_trace &&
-        (TEST(FRAG_COARSE_GRAIN, f->flags) || TEST(FRAG_SHARED, f->flags) ||
+        (TESTANY(FRAG_COARSE_GRAIN, f->flags) || TESTANY(FRAG_SHARED, f->flags) ||
          md->pass_to_client)) {
-        ASSERT(TEST(FRAG_IS_TRACE_HEAD, f->flags));
+        ASSERT(TESTANY(FRAG_IS_TRACE_HEAD, f->flags));
         /* We need linkstub_t info for trace_exit_stub_size_diff() so we go
          * ahead and make a private copy here.
          * For shared fragments, we make a private copy of f to avoid
@@ -2230,7 +2231,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
         LOG(THREAD, LOG_MONITOR, 3, "Entering trace selection mode\n");
         /* allocate trace buffer space */
         /* we should have a bb here, since if a trace can't also be a trace head */
-        ASSERT(!TEST(FRAG_IS_TRACE, f->flags));
+        ASSERT(!TESTANY(FRAG_IS_TRACE, f->flags));
         if (!get_and_check_add_size(dcontext, f, &add_size, &prev_mangle_size) ||
             /* mangling may never use trace buffer memory but just in case */
             !make_room_in_trace_buffer(
@@ -2351,7 +2352,7 @@ get_trace_exit_component_tag(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     app_pc tag = f->tag;
     bool found = false;
     trace_only_t *t = TRACE_FIELDS(f);
-    ASSERT(TEST(FRAG_IS_TRACE, f->flags));
+    ASSERT(TESTANY(FRAG_IS_TRACE, f->flags));
     ASSERT(linkstub_fragment(dcontext, l) == f);
     for (stub = FRAGMENT_EXIT_STUBS(f); stub != NULL; stub = LINKSTUB_NEXT_EXIT(stub)) {
         if (stub == l) {

--- a/core/nudge.c
+++ b/core/nudge.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -224,7 +224,7 @@ generic_nudge_handler(nudge_arg_t *arg_dont_use)
     nudge_action_mask = safe_arg.nudge_action_mask;
 
     /* if needed tell thread exit to free the application stack */
-    if (!TEST(NUDGE_NUDGER_FREE_STACK, safe_arg.flags)) {
+    if (!TESTANY(NUDGE_NUDGER_FREE_STACK, safe_arg.flags)) {
         dcontext->free_app_stack = true;
     }
 
@@ -270,7 +270,7 @@ generic_nudge_handler(nudge_arg_t *arg_dont_use)
     }
 
     /* Free the arg if requested. */
-    if (TEST(NUDGE_FREE_ARG, safe_arg.flags)) {
+    if (TESTANY(NUDGE_FREE_ARG, safe_arg.flags)) {
         nt_free_virtual_memory(arg_dont_use);
     }
 
@@ -316,7 +316,7 @@ handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
      * case 8888. */
 #define VALID_THIN_CLIENT_NUDGES (NUDGE_GENERIC(process_control) | NUDGE_GENERIC(detach))
     if (DYNAMO_OPTION(thin_client)) {
-        if (TEST(VALID_THIN_CLIENT_NUDGES, nudge_action_mask)) {
+        if (TESTANY(VALID_THIN_CLIENT_NUDGES, nudge_action_mask)) {
             /* If it is a valid thin client nudge, then disable all others. */
             nudge_action_mask &= VALID_THIN_CLIENT_NUDGES;
         } else {
@@ -325,67 +325,67 @@ handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
     }
 
     /* TODO: NYI action handlers. As implemented move to desired order. */
-    if (TEST(NUDGE_GENERIC(upgrade), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(upgrade), nudge_action_mask)) {
         /* XXX: watch out for flushed clean-call fragment */
         nudge_action_mask &= ~NUDGE_GENERIC(upgrade);
         ASSERT_NOT_IMPLEMENTED(false && "case 4179");
     }
-    if (TEST(NUDGE_GENERIC(kstats), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(kstats), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(kstats);
         ASSERT_NOT_IMPLEMENTED(false);
     }
 #ifdef INTERNAL
-    if (TEST(NUDGE_GENERIC(stats), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(stats), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(stats);
         ASSERT_NOT_IMPLEMENTED(false);
     }
-    if (TEST(NUDGE_GENERIC(invalidate), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(invalidate), nudge_action_mask)) {
         /* XXX: watch out for flushed clean-call fragment  */
         nudge_action_mask &= ~NUDGE_GENERIC(invalidate);
         ASSERT_NOT_IMPLEMENTED(false);
     }
-    if (TEST(NUDGE_GENERIC(recreate_pc), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(recreate_pc), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(recreate_pc);
         ASSERT_NOT_IMPLEMENTED(false);
     }
-    if (TEST(NUDGE_GENERIC(recreate_state), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(recreate_state), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(recreate_state);
         ASSERT_NOT_IMPLEMENTED(false);
     }
-    if (TEST(NUDGE_GENERIC(reattach), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(reattach), nudge_action_mask)) {
         /* XXX: watch out for flushed clean-call fragment */
         nudge_action_mask &= ~NUDGE_GENERIC(reattach);
         ASSERT_NOT_IMPLEMENTED(false);
     }
 #endif /* INTERNAL */
-    if (TEST(NUDGE_GENERIC(diagnose), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(diagnose), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(diagnose);
         ASSERT_NOT_IMPLEMENTED(false);
     }
 
     /* Implemented action handlers */
-    if (TEST(NUDGE_GENERIC(opt), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(opt), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(opt);
         synchronize_dynamic_options();
     }
-    if (TEST(NUDGE_GENERIC(ldmp), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(ldmp), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(ldmp);
         os_dump_core("Nudge triggered ldmp.");
     }
-    if (TEST(NUDGE_GENERIC(freeze), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(freeze), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(freeze);
         coarse_units_freeze_all(true /*in-place: XXX: separate nudge for non?*/);
     }
-    if (TEST(NUDGE_GENERIC(persist), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(persist), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(persist);
         coarse_units_freeze_all(false /*!in-place==persist*/);
     }
-    if (TEST(NUDGE_GENERIC(client), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(client), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(client);
         instrument_nudge(dcontext, arg->client_id, arg->client_arg);
     }
 #ifdef PROCESS_CONTROL
-    if (TEST(NUDGE_GENERIC(process_control), nudge_action_mask)) { /* Case 8594 */
+    if (TESTANY(NUDGE_GENERIC(process_control), nudge_action_mask)) { /* Case 8594 */
         nudge_action_mask &= ~NUDGE_GENERIC(process_control);
         /* Need to synchronize because process control can be switched between
          * on (allow or block list) & off.  XXX - the nudge mask should specify this,
@@ -412,7 +412,7 @@ handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
     }
 #endif
 #ifdef PROGRAM_SHEPHERDING
-    if (TEST(NUDGE_GENERIC(violation), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(violation), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(violation);
         /* Use nudge mechanism to trigger a security violation at an
          * arbitrary time. Note - is only useful for testing kill process attack
@@ -422,7 +422,7 @@ handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
                            OPTION_BLOCK | OPTION_REPORT);
     }
 #endif
-    if (TEST(NUDGE_GENERIC(reset), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(reset), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(reset);
         if (DYNAMO_OPTION(enable_reset)) {
             d_r_mutex_lock(&reset_pending_lock);
@@ -436,7 +436,7 @@ handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
     }
 #if defined(WINDOWS) || defined(LINUX)
     /* The detach handler is last since in the common case it doesn't return. */
-    if (TEST(NUDGE_GENERIC(detach), nudge_action_mask)) {
+    if (TESTANY(NUDGE_GENERIC(detach), nudge_action_mask)) {
 #    ifdef WINDOWS
         dcontext->free_app_stack = false;
         nudge_action_mask &= ~NUDGE_GENERIC(detach);

--- a/core/options.c
+++ b/core/options.c
@@ -1217,7 +1217,7 @@ check_list_default_and_append(liststring_t default_list, liststring_t append_lis
 /* security options have to be enabled to be blocking or reporting */
 #    define SECURITY_OPTION_CONSISTENT(security_option)                                  \
         do {                                                                             \
-            if (!TEST(OPTION_ENABLED, DYNAMO_OPTION(security_option)) &&                 \
+            if (!TESTANY(OPTION_ENABLED, DYNAMO_OPTION(security_option)) &&              \
                 TESTANY(OPTION_BLOCK | OPTION_REPORT, DYNAMO_OPTION(security_option))) { \
                 USAGE_ERROR("Incompatible settings for %s", #security_option);           \
                 dynamo_options.security_option = OPTION_DISABLED;                        \
@@ -1322,23 +1322,23 @@ check_option_compatibility_helper(int recurse_count)
     if (
 #    ifdef WINDOWS
         /* XXX: CACHE isn't multithread safe yet */
-        TEST(SELFPROT_CACHE, dynamo_options.protect_mask) ||
+        TESTANY(SELFPROT_CACHE, dynamo_options.protect_mask) ||
 #    endif
         /* XXX: LOCAL has some unresolved issues w/ new heap units, etc. */
-        TEST(SELFPROT_LOCAL, dynamo_options.protect_mask) ||
-        TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+        TESTANY(SELFPROT_LOCAL, dynamo_options.protect_mask) ||
+        TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         ASSERT_NOT_TESTED();
     }
     /* warn of incompatible options */
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask) &&
-        !TEST(SELFPROT_GLOBAL, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask) &&
+        !TESTANY(SELFPROT_GLOBAL, dynamo_options.protect_mask)) {
         USAGE_ERROR("dcontext is only actually protected if global is as well");
         /* XXX: turn off dcontext?  or let upcontext be split anyway? */
     }
     /* XXX: better way to enforce these incompatibilities w/ certain builds
      * than by turning off protection?  Should we halt instead?
      */
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask) &&
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask) &&
         SHARED_FRAGMENTS_ENABLED()) {
         /* XXX: get all shared gen routines to properly handle unprotected_context_t */
         USAGE_ERROR("Shared cache does not support protecting dcontext yet");
@@ -1347,7 +1347,7 @@ check_option_compatibility_helper(int recurse_count)
     }
 
 #    if defined(MACOS) && defined(AARCH64)
-    if (TEST(SELFPROT_GENCODE, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_GENCODE, dynamo_options.protect_mask)) {
         USAGE_ERROR("memory protection changes incompatible with MAP_JIT");
         dynamo_options.protect_mask &= ~SELFPROT_GENCODE;
         changed_options = true;
@@ -1889,7 +1889,7 @@ check_option_compatibility_helper(int recurse_count)
     /* shared/ignore syscall writes to sysenter_storage dcontext field which
      * should be in upcontext or something XXX */
     if (DYNAMO_OPTION(sygate_sysenter) &&
-        TEST(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask))) {
+        TESTANY(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask))) {
         USAGE_ERROR("-sygate_sysenter incompatbile with -protect_mask dc");
         dynamo_options.protect_mask &= ~SELFPROT_DCONTEXT;
         changed_options = true;
@@ -1925,7 +1925,7 @@ check_option_compatibility_helper(int recurse_count)
     SECURITY_OPTION_CONSISTENT(rct_ind_call);
     SECURITY_OPTION_CONSISTENT(rct_ind_jump);
     if (!DYNAMO_OPTION(ret_after_call) &&
-        TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) {
+        TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) {
         SYSLOG_INTERNAL_INFO(".F depends on .C after calls, disabling .F");
         dynamo_options.rct_ind_jump = OPTION_DISABLED;
         changed_options = true;

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -681,34 +681,34 @@ extern uint datasec_writable_cxtswprot;
      INTERNAL_OPTION(single_privileged_thread))
 
 /* macros to put mask check outside of function, for efficiency */
-#define SELF_PROTECT_LOCAL(dc, w)                              \
-    do {                                                       \
-        if (TEST(SELFPROT_LOCAL, dynamo_options.protect_mask)) \
-            protect_local_heap(dc, w);                         \
+#define SELF_PROTECT_LOCAL(dc, w)                                 \
+    do {                                                          \
+        if (TESTANY(SELFPROT_LOCAL, dynamo_options.protect_mask)) \
+            protect_local_heap(dc, w);                            \
     } while (0);
 
-#define SELF_PROTECT_GLOBAL(w)                                  \
-    do {                                                        \
-        if (TEST(SELFPROT_GLOBAL, dynamo_options.protect_mask)) \
-            protect_global_heap(w);                             \
+#define SELF_PROTECT_GLOBAL(w)                                     \
+    do {                                                           \
+        if (TESTANY(SELFPROT_GLOBAL, dynamo_options.protect_mask)) \
+            protect_global_heap(w);                                \
     } while (0);
 
-#define ASSERT_LOCAL_HEAP_PROTECTED(dcontext)                    \
-    ASSERT(!TEST(SELFPROT_LOCAL, dynamo_options.protect_mask) || \
+#define ASSERT_LOCAL_HEAP_PROTECTED(dcontext)                       \
+    ASSERT(!TESTANY(SELFPROT_LOCAL, dynamo_options.protect_mask) || \
            local_heap_protected(dcontext))
-#define ASSERT_LOCAL_HEAP_UNPROTECTED(dcontext)                  \
-    ASSERT(!TEST(SELFPROT_LOCAL, dynamo_options.protect_mask) || \
+#define ASSERT_LOCAL_HEAP_UNPROTECTED(dcontext)                     \
+    ASSERT(!TESTANY(SELFPROT_LOCAL, dynamo_options.protect_mask) || \
            !local_heap_protected(dcontext))
 
-#define SELF_PROTECT_DATASEC(which)                                     \
-    do {                                                                \
-        if (TEST(DATASEC_SELFPROT[which], DYNAMO_OPTION(protect_mask))) \
-            protect_data_section(which, READONLY);                      \
+#define SELF_PROTECT_DATASEC(which)                                        \
+    do {                                                                   \
+        if (TESTANY(DATASEC_SELFPROT[which], DYNAMO_OPTION(protect_mask))) \
+            protect_data_section(which, READONLY);                         \
     } while (0);
-#define SELF_UNPROTECT_DATASEC(which)                                   \
-    do {                                                                \
-        if (TEST(DATASEC_SELFPROT[which], DYNAMO_OPTION(protect_mask))) \
-            protect_data_section(which, WRITABLE);                      \
+#define SELF_UNPROTECT_DATASEC(which)                                      \
+    do {                                                                   \
+        if (TESTANY(DATASEC_SELFPROT[which], DYNAMO_OPTION(protect_mask))) \
+            protect_data_section(which, WRITABLE);                         \
     } while (0);
 
 /***************************************************************************/

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -180,8 +180,8 @@ coarse_unit_create(app_pc base_pc, app_pc end_pc, module_digest_t *digest,
         coarse_unit_mark_in_use(info);
     if (digest != NULL) {
         memcpy(&info->module_md5, digest, sizeof(info->module_md5));
-    } else if (TEST(PERSCACHE_MODULE_MD5_AT_LOAD,
-                    DYNAMO_OPTION(persist_gen_validation))) {
+    } else if (TESTANY(PERSCACHE_MODULE_MD5_AT_LOAD,
+                       DYNAMO_OPTION(persist_gen_validation))) {
         /* case 9735: calculate the module md5 at load time so we have a consistent
          * point at which to compare it when loading in a persisted cache file.
          * If we inject at different points we may see different views of
@@ -699,8 +699,8 @@ coarse_unit_freeze(dcontext_t *dcontext, coarse_info_t *info, bool in_place)
     if (info->cache == NULL || info->frozen)
         goto coarse_unit_freeze_exit;
     /* invalid unit shouldn't get this far */
-    ASSERT(!TEST(PERSCACHE_CODE_INVALID, info->flags));
-    if (TEST(PERSCACHE_CODE_INVALID, info->flags)) /* paranoid */
+    ASSERT(!TESTANY(PERSCACHE_CODE_INVALID, info->flags));
+    if (TESTANY(PERSCACHE_CODE_INVALID, info->flags)) /* paranoid */
         goto coarse_unit_freeze_exit;
 
     memset(freeze_info, 0, sizeof(*freeze_info));
@@ -2215,7 +2215,7 @@ persist_get_options_level(app_pc pc, coarse_info_t *info, bool force_local)
               (force_local ||
                /* once loaded as local, must remain local, even if this
                 * process never hit the exemption */
-               (info != NULL && TEST(PERSCACHE_EXEMPTION_OPTIONS, info->flags)) ||
+               (info != NULL && TESTANY(PERSCACHE_EXEMPTION_OPTIONS, info->flags)) ||
                os_module_get_flag(pc, MODULE_WAS_EXEMPTED)) &&
               /* don't use local if no such options: else when load will think
                * local when really global */
@@ -2384,7 +2384,7 @@ persist_calculate_self_digest(module_digest_t *digest, coarse_persisted_info_t *
                               app_pc map, uint validation_option)
 {
     struct MD5Context self_md5_cxt;
-    if (TEST(PERSCACHE_GENFILE_MD5_COMPLETE, validation_option)) {
+    if (TESTANY(PERSCACHE_GENFILE_MD5_COMPLETE, validation_option)) {
         d_r_md5_init(&self_md5_cxt);
         /* Even if generated w/ -persist_map_rw_separate but loaded w/o that
          * option, the md5 should match since the memory layout is the same.
@@ -2393,7 +2393,7 @@ persist_calculate_self_digest(module_digest_t *digest, coarse_persisted_info_t *
                        pers->header_len + pers->data_len - sizeof(persisted_footer_t));
         d_r_md5_final(digest->full_MD5, &self_md5_cxt);
     }
-    if (TEST(PERSCACHE_GENFILE_MD5_SHORT, validation_option)) {
+    if (TESTANY(PERSCACHE_GENFILE_MD5_SHORT, validation_option)) {
         d_r_md5_init(&self_md5_cxt);
         d_r_md5_update(&self_md5_cxt, (byte *)pers, pers->header_len);
         d_r_md5_final(digest->short_MD5, &self_md5_cxt);
@@ -2411,7 +2411,7 @@ persist_calculate_module_digest(module_digest_t *digest, app_pc modbase, size_t 
         /* case 9717: need view size, not image size */
         view_size = os_module_get_view_size(modbase);
     }
-    if (TEST(PERSCACHE_MODULE_MD5_COMPLETE, validation_option)) {
+    if (TESTANY(PERSCACHE_MODULE_MD5_COMPLETE, validation_option)) {
         /* We can't use a full md5 from module_calculate_digest() since .data
          * and other sections change between persist and load times (this is
          * in-memory image, not file).  So we do md5 of code region.  If we have
@@ -2428,7 +2428,7 @@ persist_calculate_module_digest(module_digest_t *digest, app_pc modbase, size_t 
         d_r_md5_update(&code_md5_cxt, code_start, code_end - code_start);
         d_r_md5_final(digest->full_MD5, &code_md5_cxt);
     }
-    if (TEST(PERSCACHE_MODULE_MD5_SHORT, validation_option)) {
+    if (TESTANY(PERSCACHE_MODULE_MD5_SHORT, validation_option)) {
         /* Examine only the image header and the footer (if non-writable)
          * XXX: if view_size < modsize, better to skip the footer than have it
          * cover a data section?  Should be ok w/ PERSCACHE_MODULE_MD5_AT_LOAD.
@@ -2454,8 +2454,9 @@ persist_modinfo_cmp(persisted_module_info_t *mi1, persisted_module_info_t *mi2)
     ASSERT_CURIOSITY(
         module_digests_equal(
             &mi1->module_md5, &mi2->module_md5,
-            TEST(PERSCACHE_MODULE_MD5_SHORT, DYNAMO_OPTION(persist_load_validation)),
-            TEST(PERSCACHE_MODULE_MD5_COMPLETE, DYNAMO_OPTION(persist_load_validation)))
+            TESTANY(PERSCACHE_MODULE_MD5_SHORT, DYNAMO_OPTION(persist_load_validation)),
+            TESTANY(PERSCACHE_MODULE_MD5_COMPLETE,
+                    DYNAMO_OPTION(persist_load_validation)))
         /* relocs => md5 diffs, until we handle relocs wrt md5 */
         IF_WINDOWS(|| mi1->base != mi2->base) ||
         check_filter("win32.partial_map.exe", get_short_name(get_application_name())));
@@ -2468,12 +2469,12 @@ persist_modinfo_cmp(persisted_module_info_t *mi1, persisted_module_info_t *mi2)
         (memcmp(&mi1->checksum, &mi2->checksum,
                 offsetof(persisted_module_info_t, module_md5) -
                     offsetof(persisted_module_info_t, checksum)) == 0);
-    match =
-        match &&
-        module_digests_equal(
-            &mi1->module_md5, &mi2->module_md5,
-            TEST(PERSCACHE_MODULE_MD5_SHORT, DYNAMO_OPTION(persist_load_validation)),
-            TEST(PERSCACHE_MODULE_MD5_COMPLETE, DYNAMO_OPTION(persist_load_validation)));
+    match = match &&
+        module_digests_equal(&mi1->module_md5, &mi2->module_md5,
+                             TESTANY(PERSCACHE_MODULE_MD5_SHORT,
+                                     DYNAMO_OPTION(persist_load_validation)),
+                             TESTANY(PERSCACHE_MODULE_MD5_COMPLETE,
+                                     DYNAMO_OPTION(persist_load_validation)));
     return match;
 }
 
@@ -2667,8 +2668,8 @@ coarse_unit_calculate_persist_info(dcontext_t *dcontext, coarse_info_t *info)
 
 #ifdef RCT_IND_BRANCH
     ASSERT(info->rct_table == NULL);
-    if ((TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-         TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) &&
+    if ((TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+         TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) &&
         (DYNAMO_OPTION(persist_rct)
 #    if defined(RETURN_AFTER_CALL) && defined(WINDOWS)
          /* case 8648: we can have RCT entries that come from code patterns
@@ -2780,8 +2781,8 @@ coarse_unit_merge_persist_info(dcontext_t *dcontext, coarse_info_t *dst,
      * PERSCACHE_SUPPORT_TRACES are weeded out at load time and should
      * not differ here)
      */
-    if (!TEST(PERSCACHE_MAP_RW_SEPARATE, info1->flags) ||
-        !TEST(PERSCACHE_MAP_RW_SEPARATE, info2->flags))
+    if (!TESTANY(PERSCACHE_MAP_RW_SEPARATE, info1->flags) ||
+        !TESTANY(PERSCACHE_MAP_RW_SEPARATE, info2->flags))
         dst->flags &= ~PERSCACHE_MAP_RW_SEPARATE;
     /* Same bounds, so same persistence privileges */
     dst->primary_for_module = info1->primary_for_module || info2->primary_for_module;
@@ -2810,8 +2811,8 @@ coarse_unit_merge_persist_info(dcontext_t *dcontext, coarse_info_t *dst,
 
 #ifdef RCT_IND_BRANCH
     ASSERT(dst->rct_table == NULL);
-    if (TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-        TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) {
+    if (TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+        TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) {
         if (info2->persisted && info2->in_use && !info1->persisted) {
             /* coarse_unit_calculate_persist_info already merged the new entries
              * with the in-use persisted entries
@@ -2944,7 +2945,7 @@ coarse_unit_set_persist_data(dcontext_t *dcontext, coarse_info_t *info,
     pers->build_number = 0;
 #endif
 
-    if (TEST(PERSCACHE_MODULE_MD5_AT_LOAD, DYNAMO_OPTION(persist_gen_validation))) {
+    if (TESTANY(PERSCACHE_MODULE_MD5_AT_LOAD, DYNAMO_OPTION(persist_gen_validation))) {
         ASSERT(!is_region_memset_to_char((byte *)&info->module_md5,
                                          sizeof(info->module_md5), 0));
         DOLOG(1, LOG_CACHE, {
@@ -3231,8 +3232,8 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
     ASSERT(info->frozen && !info->persisted);
 
     /* invalid unit shouldn't get this far */
-    ASSERT(!TEST(PERSCACHE_CODE_INVALID, info->flags));
-    if (TEST(PERSCACHE_CODE_INVALID, info->flags)) /* paranoid */
+    ASSERT(!TESTANY(PERSCACHE_CODE_INVALID, info->flags));
+    if (TESTANY(PERSCACHE_CODE_INVALID, info->flags)) /* paranoid */
         goto coarse_unit_persist_exit;
 
     modbase = get_module_base(info->base_pc);
@@ -3474,7 +3475,8 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
         byte *map = (byte *)&pers;
         uint which = DYNAMO_OPTION(persist_gen_validation);
         size_t sz = 0;
-        if (TEST(PERSCACHE_GENFILE_MD5_COMPLETE, DYNAMO_OPTION(persist_gen_validation))) {
+        if (TESTANY(PERSCACHE_GENFILE_MD5_COMPLETE,
+                    DYNAMO_OPTION(persist_gen_validation))) {
             /* XXX if mmap up front (case 9758) don't need this mmap */
             sz = pers.header_len + pers.data_len - sizeof(persisted_footer_t);
             map = d_r_map_file(fd, &sz, 0, NULL, MEMPROT_READ,
@@ -3489,7 +3491,8 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
         persist_calculate_self_digest(&footer.self_md5, &pers, map, which);
         DOLOG(1, LOG_CACHE,
               { print_module_digest(THREAD, &footer.self_md5, "self md5: "); });
-        if (TEST(PERSCACHE_GENFILE_MD5_COMPLETE, DYNAMO_OPTION(persist_gen_validation)) &&
+        if (TESTANY(PERSCACHE_GENFILE_MD5_COMPLETE,
+                    DYNAMO_OPTION(persist_gen_validation)) &&
             map != (byte *)&pers) {
             ASSERT(map != NULL); /* we cleared _COMPLETE so shouldn't get here */
             d_r_unmap_file(map, sz);
@@ -3566,7 +3569,8 @@ persist_check_option_compat(dcontext_t *dcontext, coarse_persisted_info_t *pers,
         return false;
     }
 
-    if (!TEST(PERSCACHE_SUPPORT_TRACES, pers->flags) && !DYNAMO_OPTION(disable_traces)) {
+    if (!TESTANY(PERSCACHE_SUPPORT_TRACES, pers->flags) &&
+        !DYNAMO_OPTION(disable_traces)) {
         /* We bail out; the consequences of continuing are huge performance
          * problems akin to -no_link_ibl.
          */
@@ -3578,10 +3582,10 @@ persist_check_option_compat(dcontext_t *dcontext, coarse_persisted_info_t *pers,
 
     /* we don't bother to split the ifdefs */
 #if defined(RCT_IND_BRANCH) || defined(RETURN_AFTER_CALL)
-    if ((!TEST(PERSCACHE_SUPPORT_RAC, pers->flags) && DYNAMO_OPTION(ret_after_call)) ||
-        (!TEST(PERSCACHE_SUPPORT_RCT, pers->flags) &&
-         (TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-          TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))))) {
+    if ((!TESTANY(PERSCACHE_SUPPORT_RAC, pers->flags) && DYNAMO_OPTION(ret_after_call)) ||
+        (!TESTANY(PERSCACHE_SUPPORT_RCT, pers->flags) &&
+         (TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+          TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))))) {
         LOG(THREAD, LOG_CACHE, 1, "  error: persisted cache has no RAC/RCT support\n");
         STATS_INC(perscache_rct_mismatch);
         SYSLOG_INTERNAL_WARNING_ONCE("persistent cache RAC/RCT support mismatch");
@@ -3842,10 +3846,10 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
         ALIGN_FORWARD(pers->header_len + pers->data_len, PAGE_SIZE) !=
             ALIGN_FORWARD(map_size, PAGE_SIZE) ||
         footer->magic != PERSISTENT_CACHE_MAGIC ||
-        TEST(PERSCACHE_CODE_INVALID, pers->flags)) {
+        TESTANY(PERSCACHE_CODE_INVALID, pers->flags)) {
         LOG(THREAD, LOG_CACHE, 1, "  invalid persisted file %s\n", filename);
         /* This flag shouldn't be set for on-disk units */
-        ASSERT(!TEST(PERSCACHE_CODE_INVALID, pers->flags));
+        ASSERT(!TESTANY(PERSCACHE_CODE_INVALID, pers->flags));
         STATS_INC(perscache_bad_file);
         /* We didn't have a footer prior to version 4 */
         ASSERT_CURIOSITY_ONCE(pers->version < 4 && "persistent cache file corrupt");
@@ -3860,7 +3864,7 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
         goto coarse_unit_load_exit;
     }
 
-    if (!TEST(IF_X64_ELSE(PERSCACHE_X86_64, PERSCACHE_X86_32), pers->flags)) {
+    if (!TESTANY(IF_X64_ELSE(PERSCACHE_X86_64, PERSCACHE_X86_32), pers->flags)) {
         LOG(THREAD, LOG_CACHE, 1, "  invalid architecture: not %s %s\n",
             IF_X64_ELSE("AMD64", "IA-32"), filename);
         STATS_INC(perscache_version_mismatch);
@@ -3878,10 +3882,11 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
             print_module_digest(THREAD, &footer->self_md5, "md5 stored in file: ");
             print_module_digest(THREAD, &footer->self_md5, "md5 calculated:     ");
         });
-        if ((TEST(PERSCACHE_GENFILE_MD5_SHORT, DYNAMO_OPTION(persist_load_validation)) &&
+        if ((TESTANY(PERSCACHE_GENFILE_MD5_SHORT,
+                     DYNAMO_OPTION(persist_load_validation)) &&
              !md5_digests_equal(self_md5.short_MD5, footer->self_md5.short_MD5)) ||
-            (TEST(PERSCACHE_GENFILE_MD5_COMPLETE,
-                  DYNAMO_OPTION(persist_load_validation)) &&
+            (TESTANY(PERSCACHE_GENFILE_MD5_COMPLETE,
+                     DYNAMO_OPTION(persist_load_validation)) &&
              !md5_digests_equal(self_md5.full_MD5, footer->self_md5.full_MD5))) {
             LOG(THREAD, LOG_CACHE, 1, "  file header md5 mismatch\n");
             STATS_INC(perscache_md5_mismatch);
@@ -3970,7 +3975,7 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
          pers->ibl_ret_prefix_len + pers->trace_head_return_prefix_len +
          pers->fcache_return_prefix_len);
 
-    if (TEST(PERSCACHE_MAP_RW_SEPARATE, pers->flags) &&
+    if (TESTANY(PERSCACHE_MAP_RW_SEPARATE, pers->flags) &&
         DYNAMO_OPTION(persist_map_rw_separate)) {
         size_t ro_size;
         map2_size = stubs_and_prefixes_len + sizeof(persisted_footer_t);
@@ -4058,14 +4063,14 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
     info->flags = pers->flags;
 #if defined(RETURN_AFTER_CALL) && defined(WINDOWS)
     /* XXX: provide win32/ interface for setting the flag? */
-    if (TEST(PERSCACHE_SEEN_BORLAND_SEH, pers->flags) && !seen_Borland_SEH) {
+    if (TESTANY(PERSCACHE_SEEN_BORLAND_SEH, pers->flags) && !seen_Borland_SEH) {
         SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
         seen_Borland_SEH = true;
         SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
     }
 #endif
     ASSERT(option_level != OP_PCACHE_LOCAL ||
-           TEST(PERSCACHE_EXEMPTION_OPTIONS, info->flags));
+           TESTANY(PERSCACHE_EXEMPTION_OPTIONS, info->flags));
 
     /* Process data sections (other than option string) in reverse order */
     pc = map + pers->header_len + pers->data_len; /* end of file */
@@ -4170,10 +4175,10 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
             info->rct_table = rct_table_resurrect(GLOBAL_DCONTEXT, pc, RCT_RCT);
             ASSERT(info->rct_table != NULL);
             if (for_execution &&
-                (TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-                 TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) &&
+                (TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+                 TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) &&
                 (DYNAMO_OPTION(use_persisted_rct) ||
-                 TEST(PERSCACHE_SEEN_BORLAND_SEH, pers->flags)) &&
+                 TESTANY(PERSCACHE_SEEN_BORLAND_SEH, pers->flags)) &&
                 /* Case 9834: avoid double-add from earlier entire-module resurrect */
                 !os_module_get_flag(info->base_pc, MODULE_RCT_LOADED)) {
                 /* load into the official module table */
@@ -4181,7 +4186,7 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
                 rct_module_table_set(GLOBAL_DCONTEXT, modbase, info->rct_table, RCT_RCT);
                 ASSERT(used);
 #    ifdef WINDOWS
-                if (TEST(PERSCACHE_ENTIRE_MODULE_RCT, pers->flags)) {
+                if (TESTANY(PERSCACHE_ENTIRE_MODULE_RCT, pers->flags)) {
                     /* mark as not needing to be analyzed */
                     os_module_set_flag(info->base_pc, MODULE_RCT_LOADED);
                 }
@@ -4319,7 +4324,7 @@ exists_coarse_ibl_pending_table(dcontext_t *dcontext, /* in case per-thread some
                 rct_module_persisted_table_exists(dcontext, info->base_pc, RCT_RAC);
         }
         return (exists &&
-                !TEST(COARSE_FILL_IBL_MASK(branch_type), info->ibl_pending_used));
+                !TESTANY(COARSE_FILL_IBL_MASK(branch_type), info->ibl_pending_used));
     }
 #endif
     return false;

--- a/core/perscache.h
+++ b/core/perscache.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -211,7 +211,8 @@ struct _coarse_info_t {
 }; /* typedef as "coarse_info_t" is in globals.h */
 
 #if defined(X86) && defined(X64)
-#    define COARSE_32_FLAG(info) (TEST(PERSCACHE_X86_32, (info)->flags) ? FRAG_32_BIT : 0)
+#    define COARSE_32_FLAG(info) \
+        (TESTANY(PERSCACHE_X86_32, (info)->flags) ? FRAG_32_BIT : 0)
 #else
 #    define COARSE_32_FLAG(info) 0
 #endif

--- a/core/rct.c
+++ b/core/rct.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -268,8 +268,8 @@ rct_ind_branch_check(dcontext_t *dcontext, app_pc target_addr, app_pc src_addr)
     DEBUG_DECLARE(const char *ibranch_type = is_ind_call ? "call" : "jmp";)
     ASSERT(is_ind_call || EXIT_IS_JMP(dcontext->last_exit->flags));
 
-    ASSERT((is_ind_call && TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call))) ||
-           (!is_ind_call && TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))));
+    ASSERT((is_ind_call && TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call))) ||
+           (!is_ind_call && TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))));
 
     LOG(THREAD, LOG_RCT, 2, "RCT: ind %s target = " PFX "\n", ibranch_type, target_addr);
 
@@ -563,8 +563,8 @@ rct_known_targets_init(void)
 void
 rct_init(void)
 {
-    if (!(TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-          TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump)))) {
+    if (!(TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+          TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump)))) {
         ASSERT(!(TESTANY(OPTION_REPORT | OPTION_BLOCK, DYNAMO_OPTION(rct_ind_call)) ||
                  TESTANY(OPTION_REPORT | OPTION_BLOCK, DYNAMO_OPTION(rct_ind_jump))));
         return;
@@ -576,8 +576,8 @@ rct_init(void)
 void
 rct_exit(void)
 {
-    if (!(TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-          TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))))
+    if (!(TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+          TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))))
         return;
 
     DELETE_LOCK(rct_module_lock);

--- a/core/synch.c
+++ b/core/synch.c
@@ -941,7 +941,7 @@ synch_with_thread(thread_id_t id, bool block, bool hold_initexit_lock,
     thread_synch_result_t res = THREAD_SYNCH_RESULT_NOT_SAFE;
     bool first_loop = true;
     IF_UNIX(bool actually_suspended = true;)
-    const uint max_loops = TEST(THREAD_SYNCH_SMALL_LOOP_MAX, flags)
+    const uint max_loops = TESTANY(THREAD_SYNCH_SMALL_LOOP_MAX, flags)
         ? (SYNCH_MAXIMUM_LOOPS / 10)
         : SYNCH_MAXIMUM_LOOPS;
 
@@ -1024,7 +1024,7 @@ synch_with_thread(thread_id_t id, bool block, bool hold_initexit_lock,
                     (trec->dcontext->currently_stopped IF_APP_EXPORTS(|| dr_api_exit)) &&
                     "Thead synch unable to suspend target"
                     " thread, case 2096?");
-                res = (TEST(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags)
+                res = (TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags)
                            ? THREAD_SYNCH_RESULT_SUCCESS
                            : THREAD_SYNCH_RESULT_SUSPEND_FAILURE);
                 IF_UNIX(actually_suspended = false);
@@ -1036,11 +1036,11 @@ synch_with_thread(thread_id_t id, bool block, bool hold_initexit_lock,
                 ASSERT_CURIOSITY_ONCE(false &&
                                       "Thead synch unable to get_context target"
                                       " thread, case 2096?");
-                res = (TEST(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags)
+                res = (TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags)
                            ? THREAD_SYNCH_RESULT_SUCCESS
                            : THREAD_SYNCH_RESULT_SUSPEND_FAILURE);
                 /* Make sure to not leave suspended if not returning success */
-                if (!TEST(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags))
+                if (!TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags))
                     os_thread_resume(trec);
                 break;
             }
@@ -1061,7 +1061,7 @@ synch_with_thread(thread_id_t id, bool block, bool hold_initexit_lock,
             }
             if (!os_thread_resume(trec)) {
                 ASSERT_NOT_REACHED();
-                res = (TEST(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags)
+                res = (TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags)
                            ? THREAD_SYNCH_RESULT_SUCCESS
                            : THREAD_SYNCH_RESULT_SUSPEND_FAILURE);
                 break;
@@ -1145,7 +1145,7 @@ synch_with_thread(thread_id_t id, bool block, bool hold_initexit_lock,
                     os_wait_thread_terminated(trec->dcontext);
                 }
             } else
-                ASSERT(TEST(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags));
+                ASSERT(TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_IGNORE, flags));
 #endif
         }
         if (THREAD_SYNCH_IS_CLEANED(desired_state)) {
@@ -1209,7 +1209,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
     dcontext_t *dcontext = NULL;
     uint flags_one; /* flags for synch_with_thread() call */
     thread_synch_result_t synch_res;
-    const uint max_loops = TEST(THREAD_SYNCH_SMALL_LOOP_MAX, flags)
+    const uint max_loops = TESTANY(THREAD_SYNCH_SMALL_LOOP_MAX, flags)
         ? (SYNCH_ALL_THREADS_MAXIMUM_LOOPS / 10)
         : SYNCH_ALL_THREADS_MAXIMUM_LOOPS;
     /* We treat client-owned threads as native but they don't have a clean native state
@@ -1250,7 +1250,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
                  flags));
     flags_one = flags;
     /* we'll do the retry */
-    if (TEST(THREAD_SYNCH_SUSPEND_FAILURE_RETRY, flags)) {
+    if (TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_RETRY, flags)) {
         flags_one &= ~THREAD_SYNCH_SUSPEND_FAILURE_RETRY;
         flags_one |= THREAD_SYNCH_SUSPEND_FAILURE_ABORT;
     }
@@ -1407,7 +1407,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
                     continue; /* skip this thread for now till non-client are finished */
                 }
                 if (IS_CLIENT_THREAD(threads[i]->dcontext) &&
-                    (TEST(flags, THREAD_SYNCH_SKIP_CLIENT_THREAD) ||
+                    (TESTANY(flags, THREAD_SYNCH_SKIP_CLIENT_THREAD) ||
                      !should_suspend_client_thread(threads[i]->dcontext,
                                                    desired_synch_state))) {
                     /* PR 609569: do not suspend this thread.
@@ -1448,7 +1448,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
                     LOG(THREAD, LOG_SYNCH, 2, "Synch failed!\n");
                     all_synched = false;
                     if (synch_res == THREAD_SYNCH_RESULT_SUSPEND_FAILURE) {
-                        if (TEST(THREAD_SYNCH_SUSPEND_FAILURE_ABORT, flags))
+                        if (TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_ABORT, flags))
                             goto synch_with_all_abort;
                     } else
                         ASSERT(synch_res == THREAD_SYNCH_RESULT_NOT_SAFE);
@@ -1502,7 +1502,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
      * to correspond w/ no suspended threads, a freed threads array, and no
      * locks being held, so we go through the abort path
      */
-    if (!all_synched && TEST(THREAD_SYNCH_SUSPEND_FAILURE_ABORT, flags))
+    if (!all_synched && TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_ABORT, flags))
         goto synch_with_all_abort;
 synch_with_all_exit:
     /* make sure we didn't exit the loop without synchronizing, XXX : in
@@ -1538,7 +1538,7 @@ synch_with_all_exit:
      * synch_result is ignored.  Callers are responsible for resuming threads that are
      * suspended and freeing allocation for threads array
      */
-    if ((!all_synched && TEST(THREAD_SYNCH_SUSPEND_FAILURE_ABORT, flags)) ||
+    if ((!all_synched && TESTANY(THREAD_SYNCH_SUSPEND_FAILURE_ABORT, flags)) ||
         THREAD_SYNCH_IS_CLEANED(desired_synch_state)) {
         global_heap_free(
             threads, num_threads * sizeof(thread_record_t *) HEAPACCT(ACCT_THREAD_MGT));

--- a/core/translate.c
+++ b/core/translate.c
@@ -854,9 +854,9 @@ recreate_app_state_from_info(dcontext_t *tdcontext, const translation_info_t *in
             cpc - start_cache >= info->translation[i].cache_offs) {
             /* We hit a change point: new app translation target */
             answer = info->translation[i].app;
-            contig = !TEST(TRANSLATE_IDENTICAL, info->translation[i].flags);
-            ours = TEST(TRANSLATE_OUR_MANGLING, info->translation[i].flags);
-            in_clean_call = TEST(TRANSLATE_CLEAN_CALL, info->translation[i].flags);
+            contig = !TESTANY(TRANSLATE_IDENTICAL, info->translation[i].flags);
+            ours = TESTANY(TRANSLATE_OUR_MANGLING, info->translation[i].flags);
+            in_clean_call = TESTANY(TRANSLATE_CLEAN_CALL, info->translation[i].flags);
             i++;
         }
 
@@ -930,7 +930,8 @@ recreate_app_state_from_info(dcontext_t *tdcontext, const translation_info_t *in
                   INTERNAL_OPTION(stress_recreate_pc) ||
                   /* we can currently fail for flushed code (PR 208037/i#399)
                    * (and hotpatch, native_exec, and sysenter: but too rare to check) */
-                  TEST(FRAG_SELFMOD_SANDBOXED, flags) || TEST(FRAG_WAS_DELETED, flags))) {
+                  TESTANY(FRAG_SELFMOD_SANDBOXED, flags) ||
+                  TESTANY(FRAG_WAS_DELETED, flags))) {
                 CLIENT_ASSERT(false,
                               "meta-instr faulted?  must set translation"
                               " field and handle fault!");
@@ -1113,7 +1114,7 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
                         walk.translation);
 #ifdef X86
                     int op = instr_get_opcode(inst);
-                    if (TEST(FRAG_SELFMOD_SANDBOXED, flags) &&
+                    if (TESTANY(FRAG_SELFMOD_SANDBOXED, flags) &&
                         (op == OP_rep_ins || op == OP_rep_movs || op == OP_rep_stos)) {
                         /* i#398: xl8 selfmod: rep string instrs have xbx spilled in
                          * thread-private slot.  We assume no other selfmod mangling
@@ -1138,8 +1139,8 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
                                /* we can currently fail for flushed code (PR 208037)
                                 * (and hotpatch, native_exec, and sysenter: but too
                                 * rare to check) */
-                               TEST(FRAG_SELFMOD_SANDBOXED, flags) ||
-                               TEST(FRAG_WAS_DELETED, flags));
+                               TESTANY(FRAG_SELFMOD_SANDBOXED, flags) ||
+                               TESTANY(FRAG_WAS_DELETED, flags));
                         LOG(THREAD_GET, LOG_INTERP, 2,
                             "recreate_app -- not able to fully recreate "
                             "context, pc is in added instruction from mangling\n");
@@ -1201,7 +1202,7 @@ recreate_selfmod_ilist(dcontext_t *dcontext, fragment_t *f)
     cache_pc selfmod_copy;
     instrlist_t *ilist;
     instr_t *inst;
-    ASSERT(TEST(FRAG_SELFMOD_SANDBOXED, f->flags));
+    ASSERT(TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags));
     /* If f is selfmod, app code may have changed (we see this w/ code
      * on the stack later flushed w/ os_thread_stack_exit(), though in that
      * case we don't expect it to be executed again), so we do a special
@@ -1210,8 +1211,8 @@ recreate_selfmod_ilist(dcontext_t *dcontext, fragment_t *f)
      * offset each translation entry
      */
     selfmod_copy = FRAGMENT_SELFMOD_COPY_PC(f);
-    ASSERT(!TEST(FRAG_IS_TRACE, f->flags));
-    ASSERT(!TEST(FRAG_HAS_DIRECT_CTI, f->flags));
+    ASSERT(!TESTANY(FRAG_IS_TRACE, f->flags));
+    ASSERT(!TESTANY(FRAG_HAS_DIRECT_CTI, f->flags));
     /* We must build our ilist w/o calling check_thread_vm_area(), as it will
      * freak out that we are decoding DR memory.
      */
@@ -1463,8 +1464,8 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
             f = fragment_pclookup_with_linkstubs(tdcontext, mcontext->pc, &alloc);
 
         /* If the passed-in fragment is fake, we need to get the linkstubs */
-        if (f != NULL && TEST(FRAG_FAKE, f->flags)) {
-            ASSERT(TEST(FRAG_COARSE_GRAIN, f->flags));
+        if (f != NULL && TESTANY(FRAG_FAKE, f->flags)) {
+            ASSERT(TESTANY(FRAG_COARSE_GRAIN, f->flags));
             f = fragment_recreate_with_linkstubs(tdcontext, f);
             alloc = true;
         }
@@ -1474,7 +1475,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
             ilist = recreate_fragment_ilist(tdcontext, mcontext->pc, &f, &alloc,
                                             true /*mangle*/, true /*client*/);
         } else if (FRAGMENT_TRANSLATION_INFO(f) == NULL) {
-            if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags)) {
+            if (TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)) {
                 ilist = recreate_selfmod_ilist(tdcontext, f);
             } else {
                 /* NULL for pc indicates that f is valid */
@@ -1483,7 +1484,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
                 ilist = recreate_fragment_ilist(tdcontext, NULL, &f, &new_alloc,
                                                 true /*mangle*/, true /*client*/);
                 ASSERT(owning_f == NULL || f == owning_f ||
-                       (TEST(FRAG_COARSE_GRAIN, owning_f->flags) && f == pre_f));
+                       (TESTANY(FRAG_COARSE_GRAIN, owning_f->flags) && f == pre_f));
                 ASSERT(!new_alloc);
             }
         }
@@ -1575,7 +1576,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
         client_info.raw_mcontext_valid = true;
         if (ilist == NULL) {
             ASSERT(f != NULL && FRAGMENT_TRANSLATION_INFO(f) != NULL);
-            ASSERT(!TEST(FRAG_WAS_DELETED, f->flags) ||
+            ASSERT(!TESTANY(FRAG_WAS_DELETED, f->flags) ||
                    INTERNAL_OPTION(safe_translate_flushed));
             res = recreate_app_state_from_info(
                 tdcontext, FRAGMENT_TRANSLATION_INFO(f), (byte *)f->start_pc,
@@ -1605,7 +1606,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
              */
             ASSERT(client_info.raw_mcontext->pc >=
                    client_info.fragment_info.cache_start_pc);
-            client_info.fragment_info.is_trace = TEST(FRAG_IS_TRACE, f->flags);
+            client_info.fragment_info.is_trace = TESTANY(FRAG_IS_TRACE, f->flags);
             client_info.fragment_info.app_code_consistent =
                 !TESTANY(FRAG_WAS_DELETED | FRAG_SELFMOD_SANDBOXED, f->flags);
             client_info.fragment_info.ilist = ilist;
@@ -1806,14 +1807,14 @@ translation_info_print(const translation_info_t *info, cache_pc start, file_t fi
     ASSERT(file != INVALID_FILE);
     print_file(file, "translation info " PFX "\n", info);
     for (i = 0; i < info->num_entries; i++) {
-        print_file(file, "\t%d +%5d == " PFX " => " PFX " %s%s%s\n", i,
-                   info->translation[i].cache_offs,
-                   start + info->translation[i].cache_offs, info->translation[i].app,
-                   TEST(TRANSLATE_IDENTICAL, info->translation[i].flags) ? "identical"
-                                                                         : "contiguous",
-                   TEST(TRANSLATE_OUR_MANGLING, info->translation[i].flags) ? " ours"
-                                                                            : "",
-                   TEST(TRANSLATE_CLEAN_CALL, info->translation[i].flags) ? " call" : "");
+        print_file(
+            file, "\t%d +%5d == " PFX " => " PFX " %s%s%s\n", i,
+            info->translation[i].cache_offs, start + info->translation[i].cache_offs,
+            info->translation[i].app,
+            TESTANY(TRANSLATE_IDENTICAL, info->translation[i].flags) ? "identical"
+                                                                     : "contiguous",
+            TESTANY(TRANSLATE_OUR_MANGLING, info->translation[i].flags) ? " ours" : "",
+            TESTANY(TRANSLATE_CLEAN_CALL, info->translation[i].flags) ? " call" : "");
     }
 }
 
@@ -1844,7 +1845,7 @@ record_translation_info(dcontext_t *dcontext, fragment_t *f, instrlist_t *existi
 
     if (existing_ilist != NULL)
         ilist = existing_ilist;
-    else if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags)) {
+    else if (TESTANY(FRAG_SELFMOD_SANDBOXED, f->flags)) {
         ilist = recreate_selfmod_ilist(dcontext, f);
     } else {
         /* Must re-build fragment and record translation info for each instr.
@@ -1923,7 +1924,7 @@ record_translation_info(dcontext_t *dcontext, fragment_t *f, instrlist_t *existi
                  */
                 if (i > 0 && entries[i - 1].cache_offs == cpc - last_len - f->start_pc) {
                     /* convert prev contig into identical */
-                    ASSERT(!TEST(TRANSLATE_IDENTICAL, entries[i - 1].flags));
+                    ASSERT(!TESTANY(TRANSLATE_IDENTICAL, entries[i - 1].flags));
                     entries[i - 1].flags |= TRANSLATE_IDENTICAL;
                     LOG(THREAD, LOG_FRAGMENT, 3, "\tchanging %d to identical\n", i - 1);
                 } else {
@@ -1956,7 +1957,7 @@ record_translation_info(dcontext_t *dcontext, fragment_t *f, instrlist_t *existi
                 if (app == last_translation + last_len &&
                     entries[i - 1].cache_offs == cpc - last_len - f->start_pc) {
                     /* convert prev identical into contig */
-                    ASSERT(TEST(TRANSLATE_IDENTICAL, entries[i - 1].flags));
+                    ASSERT(TESTANY(TRANSLATE_IDENTICAL, entries[i - 1].flags));
                     entries[i - 1].flags &= ~TRANSLATE_IDENTICAL;
                     LOG(THREAD, LOG_FRAGMENT, 3, "\tchanging %d to contig\n", i - 1);
                 } else {
@@ -1974,9 +1975,9 @@ record_translation_info(dcontext_t *dcontext, fragment_t *f, instrlist_t *existi
         /* We need to make a new entry if the flags changed. */
         if (i > 0 && i == prev_i &&
             (!BOOLS_MATCH(instr_is_our_mangling(inst),
-                          TEST(TRANSLATE_OUR_MANGLING, entries[i - 1].flags)) ||
+                          TESTANY(TRANSLATE_OUR_MANGLING, entries[i - 1].flags)) ||
              !BOOLS_MATCH(in_clean_call,
-                          TEST(TRANSLATE_CLEAN_CALL, entries[i - 1].flags)))) {
+                          TESTANY(TRANSLATE_CLEAN_CALL, entries[i - 1].flags)))) {
             /* our manglings are usually identical */
             bool identical = instr_is_our_mangling(inst);
             set_translation(dcontext, &entries, &num_entries, i,
@@ -2032,7 +2033,7 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
     LOG(THREAD, LOG_INTERP, 3, "Testing restoring state fragment #%d\n",
         GLOBAL_STAT(num_fragments));
 
-    if (TEST(FRAG_IS_TRACE, f->flags)) {
+    if (TESTANY(FRAG_IS_TRACE, f->flags)) {
         /* decode_fragment() does not set the our-mangling bits, nor the
          * translation fields (to distinguish back-to-back mangling
          * regions): not ideal to test using part of what we're testing but
@@ -2050,7 +2051,8 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
             (!instr_is_our_mangling(in) ||
              /* handle adjacent mangle regions */
              IF_X86((inside_mangle_epilogue && !instr_is_our_mangling_epilogue(in)) ||)(
-                 TEST(FRAG_IS_TRACE, f->flags) /* we have translation only for traces */
+                 TESTANY(FRAG_IS_TRACE,
+                         f->flags) /* we have translation only for traces */
                  && mangle_translation !=
                      instr_get_translation(in)
                          IF_X86(&&!(!inside_mangle_epilogue &&
@@ -2076,7 +2078,7 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
                 LOG(THREAD, LOG_INTERP, 3, "  entering mangling epilogue\n");
                 IF_X86(inside_mangle_epilogue = true;)
             } else {
-                ASSERT(!TEST(FRAG_IS_TRACE, f->flags) ||
+                ASSERT(!TESTANY(FRAG_IS_TRACE, f->flags) ||
                        IF_X86(instr_is_our_mangling_epilogue(in) ||)
                                mangle_translation == instr_get_translation(in));
             }
@@ -2132,7 +2134,7 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
             }
         }
     }
-    if (TEST(FRAG_IS_TRACE, f->flags)) {
+    if (TESTANY(FRAG_IS_TRACE, f->flags)) {
         instrlist_clear_and_destroy(dcontext, ilist);
     }
 #    endif /* AARCH64 */

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -583,13 +583,13 @@ os_dump_core_internal(dcontext_t *dcontext, const char *output_directory DR_PARA
     // not require a LOAD program header.
     for (int section_index = 0; section_index < section_count - 1; ++section_index) {
         ELF_WORD flags = 0;
-        if (TEST(PROT_EXEC, section_header_info[section_index].prot)) {
+        if (TESTANY(PROT_EXEC, section_header_info[section_index].prot)) {
             flags |= PF_X;
         }
-        if (TEST(PROT_WRITE, section_header_info[section_index].prot)) {
+        if (TESTANY(PROT_WRITE, section_header_info[section_index].prot)) {
             flags |= PF_W;
         }
-        if (TEST(PROT_READ, section_header_info[section_index].prot)) {
+        if (TESTANY(PROT_READ, section_header_info[section_index].prot)) {
             flags |= PF_R;
         }
         const ELF_WORD size = section_header_info[section_index].vm_end -
@@ -683,10 +683,10 @@ os_dump_core_internal(dcontext_t *dcontext, const char *output_directory DR_PARA
     // this loop.
     for (int section_index = 0; section_index < section_count - 1; ++section_index) {
         ELF_WORD flags = SHF_ALLOC | SHF_MERGE;
-        if (TEST(PROT_WRITE, section_header_info[section_index].prot)) {
+        if (TESTANY(PROT_WRITE, section_header_info[section_index].prot)) {
             flags |= SHF_WRITE;
         }
-        if (TEST(PROT_EXEC, section_header_info[section_index].prot)) {
+        if (TESTANY(PROT_EXEC, section_header_info[section_index].prot)) {
             flags |= SHF_EXECINSTR;
         }
         if (!write_section_header(

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -1120,7 +1120,7 @@ get_sve_state(pid_t pid, struct user_sve_header **sve_state_out)
      * state.
      */
     const bool has_active_sve_state =
-        !ptrace_error && TEST((*sve_state_out)->flags, SVE_PT_REGS_SVE);
+        !ptrace_error && TESTANY((*sve_state_out)->flags, SVE_PT_REGS_SVE);
 
     if (!has_active_sve_state) {
         free(*sve_state_out);
@@ -1348,7 +1348,7 @@ injectee_run_get_retval(dr_inject_info_t *info, void *dc, instrlist_t *ilist)
 #    elif defined(AARCH64)
     app_mode = DR_ISA_ARM_A64;
 #    elif defined(ARM)
-    app_mode = TEST(EFLAGS_T, regs.uregs[16]) ? DR_ISA_ARM_THUMB : DR_ISA_ARM_A32;
+    app_mode = TESTANY(EFLAGS_T, regs.uregs[16]) ? DR_ISA_ARM_THUMB : DR_ISA_ARM_A32;
 #    elif defined(RISCV64)
     app_mode = DR_ISA_RV64;
 #    else
@@ -1515,9 +1515,9 @@ injectee_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc add
     int fd;
     int flags = 0;
     app_pc r;
-    if (TEST(MAP_FILE_COPY_ON_WRITE, map_flags))
+    if (TESTANY(MAP_FILE_COPY_ON_WRITE, map_flags))
         flags |= MAP_PRIVATE;
-    if (TEST(MAP_FILE_FIXED, map_flags))
+    if (TESTANY(MAP_FILE_FIXED, map_flags))
         flags |= MAP_FIXED;
     /* MAP_FILE_IMAGE is a nop on Linux. */
     if (f == injector_dr_fd)
@@ -1567,7 +1567,7 @@ injectee_overlap_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, ap
     /* This works only if the user wants the new mapping only at the given addr,
      * and it is acceptable to unmap any mapping already existing there.
      */
-    ASSERT(TEST(MAP_FILE_FIXED, map_flags));
+    ASSERT(TESTANY(MAP_FILE_FIXED, map_flags));
     return injectee_map_file(f, size, offs, addr, prot, map_flags);
 }
 
@@ -1739,7 +1739,7 @@ user_regs_to_mc(priv_mcontext_t *mc, struct USER_REGS_TYPE *regs)
 
     if (sve_header != NULL) {
         /* Process has active SVE state. */
-        ASSERT(TEST(SVE_PT_REGS_SVE, sve_header->flags));
+        ASSERT(TESTANY(SVE_PT_REGS_SVE, sve_header->flags));
         ASSERT(sve_header->vl <= MAX_SUPPORTED_SVE_VECTOR_LENGTH);
 
         /* The ptrace macros calculate sizes based on "vq": the vector length in
@@ -1973,7 +1973,7 @@ inject_ptrace(dr_inject_info_t *info, const char *library_path)
 #    elif defined(AARCH64)
     app_mode = DR_ISA_ARM_A64;
 #    elif defined(ARM)
-    app_mode = TEST(EFLAGS_T, regs.uregs[16]) ? DR_ISA_ARM_THUMB : DR_ISA_ARM_A32;
+    app_mode = TESTANY(EFLAGS_T, regs.uregs[16]) ? DR_ISA_ARM_THUMB : DR_ISA_ARM_A32;
 #    elif defined(RISCV64)
     app_mode = DR_ISA_RV64;
 #    else

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -462,7 +462,8 @@ privload_map_flags(modload_flags_t init_flags)
     /* XXX: Keep this condition matching the check in privload_unmap_file()
      * (minus MODLOAD_NOT_PRIVLIB since non-privlibs don't reach our unmap).
      */
-    if (INTERNAL_OPTION(separate_private_bss) && !TEST(MODLOAD_NOT_PRIVLIB, init_flags)) {
+    if (INTERNAL_OPTION(separate_private_bss) &&
+        !TESTANY(MODLOAD_NOT_PRIVLIB, init_flags)) {
         /* place an extra no-access page after .bss */
         /* XXX: update privload_early_inject call to init_emulated_brk if this changes */
         /* XXX: should we avoid this for -early_inject's map of the app and ld.so? */
@@ -495,7 +496,7 @@ overlap_map_file_func(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc
     /* This works only if the user wants the new mapping only at the given addr,
      * and it is acceptable to unmap any mapping already existing there.
      */
-    ASSERT(TEST(MAP_FILE_FIXED, map_flags));
+    ASSERT(TESTANY(MAP_FILE_FIXED, map_flags));
     if (DYNAMO_OPTION(vm_reserve) && is_vmm_reserved_address(addr, *size, NULL, NULL)) {
         /* If the initially reserved address was from our vmm range, we need to
          * use os_unmap_file to make sure we perform our heap bookkeeping.
@@ -526,7 +527,7 @@ privload_map_and_relocate(const char *filename, size_t *size DR_PARAM_OUT,
     app_pc base = NULL;
     elf_loader_t loader;
 
-    ASSERT_OWN_RECURSIVE_LOCK(!TEST(MODLOAD_NOT_PRIVLIB, flags), &privload_lock);
+    ASSERT_OWN_RECURSIVE_LOCK(!TESTANY(MODLOAD_NOT_PRIVLIB, flags), &privload_lock);
     /* get appropriate function */
     /* NOTE: all but the client lib will be added to DR areas list b/c using
      * d_r_map_file()
@@ -555,7 +556,7 @@ privload_map_and_relocate(const char *filename, size_t *size DR_PARAM_OUT,
          */
         ELF_HEADER_TYPE *elf_header = (ELF_HEADER_TYPE *)loader.buf;
         ELF_ALTARCH_HEADER_TYPE *altarch = (ELF_ALTARCH_HEADER_TYPE *)elf_header;
-        if (!TEST(MODLOAD_NOT_PRIVLIB, flags) && elf_header->e_version == 1 &&
+        if (!TESTANY(MODLOAD_NOT_PRIVLIB, flags) && elf_header->e_version == 1 &&
             altarch->e_ehsize == sizeof(ELF_ALTARCH_HEADER_TYPE) &&
             altarch->e_machine ==
                 IF_X64_ELSE(IF_AARCHXX_ELSE(EM_ARM, EM_386),
@@ -575,8 +576,8 @@ privload_map_and_relocate(const char *filename, size_t *size DR_PARAM_OUT,
         if (size != NULL)
             *size = loader.image_size;
 
-        if (!TEST(MODLOAD_NOT_PRIVLIB, flags))
-            privload_add_gdb_cmd(&loader, filename, TEST(MODLOAD_REACHABLE, flags));
+        if (!TESTANY(MODLOAD_NOT_PRIVLIB, flags))
+            privload_add_gdb_cmd(&loader, filename, TESTANY(MODLOAD_REACHABLE, flags));
     }
     elf_loader_destroy(&loader);
 
@@ -1322,13 +1323,13 @@ privload_relocate_relr(os_privmod_data_t *opd, const ELF_WORD *relr, size_t size
     ELF_ADDR *r_addr = NULL;
 
     for (; size != 0; relr++, size -= sizeof(ELF_WORD)) {
-        if (!TEST(1, relr[0])) {
+        if (!TESTANY(1, relr[0])) {
             r_addr = (ELF_ADDR *)(relr[0] + opd->load_delta);
             *r_addr++ += opd->load_delta;
         } else {
             int i = 0;
             for (ELF_WORD bitmap = relr[0]; (bitmap >>= 1) != 0; i++) {
-                if (TEST(1, bitmap))
+                if (TESTANY(1, bitmap))
                     r_addr[i] += opd->load_delta;
             }
             r_addr += CHAR_BIT * sizeof(ELF_WORD) - 1;

--- a/core/unix/loader_linux.c
+++ b/core/unix/loader_linux.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -549,7 +549,7 @@ privload_tls_init(void *app_tp, bool use_safe_read)
             /* Only copy the valid mapped memory of app_tp (pointer to TCB/TLS block). */
             if (get_memory_info_from_os((byte *)app_tp, &tp_map_base, &tp_map_size,
                                         &prot) &&
-                TEST(MEMPROT_READ, prot)) {
+                TESTANY(MEMPROT_READ, prot)) {
                 byte *region_end = tp_map_base + tp_map_size;
                 if (app_start < tp_map_base) {
                     size_t delta = tp_map_base - app_start;

--- a/core/unix/memcache.c
+++ b/core/unix/memcache.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -287,7 +287,8 @@ memcache_update(app_pc start, app_pc end_in, uint prot, int type)
                      * write => COW => no longer shareable (i#669)
                      */
                     shareable = info->shareable;
-                    if (TEST(MEMPROT_WRITE, prot) != TEST(MEMPROT_WRITE, info->prot))
+                    if (TESTANY(MEMPROT_WRITE, prot) !=
+                        TESTANY(MEMPROT_WRITE, info->prot))
                         shareable = false;
                     /* re-add so we can merge w/ adjacent non-shareable */
                 } else {

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -145,7 +145,7 @@ memquery_library_bounds_by_iterator_internal(
                 !funcs->module_is_header(iter.vm_start, iter.vm_end - iter.vm_start))
                 last_lib_base = prev_base;
             /* last_lib_end is used to know what's readable beyond last_lib_base */
-            if (TEST(MEMPROT_READ, iter.prot))
+            if (TESTANY(MEMPROT_READ, iter.prot))
                 last_lib_end = iter.vm_end;
             else
                 last_lib_end = last_lib_base;

--- a/core/unix/memquery_emulate.c
+++ b/core/unix/memquery_emulate.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -351,7 +351,7 @@ probe_address(dcontext_t *dcontext, app_pc pc_in, DR_PARAM_OUT uint *prot)
                    /* nothing: just continue */
                });
     /* x86 can't be writable w/o being readable.  avoiding nested TRY though. */
-    if (TEST(MEMPROT_READ, *prot)) {
+    if (TESTANY(MEMPROT_READ, *prot)) {
         TRY_EXCEPT(dcontext, /* try */
                    {
                        PROBE_WRITE_PC(pc);

--- a/core/unix/memquery_macos.h
+++ b/core/unix/memquery_macos.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -44,11 +44,11 @@ static inline uint
 vmprot_to_memprot(uint prot)
 {
     uint mem_prot = 0;
-    if (TEST(VM_PROT_EXECUTE, prot))
+    if (TESTANY(VM_PROT_EXECUTE, prot))
         mem_prot |= MEMPROT_EXEC;
-    if (TEST(VM_PROT_READ, prot))
+    if (TESTANY(VM_PROT_READ, prot))
         mem_prot |= MEMPROT_READ;
-    if (TEST(VM_PROT_WRITE, prot))
+    if (TESTANY(VM_PROT_WRITE, prot))
         mem_prot |= MEMPROT_WRITE;
     return mem_prot;
 }

--- a/core/unix/memquery_test.h
+++ b/core/unix/memquery_test.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2026 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -286,7 +286,7 @@ record_memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/
         app_pc mod_base = 0, mod_end = 0;
         bool is_header = false;
 
-        if (TEST(MEMPROT_READ, iter.prot) &&
+        if (TESTANY(MEMPROT_READ, iter.prot) &&
 #    ifdef X64
             /* We have observed segfaults reading data from very high addresses,
              * even though their mappings are listed as readable.

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -138,7 +138,7 @@ module_is_partial_map(app_pc base, size_t size, uint memprot)
     app_pc last_seg_end = NULL;
     ELF_HEADER_TYPE *elf_hdr;
 
-    if (size < sizeof(ELF_HEADER_TYPE) || !TEST(MEMPROT_READ, memprot) ||
+    if (size < sizeof(ELF_HEADER_TYPE) || !TESTANY(MEMPROT_READ, memprot) ||
         !is_elf_so_header(base, 0 /*i#727: safer to ask for safe_read*/)) {
         return true;
     }
@@ -660,8 +660,8 @@ gnu_hash_lookup(const char *name, ptr_int_t load_delta, ELF_SYM_TYPE *symtab,
     hidx = elf_gnu_hash(name);
     entry = bitmask[(hidx / ELF_WORD_SIZE) & bitidx];
     h1 = hidx & (ELF_WORD_SIZE - 1);
-    h2 = (hidx >> shift) & (ELF_WORD_SIZE - 1);   /* bloom filter hash */
-    if (TEST(1, (entry >> h1) & (entry >> h2))) { /* bloom filter check */
+    h2 = (hidx >> shift) & (ELF_WORD_SIZE - 1);      /* bloom filter hash */
+    if (TESTANY(1, (entry >> h1) & (entry >> h2))) { /* bloom filter check */
         Elf32_Word bucket = buckets[hidx % num_buckets];
         if (bucket != 0) {
             Elf32_Word *harray = &chain[bucket];
@@ -683,7 +683,7 @@ gnu_hash_lookup(const char *name, ptr_int_t load_delta, ELF_SYM_TYPE *symtab,
                         break;
                     }
                 }
-            } while (!TEST(1, *harray++));
+            } while (!TESTANY(1, *harray++));
         }
     }
     return res;
@@ -851,7 +851,7 @@ module_has_text_relocs(app_pc base, bool at_map)
             return true;
         /* Newer binaries have a DF_TEXTREL flag in DT_FLAGS */
         if (dyn->d_tag == DT_FLAGS) {
-            if (TEST(DF_TEXTREL, dyn->d_un.d_val))
+            if (TESTANY(DF_TEXTREL, dyn->d_un.d_val))
                 return true;
         }
         dyn++;
@@ -959,7 +959,7 @@ module_init_os_privmod_data_from_dyn(os_privmod_data_t *opd, ELF_DYNAMIC_ENTRY_T
         case DT_PLTREL: opd->pltrel = dyn->d_un.d_val; break;
         case DT_TEXTREL: opd->textrel = true; break;
         case DT_FLAGS:
-            if (TEST(DF_TEXTREL, dyn->d_un.d_val))
+            if (TESTANY(DF_TEXTREL, dyn->d_un.d_val))
                 opd->textrel = true;
             break;
         case DT_JMPREL: opd->jmprel = (app_pc)(dyn->d_un.d_ptr + load_delta); break;
@@ -1209,7 +1209,7 @@ symbol_iterator_next_noread(elf_symbol_iterator_t *iter)
     if (iter->hidx < iter->num_buckets) {
         /* XXX: perhaps we should safe_read buckets[] and chain[] */
         if (iter->chain_idx != 0) {
-            if (TEST(1, iter->chain[iter->chain_idx])) {
+            if (TESTANY(1, iter->chain[iter->chain_idx])) {
                 /* LSB being 1 marks end of chain. */
                 iter->chain_idx = 0;
             } else
@@ -1704,13 +1704,13 @@ module_relocate_relr(app_pc modbase, os_privmod_data_t *pd, const ELF_WORD *relr
     LOG(GLOBAL, LOG_LOADER, 4, "%s walking relr %p-%p\n", __FUNCTION__, relr,
         (char *)relr + size);
     for (; size != 0; relr++, size -= sizeof(ELF_WORD)) {
-        if (!TEST(1, relr[0])) {
+        if (!TESTANY(1, relr[0])) {
             r_addr = (ELF_ADDR *)(relr[0] + pd->load_delta);
             *r_addr++ += pd->load_delta;
         } else {
             int i = 0;
             for (ELF_WORD bitmap = relr[0]; (bitmap >>= 1) != 0; i++) {
-                if (TEST(1, bitmap))
+                if (TESTANY(1, bitmap))
                     r_addr[i] += pd->load_delta;
             }
             r_addr += CHAR_BIT * sizeof(ELF_WORD) - 1;

--- a/core/unix/module_macho.c
+++ b/core/unix/module_macho.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -435,7 +435,7 @@ get_proc_address_from_os_data(os_module_data_t *os_data, ptr_int_t load_delta,
         uint flags = read_uleb128(ptr, max, &ptr);
         if (is_indirect_code != NULL)
             *is_indirect_code = false;
-        if (TEST(EXPORT_SYMBOL_FLAGS_REEXPORT, flags)) {
+        if (TESTANY(EXPORT_SYMBOL_FLAGS_REEXPORT, flags)) {
             /* Forwarder */
             read_uleb128(ptr, max, &ptr); /* ordinal */
             const char *forw_name = (const char *)ptr;
@@ -443,7 +443,7 @@ get_proc_address_from_os_data(os_module_data_t *os_data, ptr_int_t load_delta,
                 forw_name = name;
             LOG(GLOBAL, LOG_SYMBOLS, 4, "\tforwarder %s\n", forw_name);
             /* XXX i#1360: handle forwards */
-        } else if (TEST(EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER, flags)) {
+        } else if (TESTANY(EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER, flags)) {
             /* Lazy or non-lazy pointer */
             DEBUG_DECLARE(size_t stub_offs =)
             read_uleb128(ptr, max, &ptr);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1561,13 +1561,13 @@ os_terminate_with_code(dcontext_t *dcontext, terminate_flags_t flags, int exit_c
     /* i#1319: we support a signal via 2nd byte */
     bool use_signal = exit_code > 0x00ff;
     /* XXX: TERMINATE_THREAD not supported */
-    ASSERT_NOT_IMPLEMENTED(TEST(TERMINATE_PROCESS, flags));
+    ASSERT_NOT_IMPLEMENTED(TESTANY(TERMINATE_PROCESS, flags));
     if (use_signal) {
         int sig = (exit_code & 0xff00) >> 8;
         os_terminate_via_signal(dcontext, flags, sig);
         ASSERT_NOT_REACHED();
     }
-    if (TEST(TERMINATE_CLEANUP, flags)) {
+    if (TESTANY(TERMINATE_CLEANUP, flags)) {
         /* we enter from several different places, so rewind until top-level kstat */
         KSTOP_REWIND_UNTIL(thread_measured);
         block_cleanup_and_terminate(dcontext, SYSNUM_EXIT_PROCESS, exit_code, 0,
@@ -2874,7 +2874,7 @@ os_fork_init(dcontext_t *dcontext)
                                          (void **)&flags);
         if (iter < 0)
             break;
-        if (TEST(OS_OPEN_CLOSE_ON_FORK, flags)) {
+        if (TESTANY(OS_OPEN_CLOSE_ON_FORK, flags)) {
             close_syscall((file_t)fd);
             iter = generic_hash_iterate_remove(GLOBAL_DCONTEXT, fd_table, iter, fd);
         }
@@ -3034,7 +3034,7 @@ os_swap_context(dcontext_t *dcontext, bool to_app, dr_state_flags_t flags)
 {
     if (os_should_swap_state())
         os_switch_seg_to_context(dcontext, LIB_SEG_TLS, to_app);
-    if (TEST(DR_STATE_DR_TLS, flags))
+    if (TESTANY(DR_STATE_DR_TLS, flags))
         os_swap_dr_tls(dcontext, to_app);
 }
 
@@ -3319,11 +3319,11 @@ static inline uint
 osprot_to_memprot(uint prot)
 {
     uint mem_prot = 0;
-    if (TEST(PROT_EXEC, prot))
+    if (TESTANY(PROT_EXEC, prot))
         mem_prot |= MEMPROT_EXEC;
-    if (TEST(PROT_READ, prot))
+    if (TESTANY(PROT_READ, prot))
         mem_prot |= MEMPROT_READ;
-    if (TEST(PROT_WRITE, prot))
+    if (TESTANY(PROT_WRITE, prot))
         mem_prot |= MEMPROT_WRITE;
     return mem_prot;
 }
@@ -3374,9 +3374,9 @@ os_raw_mem_alloc(void *preferred, size_t size, uint prot, uint flags,
     byte *p;
     uint os_prot = memprot_to_osprot(prot);
     uint os_flags =
-        MAP_PRIVATE | MAP_ANONYMOUS | (TEST(RAW_ALLOC_32BIT, flags) ? MAP_32BIT : 0);
+        MAP_PRIVATE | MAP_ANONYMOUS | (TESTANY(RAW_ALLOC_32BIT, flags) ? MAP_32BIT : 0);
 #if defined(MACOS) && defined(AARCH64)
-    if (TEST(MEMPROT_EXEC, prot))
+    if (TESTANY(MEMPROT_EXEC, prot))
         os_flags |= MAP_JIT;
 #endif
 
@@ -4749,7 +4749,7 @@ os_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc addr, uin
 #ifdef VMX86_SERVER
     flags = MAP_PRIVATE; /* MAP_SHARED not supported yet */
 #else
-    flags = TEST(MAP_FILE_COPY_ON_WRITE, map_flags) ? MAP_PRIVATE : MAP_SHARED;
+    flags = TESTANY(MAP_FILE_COPY_ON_WRITE, map_flags) ? MAP_PRIVATE : MAP_SHARED;
 #endif
 #if defined(X64)
     /* Allocate memory from reachable range for image: or anything (pcache
@@ -4764,17 +4764,17 @@ os_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc addr, uin
      * so we can request memory from a particular address with fixed argument */
     if (f == -1)
         flags |= MAP_ANONYMOUS;
-    if (TEST(MAP_FILE_FIXED, map_flags))
+    if (TESTANY(MAP_FILE_FIXED, map_flags))
         flags |= MAP_FIXED;
 #if defined(X64)
-    if (!TEST(MAP_32BIT, flags) && TEST(MAP_FILE_REACHABLE, map_flags)) {
+    if (!TESTANY(MAP_32BIT, flags) && TESTANY(MAP_FILE_REACHABLE, map_flags)) {
         vmcode_get_reachable_region(&region_start, &region_end);
         /* addr need not be NULL: we'll use it if it's in the region */
-        ASSERT(!TEST(MAP_FILE_FIXED, map_flags));
+        ASSERT(!TESTANY(MAP_FILE_FIXED, map_flags));
         /* Loop to handle races */
         loop = true;
     }
-    if ((!TEST(MAP_32BIT, flags) && TEST(MAP_FILE_REACHABLE, map_flags) &&
+    if ((!TESTANY(MAP_32BIT, flags) && TESTANY(MAP_FILE_REACHABLE, map_flags) &&
          (is_vmm_reserved_address(addr, *size, NULL, NULL) ||
           /* Try to honor a library's preferred address.  This does open up a race
            * window during attach where another thread could take this spot,
@@ -4782,7 +4782,7 @@ os_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc addr, uin
            * memory.  We live with that as being rare rather than complicate the code.
            */
           !rel32_reachable_from_current_vmcode(addr))) ||
-        (TEST(MAP_FILE_FIXED, map_flags) && !TEST(MAP_FILE_VMM_COMMIT, map_flags) &&
+        (TESTANY(MAP_FILE_FIXED, map_flags) && !TESTANY(MAP_FILE_VMM_COMMIT, map_flags) &&
          is_vmm_reserved_address(addr, *size, NULL, NULL))) {
         if (DYNAMO_OPTION(vm_reserve)) {
             /* Try to get space inside the vmcode reservation. */
@@ -5182,7 +5182,7 @@ os_set_protection(byte *pc, size_t length, uint prot /*MEMPROT_*/)
     uint flags = memprot_to_osprot(prot);
     DOSTATS({
         /* once on each side of prot, to get on right side of writability */
-        if (!TEST(PROT_WRITE, flags)) {
+        if (!TESTANY(PROT_WRITE, flags)) {
             STATS_INC(protection_change_calls);
             STATS_ADD(protection_change_pages, num_bytes / PAGE_SIZE);
         }
@@ -5197,7 +5197,7 @@ os_set_protection(byte *pc, size_t length, uint prot /*MEMPROT_*/)
         num_bytes / PAGE_SIZE);
     DOSTATS({
         /* once on each side of prot, to get on right side of writability */
-        if (TEST(PROT_WRITE, flags)) {
+        if (TESTANY(PROT_WRITE, flags)) {
             STATS_INC(protection_change_calls);
             STATS_ADD(protection_change_pages, num_bytes / PAGE_SIZE);
         }
@@ -5358,7 +5358,7 @@ os_normalized_sysnum(int num_raw, instr_t *gateway, dcontext_t *dcontext)
             interrupt = instr_get_interrupt_number(gateway);
     } else {
         ASSERT(dcontext != NULL);
-        if (TEST(LINK_SPECIAL_EXIT, dcontext->last_exit->flags)) {
+        if (TESTANY(LINK_SPECIAL_EXIT, dcontext->last_exit->flags)) {
             if (dcontext->upcontext.upcontext.exit_reason ==
                 EXIT_REASON_NI_SYSCALL_INT_0x81)
                 interrupt = 0x81;
@@ -5370,7 +5370,7 @@ os_normalized_sysnum(int num_raw, instr_t *gateway, dcontext_t *dcontext)
         }
     }
 #    ifdef X64
-    if (TEST(SYSCALL_NUM_MARKER_BSD, num_raw))
+    if (TESTANY(SYSCALL_NUM_MARKER_BSD, num_raw))
         return (int)(num_raw & 0xffffff); /* Drop BSD bit */
     else
         num = (int)num_raw; /* Keep Mach and Machdep bits */
@@ -5668,7 +5668,7 @@ static inline bool
 syscall_successful(priv_mcontext_t *mc, int normalized_sysnum)
 {
 #ifdef MACOS
-    if (TEST(SYSCALL_NUM_MARKER_MACH, normalized_sysnum)) {
+    if (TESTANY(SYSCALL_NUM_MARKER_MACH, normalized_sysnum)) {
         /* XXX: Mach syscalls vary (for some KERN_SUCCESS=0 is success,
          * for others that return mach_port_t 0 is failure (I think?).
          * We defer to drsyscall.
@@ -5676,9 +5676,9 @@ syscall_successful(priv_mcontext_t *mc, int normalized_sysnum)
         return ((ptr_int_t)MCXT_SYSCALL_RES(mc) >= 0);
     } else {
 #    ifdef X86
-        return !TEST(EFLAGS_CF, mc->xflags);
+        return !TESTANY(EFLAGS_CF, mc->xflags);
 #    elif defined(AARCH64)
-        return !TEST(EFLAGS_C, mc->xflags);
+        return !TESTANY(EFLAGS_C, mc->xflags);
 #    else
 #        error NYI
 #    endif
@@ -5958,7 +5958,7 @@ is_thread_create_syscall_helper(ptr_uint_t sysnum, uint64 flags)
         return true;
 #    endif
 #    ifdef LINUX
-    if ((sysnum == SYS_clone || sysnum == SYS_clone3) && TEST(CLONE_VM, flags))
+    if ((sysnum == SYS_clone || sysnum == SYS_clone3) && TESTANY(CLONE_VM, flags))
         return true;
 #    endif
     return false;
@@ -7474,7 +7474,7 @@ pre_system_call(dcontext_t *dcontext)
             /* Check for overlap with existing code or patch-proof regions */
             if (addr != NULL &&
                 !app_memory_pre_alloc(dcontext, addr, len, osprot_to_memprot(prot),
-                                      !TEST(MAP_FIXED, arg->flags),
+                                      !TESTANY(MAP_FIXED, arg->flags),
                                       false /*we'll update in post*/,
                                       false /*unknown*/)) {
                 /* Rather than failing or skipping the syscall we'd like to just
@@ -7511,13 +7511,13 @@ pre_system_call(dcontext_t *dcontext)
         /* Try to see whether it's an image, though we can't tell for addr==NULL
          * (typical for 1st mmap).
          */
-        bool image = addr != NULL && !TEST(MAP_ANONYMOUS, flags) &&
-            mmap_check_for_module_overlap(addr, len, TEST(PROT_READ, prot), 0, true);
+        bool image = addr != NULL && !TESTANY(MAP_ANONYMOUS, flags) &&
+            mmap_check_for_module_overlap(addr, len, TESTANY(PROT_READ, prot), 0, true);
         if (addr != NULL &&
-            !app_memory_pre_alloc(dcontext, addr, len, osprot_to_memprot(prot),
-                                  !TEST(MAP_FIXED, flags), false /*we'll update in post*/,
-                                  image /*best estimate*/)) {
-            if (!TEST(MAP_FIXED, flags)) {
+            !app_memory_pre_alloc(
+                dcontext, addr, len, osprot_to_memprot(prot), !TESTANY(MAP_FIXED, flags),
+                false /*we'll update in post*/, image /*best estimate*/)) {
+            if (!TESTANY(MAP_FIXED, flags)) {
                 /* Rather than failing or skipping the syscall we just remove
                  * the hint which should eliminate any overlap.
                  */
@@ -8277,7 +8277,7 @@ pre_system_call(dcontext_t *dcontext)
         IF_AARCHXX(ASSERT_NOT_TESTED());
         uint first_fd = sys_param(dcontext, 0), last_fd = sys_param(dcontext, 1);
         uint flags = sys_param(dcontext, 2);
-        bool is_cloexec = TEST(CLOSE_RANGE_CLOEXEC, flags);
+        bool is_cloexec = TESTANY(CLOSE_RANGE_CLOEXEC, flags);
         if (is_cloexec) {
             /* client.file_io has a test for CLOSE_RANGE_CLOEXEC, but it hasn't been
              * verified on a system with kernel version >= 5.11 yet.
@@ -8808,7 +8808,7 @@ os_add_new_app_module(dcontext_t *dcontext, bool at_map, app_pc base, size_t siz
         }
     }
     LOG(THREAD, LOG_SYSCALLS | LOG_VMAREAS, 2, "dlopen " PFX "-" PFX "%s\n", base,
-        base + mod_size, TEST(MEMPROT_EXEC, memprot) ? " +x" : "");
+        base + mod_size, TESTANY(MEMPROT_EXEC, memprot) ? " +x" : "");
 
     /* Mapping in a new module.  From what we've observed of the loader's
      * behavior, it first maps the file in with size equal to the final
@@ -8910,7 +8910,7 @@ process_mmap(dcontext_t *dcontext, app_pc base, size_t size, uint prot,
     uint memprot = osprot_to_memprot(prot);
 #ifdef ANDROID
     /* i#1861: avoid merging file-backed w/ anon regions */
-    if (!TEST(MAP_ANONYMOUS, flags))
+    if (!TESTANY(MAP_ANONYMOUS, flags))
         memprot |= MEMPROT_HAS_COMMENT;
 #endif
 
@@ -8940,18 +8940,18 @@ process_mmap(dcontext_t *dcontext, app_pc base, size_t size, uint prot,
      * can read the memory to see if it is a elf_header
      */
     /* XXX: get inode for check */
-    if (TEST(MAP_ANONYMOUS, flags)) {
+    if (TESTANY(MAP_ANONYMOUS, flags)) {
         /* not an ELF mmap */
         LOG(THREAD, LOG_SYSCALLS, 4, "mmap " PFX ": anon\n", base);
-    } else if (mmap_check_for_module_overlap(base, size, TEST(MEMPROT_READ, memprot), 0,
-                                             true)) {
+    } else if (mmap_check_for_module_overlap(base, size, TESTANY(MEMPROT_READ, memprot),
+                                             0, true)) {
         /* XXX - how can we distinguish between the loader mapping the segments
          * over the initial map from someone just mapping over part of a module? If
          * is the latter case need to adjust the view size or remove from module list. */
         image = true;
         DODEBUG({ map_type = "ELF SO"; });
         LOG(THREAD, LOG_SYSCALLS, 4, "mmap " PFX ": overlaps image\n", base);
-    } else if (TEST(MEMPROT_READ, memprot) &&
+    } else if (TESTANY(MEMPROT_READ, memprot) &&
                /* i#727: We can still get SIGBUS on mmap'ed files that can't be
                 * read, so pass size=0 to use a safe_read.
                 */
@@ -9113,10 +9113,11 @@ post_system_call(dcontext_t *dcontext)
         || sysnum ==
             SYS_fork
 #endif
-                IF_LINUX(||
-                         (sysnum == SYS_clone && !TEST(CLONE_VM, dcontext->sys_param0)) ||
-                         (sysnum == SYS_clone3 &&
-                          !TEST(CLONE_VM, get_stored_clone3_flags(dcontext))))) {
+                IF_LINUX(
+                    ||
+                    (sysnum == SYS_clone && !TESTANY(CLONE_VM, dcontext->sys_param0)) ||
+                    (sysnum == SYS_clone3 &&
+                     !TESTANY(CLONE_VM, get_stored_clone3_flags(dcontext))))) {
         if (result == 0) {
             /* we're the child */
             thread_id_t child = get_sys_thread_id();
@@ -9356,8 +9357,8 @@ post_system_call(dcontext_t *dcontext)
             if (!get_memory_info_from_os(addr, NULL, NULL, &memprot))
                 memprot = MEMPROT_NONE;
             /* We're post-syscall so from_os should match the prctl */
-            ASSERT((comment == NULL && !TEST(MEMPROT_HAS_COMMENT, memprot)) ||
-                   (comment != NULL && TEST(MEMPROT_HAS_COMMENT, memprot)));
+            ASSERT((comment == NULL && !TESTANY(MEMPROT_HAS_COMMENT, memprot)) ||
+                   (comment != NULL && TESTANY(MEMPROT_HAS_COMMENT, memprot)));
             LOG(THREAD, LOG_SYSCALLS, 2,
                 "syscall: prctl PR_SET_VMA_ANON_NAME base=" PFX " size=" PFX
                 " comment=%s\n",
@@ -10291,12 +10292,12 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules)
              */
         } else if (add_modules &&
                    mmap_check_for_module_overlap(iter->vm_start, size,
-                                                 TEST(MEMPROT_READ, iter->prot),
+                                                 TESTANY(MEMPROT_READ, iter->prot),
                                                  iter->inode, false)) {
             /* we already added the whole image region when we hit the first map for it */
             image = true;
             DODEBUG({ map_type = "ELF SO"; });
-        } else if (TEST(MEMPROT_READ, iter->prot) &&
+        } else if (TESTANY(MEMPROT_READ, iter->prot) &&
                    module_is_header(iter->vm_start, size)) {
             DEBUG_DECLARE(size_t image_size = size;)
             app_pc mod_base, mod_first_end, mod_max_end;
@@ -10307,8 +10308,9 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules)
             LOG(GLOBAL, LOG_VMAREAS, 2,
                 "Found already mapped module first segment :\n"
                 "\t" PFX "-" PFX "%s inode=" UINT64_FORMAT_STRING " name=%s\n",
-                iter->vm_start, iter->vm_end, TEST(MEMPROT_EXEC, iter->prot) ? " +x" : "",
-                iter->inode, iter->comment);
+                iter->vm_start, iter->vm_end,
+                TESTANY(MEMPROT_EXEC, iter->prot) ? " +x" : "", iter->inode,
+                iter->comment);
 #    ifdef LINUX
             /* Mapped images should have inodes, except for cases where an anon
              * map is placed on top (i#2566)
@@ -10611,7 +10613,7 @@ query_memory_ex_from_os(const byte *pc, DR_PARAM_OUT dr_mem_info_t *info)
          * The cleaner fix is to allow safe_read to work w/o a dcontext or
          * fault handling: i#350/PR 529066.
          */
-        if (TEST(MEMPROT_READ, info->prot) &&
+        if (TESTANY(MEMPROT_READ, info->prot) &&
             module_is_header(info->base_pc, fault_handling_initialized ? 0 : info->size))
             info->type = DR_MEMTYPE_IMAGE;
         else {

--- a/core/unix/ptrace_attach.c
+++ b/core/unix/ptrace_attach.c
@@ -276,7 +276,7 @@ ptrace_get_sve_state(thread_id_t tid, struct user_sve_header **sve_state_out,
         return false;
     }
 
-    if (!TEST(SVE_PT_REGS_SVE, sve_state->flags)) {
+    if (!TESTANY(SVE_PT_REGS_SVE, sve_state->flags)) {
         global_heap_free(sve_state, full_sve_state_size HEAPACCT(ACCT_THREAD_MGT));
         return true;
     }
@@ -342,7 +342,7 @@ user_regs_to_mc_aarch64(priv_mcontext_t *mc, struct user_pt_regs *regs,
     mc->nzcv = regs->pstate & 0xF0000000;
 
     if (sve_state != NULL) {
-        ASSERT(TEST(SVE_PT_REGS_SVE, sve_state->flags));
+        ASSERT(TESTANY(SVE_PT_REGS_SVE, sve_state->flags));
         ASSERT(sve_state->vl <= sizeof(dr_simd_t));
         const size_t vq = sve_vq_from_vl(sve_state->vl);
         for (size_t i = 0; i < MCXT_NUM_SIMD_SVE_SLOTS; i++) {

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -158,11 +158,12 @@ sig_is_real_time(int sig)
 
 /* if no app sigaction, it's RT, since that's our handler */
 #ifdef LINUX
-#    define IS_RT_FOR_APP(info, sig)                        \
-        IF_X64_ELSE(true,                                   \
-                    ((info)->sighand->action[(sig)] == NULL \
-                         ? true                             \
-                         : (TEST(SA_SIGINFO, (info)->sighand->action[(sig)]->flags))))
+#    define IS_RT_FOR_APP(info, sig)                \
+        IF_X64_ELSE(                                \
+            true,                                   \
+            ((info)->sighand->action[(sig)] == NULL \
+                 ? true                             \
+                 : (TESTANY(SA_SIGINFO, (info)->sighand->action[(sig)]->flags))))
 #elif defined(MACOS)
 #    define IS_RT_FOR_APP(info, sig) (true)
 #endif
@@ -183,7 +184,7 @@ sig_is_real_time(int sig)
  */
 #define USE_APP_SIGSTACK(info, sig)                                    \
     (APP_HAS_SIGSTACK(info) && (info)->sighand->action[sig] != NULL && \
-     TEST(SA_ONSTACK, (info)->sighand->action[sig]->flags))
+     TESTANY(SA_ONSTACK, (info)->sighand->action[sig]->flags))
 
 /* If we only intercept a few signals, we leave whether un-intercepted signals
  * are blocked unchanged and stored in the kernel.  If we intercept all (not
@@ -362,7 +363,7 @@ sigaction_syscall(int sig, kernel_sigaction_t *act, kernel_sigaction_t *oact)
 #if !defined(VMX86_SERVER) && defined(LINUX)
     /* PR 305020: must have SA_RESTORER for x64 */
     /* i#2812: must have SA_RESTORER to handle vsyscall32 being disabled */
-    if (act != NULL && !TEST(SA_RESTORER, act->flags)) {
+    if (act != NULL && !TESTANY(SA_RESTORER, act->flags)) {
         act->flags |= SA_RESTORER;
         act->restorer = (void (*)(void))dynamorio_sigreturn;
     }
@@ -870,7 +871,7 @@ create_clone_record(dcontext_t *dcontext, reg_t *app_thread_xsp)
      * thread register in new_thread_setup, so that DR can distinguish
      * this case from normal pthread thread creation.
      */
-    record->app_lib_tls_base = (!TEST(CLONE_SETTLS, record->clone_flags))
+    record->app_lib_tls_base = (!TESTANY(CLONE_SETTLS, record->clone_flags))
         ? os_get_app_tls_base(dcontext, TLS_REG_LIB)
         : NULL;
 #endif
@@ -1048,7 +1049,7 @@ restore_clone_param_from_clone_record(dcontext_t *dcontext, void *record)
 #ifdef LINUX
     ASSERT(record != NULL);
     clone_record_t *crec = (clone_record_t *)record;
-    if (TEST(CLONE_VM, crec->clone_flags)) {
+    if (TESTANY(CLONE_VM, crec->clone_flags)) {
         /* Restore the original stack parameter to the syscall, which we clobbered
          * in create_clone_record().  Some apps examine it post-syscall (i#3171).
          */
@@ -1176,7 +1177,7 @@ signal_thread_inherit(dcontext_t *dcontext, void *clone_record)
 #endif
 
         /* Handlers are either inherited or shared. */
-        if (TEST(CLONE_SIGHAND, record->clone_flags)) {
+        if (TESTANY(CLONE_SIGHAND, record->clone_flags)) {
             /* Need to share table of handlers! */
             LOG(THREAD, LOG_ASYNCH, 2, "sharing signal handlers with parent\n");
             info->sighand = record->info.sighand;
@@ -1233,7 +1234,7 @@ signal_thread_inherit(dcontext_t *dcontext, void *clone_record)
         }
 
         /* itimers are either private or shared */
-        if (TEST(CLONE_THREAD, record->clone_flags) && os_itimers_thread_shared()) {
+        if (TESTANY(CLONE_THREAD, record->clone_flags) && os_itimers_thread_shared()) {
             ASSERT(record->info.shared_itimer);
             LOG(THREAD, LOG_ASYNCH, 2, "sharing itimers with parent\n");
             info->shared_itimer = true;
@@ -1607,7 +1608,7 @@ signal_thread_exit(dcontext_t *dcontext, bool other_thread)
                 info->app_sigstack.ss_sp,
                 info->app_sigstack.ss_sp + info->app_sigstack.ss_size);
         } else {
-            ASSERT(TEST(SS_DISABLE, info->app_sigstack.ss_flags));
+            ASSERT(TESTANY(SS_DISABLE, info->app_sigstack.ss_flags));
         }
         if (info->sigstack.ss_sp != NULL) {
             /* i#552: to raise client exit event, we may call dynamo_process_exit
@@ -1974,7 +1975,7 @@ handle_clone(dcontext_t *dcontext, uint64 flags)
 
     pre_second_thread();
 
-    if (TEST(CLONE_SIGHAND, flags)) {
+    if (TESTANY(CLONE_SIGHAND, flags)) {
         /* need to share table of handlers! */
         LOG(THREAD, LOG_ASYNCH, 2, "handle_clone: CLONE_SIGHAND set!\n");
         if (!info->sighand->is_shared) {
@@ -1993,7 +1994,7 @@ handle_clone(dcontext_t *dcontext, uint64 flags)
         d_r_mutex_unlock(&info->child_lock);
     }
 
-    if (TEST(CLONE_THREAD, flags) && os_itimers_thread_shared()) {
+    if (TESTANY(CLONE_THREAD, flags) && os_itimers_thread_shared()) {
         if (!info->shared_itimer) {
             /* this is the start of a chain of sharing
              * no synch needed here, child not created yet
@@ -2835,7 +2836,7 @@ sigcontext_to_mcontext(priv_mcontext_t *mc, sig_full_cxt_t *sc_full,
     sigcontext_t *sc = sc_full->sc;
     ASSERT(mc != NULL && sc != NULL);
 #ifdef X86
-    if (TEST(DR_MC_INTEGER, flags)) {
+    if (TESTANY(DR_MC_INTEGER, flags)) {
         mc->xax = sc->SC_XAX;
         mc->xbx = sc->SC_XBX;
         mc->xcx = sc->SC_XCX;
@@ -2854,13 +2855,13 @@ sigcontext_to_mcontext(priv_mcontext_t *mc, sig_full_cxt_t *sc_full,
         mc->r15 = sc->SC_FIELD(r15);
 #    endif /* X64 */
     }
-    if (TEST(DR_MC_CONTROL, flags)) {
+    if (TESTANY(DR_MC_CONTROL, flags)) {
         mc->xsp = sc->SC_XSP;
         mc->xflags = sc->SC_XFLAGS;
         mc->pc = (app_pc)sc->SC_XIP;
     }
 #elif defined(RISCV64)
-    if (TEST(DR_MC_INTEGER, flags)) {
+    if (TESTANY(DR_MC_INTEGER, flags)) {
         mc->ra = sc->SC_FIELD(sc_regs.ra);
         mc->gp = sc->SC_FIELD(sc_regs.gp);
         mc->tp = sc->SC_FIELD(sc_regs.tp);
@@ -2892,27 +2893,27 @@ sigcontext_to_mcontext(priv_mcontext_t *mc, sig_full_cxt_t *sc_full,
         mc->t5 = sc->SC_FIELD(sc_regs.t5);
         mc->t6 = sc->SC_FIELD(sc_regs.t6);
     }
-    if (TEST(DR_MC_CONTROL, flags)) {
+    if (TESTANY(DR_MC_CONTROL, flags)) {
         mc->pc = (void *)sc->SC_FIELD(sc_regs.pc);
         mc->sp = sc->SC_FIELD(sc_regs.sp);
         mc->fcsr = sc->SC_FIELD(sc_fpregs.f.fcsr);
     }
 #elif defined(AARCH64)
-    if (TEST(DR_MC_INTEGER, flags)) {
+    if (TESTANY(DR_MC_INTEGER, flags)) {
 #    ifdef MACOS
         memcpy(&mc->r0, &sc->SC_FIELD(x[0]), sizeof(mc->r0) * 31);
 #    else
         memcpy(&mc->r0, &sc->SC_FIELD(regs[0]), sizeof(mc->r0) * 31);
 #    endif
     }
-    if (TEST(DR_MC_CONTROL, flags)) {
+    if (TESTANY(DR_MC_CONTROL, flags)) {
         /* XXX i#2710: the link register should be under DR_MC_CONTROL */
         mc->sp = sc->SC_FIELD(sp);
         mc->pc = (void *)sc->SC_FIELD(pc);
         mc->nzcv = sc->SC_XFLAGS;
     }
 #elif defined(ARM)
-    if (TEST(DR_MC_INTEGER, flags)) {
+    if (TESTANY(DR_MC_INTEGER, flags)) {
         mc->r0 = sc->SC_FIELD(arm_r0);
         mc->r1 = sc->SC_FIELD(arm_r1);
         mc->r2 = sc->SC_FIELD(arm_r2);
@@ -2929,7 +2930,7 @@ sigcontext_to_mcontext(priv_mcontext_t *mc, sig_full_cxt_t *sc_full,
         /* XXX i#2710: the link register should be under DR_MC_CONTROL */
         mc->r14 = sc->SC_FIELD(arm_lr);
     }
-    if (TEST(DR_MC_CONTROL, flags)) {
+    if (TESTANY(DR_MC_CONTROL, flags)) {
         mc->r13 = sc->SC_FIELD(arm_sp);
         mc->r15 = sc->SC_FIELD(arm_pc);
         mc->cpsr = sc->SC_FIELD(arm_cpsr);
@@ -2938,7 +2939,7 @@ sigcontext_to_mcontext(priv_mcontext_t *mc, sig_full_cxt_t *sc_full,
 #        error NYI on AArch64
 #    endif /* X64 */
 #endif     /* X86/ARM/RISCV64 */
-    if (TEST(DR_MC_MULTIMEDIA, flags))
+    if (TESTANY(DR_MC_MULTIMEDIA, flags))
         sigcontext_to_mcontext_simd(mc, sc_full);
 }
 
@@ -2965,7 +2966,7 @@ mcontext_to_sigcontext(sig_full_cxt_t *sc_full, priv_mcontext_t *mc,
     sigcontext_t *sc = sc_full->sc;
     ASSERT(mc != NULL && sc != NULL);
 #ifdef X86
-    if (TEST(DR_MC_INTEGER, flags)) {
+    if (TESTANY(DR_MC_INTEGER, flags)) {
         sc->SC_XAX = mc->xax;
         sc->SC_XBX = mc->xbx;
         sc->SC_XCX = mc->xcx;
@@ -2984,13 +2985,13 @@ mcontext_to_sigcontext(sig_full_cxt_t *sc_full, priv_mcontext_t *mc,
         sc->SC_FIELD(r15) = mc->r15;
 #    endif /* X64 */
     }
-    if (TEST(DR_MC_CONTROL, flags)) {
+    if (TESTANY(DR_MC_CONTROL, flags)) {
         sc->SC_XSP = mc->xsp;
         sc->SC_XFLAGS = mc->xflags;
         sc->SC_XIP = (ptr_uint_t)mc->pc;
     }
 #elif defined(RISCV64)
-    if (TEST(DR_MC_INTEGER, flags)) {
+    if (TESTANY(DR_MC_INTEGER, flags)) {
         sc->SC_FIELD(sc_regs.ra) = mc->ra;
         sc->SC_FIELD(sc_regs.gp) = mc->gp;
         sc->SC_FIELD(sc_regs.tp) = mc->tp;
@@ -3022,27 +3023,27 @@ mcontext_to_sigcontext(sig_full_cxt_t *sc_full, priv_mcontext_t *mc,
         sc->SC_FIELD(sc_regs.t5) = mc->t5;
         sc->SC_FIELD(sc_regs.t6) = mc->t6;
     }
-    if (TEST(DR_MC_CONTROL, flags)) {
+    if (TESTANY(DR_MC_CONTROL, flags)) {
         sc->SC_FIELD(sc_regs.pc) = (ptr_uint_t)mc->pc;
         sc->SC_FIELD(sc_regs.sp) = mc->sp;
         sc->SC_FIELD(sc_fpregs.f.fcsr) = mc->fcsr;
     }
 #elif defined(AARCH64)
-    if (TEST(DR_MC_INTEGER, flags)) {
+    if (TESTANY(DR_MC_INTEGER, flags)) {
 #    ifdef MACOS
         memcpy(&sc->SC_FIELD(x[0]), &mc->r0, sizeof(mc->r0) * 31);
 #    else
         memcpy(&sc->SC_FIELD(regs[0]), &mc->r0, sizeof(mc->r0) * 31);
 #    endif
     }
-    if (TEST(DR_MC_CONTROL, flags)) {
+    if (TESTANY(DR_MC_CONTROL, flags)) {
         /* XXX i#2710: the link register should be under DR_MC_CONTROL */
         sc->SC_FIELD(sp) = mc->sp;
         sc->SC_FIELD(pc) = (ptr_uint_t)mc->pc;
         sc->SC_XFLAGS = mc->nzcv;
     }
 #elif defined(ARM)
-    if (TEST(DR_MC_INTEGER, flags)) {
+    if (TESTANY(DR_MC_INTEGER, flags)) {
         sc->SC_FIELD(arm_r0) = mc->r0;
         sc->SC_FIELD(arm_r1) = mc->r1;
         sc->SC_FIELD(arm_r2) = mc->r2;
@@ -3059,7 +3060,7 @@ mcontext_to_sigcontext(sig_full_cxt_t *sc_full, priv_mcontext_t *mc,
         /* XXX i#2710: the link register should be under DR_MC_CONTROL */
         sc->SC_FIELD(arm_lr) = mc->r14;
     }
-    if (TEST(DR_MC_CONTROL, flags)) {
+    if (TESTANY(DR_MC_CONTROL, flags)) {
         sc->SC_FIELD(arm_sp) = mc->r13;
         sc->SC_FIELD(arm_pc) = mc->r15;
         /* XXX i#7207: The values of RES1 bits should probably be propagated
@@ -3072,7 +3073,7 @@ mcontext_to_sigcontext(sig_full_cxt_t *sc_full, priv_mcontext_t *mc,
 #        error NYI on AArch64
 #    endif /* X64 */
 #endif     /* X86/ARM/RISCV64 */
-    if (TEST(DR_MC_MULTIMEDIA, flags))
+    if (TESTANY(DR_MC_MULTIMEDIA, flags))
         mcontext_to_sigcontext_simd(sc_full, mc);
 }
 
@@ -3125,7 +3126,7 @@ get_sigcxt_tp_reg(sigcontext_t *sc)
 static dr_isa_mode_t
 get_pc_mode_from_cpsr(sigcontext_t *sc)
 {
-    return TEST(EFLAGS_T, sc->SC_XFLAGS) ? DR_ISA_ARM_THUMB : DR_ISA_ARM_A32;
+    return TESTANY(EFLAGS_T, sc->SC_XFLAGS) ? DR_ISA_ARM_THUMB : DR_ISA_ARM_A32;
 }
 
 dr_isa_mode_t
@@ -3383,7 +3384,7 @@ sig_has_restorer(thread_sig_info_t *info, int sig)
 #    endif
     if (info->sighand->action[sig] == NULL)
         return false;
-    if (TEST(SA_RESTORER, info->sighand->action[sig]->flags))
+    if (TESTANY(SA_RESTORER, info->sighand->action[sig]->flags))
         return true;
 #    ifdef AARCH64
     /* In AArch64 either the app or the kernel defines a restorer, not glibc, contrary
@@ -4209,7 +4210,7 @@ send_signal_to_client(dcontext_t *dcontext, int sig, sigframe_rt_t *frame,
         if (fragment != NULL && !hide_tag_from_client(fragment->tag)) {
             si.fault_fragment_info.tag = fragment->tag;
             si.fault_fragment_info.cache_start_pc = FCACHE_ENTRY_PC(fragment);
-            si.fault_fragment_info.is_trace = TEST(FRAG_IS_TRACE, fragment->flags);
+            si.fault_fragment_info.is_trace = TESTANY(FRAG_IS_TRACE, fragment->flags);
             si.fault_fragment_info.app_code_consistent =
                 !TESTANY(FRAG_WAS_DELETED | FRAG_SELFMOD_SANDBOXED, fragment->flags);
         }
@@ -4376,8 +4377,8 @@ abort_on_fault(dcontext_t *dcontext, uint dumpcore_flag, app_pc pc, byte *target
 #if defined(STATIC_LIBRARY) && defined(LINUX)
     /* i#2119: if we're invoking an app handler, disable a fatal coredump. */
     if (INTERNAL_OPTION(invoke_app_on_crash) && info->sighand->action[sig] != NULL &&
-        IS_RT_FOR_APP(info, sig) && TEST(dumpcore_flag, DYNAMO_OPTION(dumpcore_mask)) &&
-        !DYNAMO_OPTION(live_dump))
+        IS_RT_FOR_APP(info, sig) &&
+        TESTANY(dumpcore_flag, DYNAMO_OPTION(dumpcore_mask)) && !DYNAMO_OPTION(live_dump))
         dumpcore_flag = 0;
 #endif
 
@@ -4432,7 +4433,7 @@ abort_on_fault(dcontext_t *dcontext, uint dumpcore_flag, app_pc pc, byte *target
                get_application_pid());
         (*info->sighand->action[sig]->handler)(sig, &frame->info, ucxt);
         /* If the app handler didn't terminate, now get a fatal core. */
-        if (TEST(orig_dumpcore_flag, DYNAMO_OPTION(dumpcore_mask)) &&
+        if (TESTANY(orig_dumpcore_flag, DYNAMO_OPTION(dumpcore_mask)) &&
             !DYNAMO_OPTION(live_dump))
             os_dump_core("post-app-handler attempt at core dump");
     }
@@ -4479,19 +4480,19 @@ unlink_fragment_for_signal(dcontext_t *dcontext, fragment_t *f,
     if (!waslinking)
         enter_couldbelinking(dcontext, NULL, false);
     /* may not be linked if trace_relink or something */
-    if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
         /* XXX PR 213040: we don't support unlinking coarse, so we try
          * not to come here, but for indirect branch and other spots
          * where we don't yet support translation (since can't fault)
          * we end up w/ no bound on delivery...
          */
-    } else if (TEST(FRAG_LINKED_OUTGOING, f->flags)) {
+    } else if (TESTANY(FRAG_LINKED_OUTGOING, f->flags)) {
         LOG(THREAD, LOG_ASYNCH, 3, "\tunlinking outgoing for interrupted F%d\n", f->id);
         SHARED_FLAGS_RECURSIVE_LOCK(f->flags, acquire, change_linking_lock);
         /* Double-check flags to ensure some other thread didn't unlink
          * while we waited for the change_linking_lock.
          */
-        if (TEST(FRAG_LINKED_OUTGOING, f->flags)) {
+        if (TESTANY(FRAG_LINKED_OUTGOING, f->flags)) {
             unlink_fragment_outgoing(dcontext, f);
             changed = true;
             /* i#4670: Fragments that use the special ibl xfer trampoline are unlinked
@@ -4503,7 +4504,7 @@ unlink_fragment_for_signal(dcontext_t *dcontext, fragment_t *f,
         LOG(THREAD, LOG_ASYNCH, 3, "\toutgoing already unlinked for interrupted F%d\n",
             f->id);
     }
-    if (TEST(FRAG_HAS_SYSCALL, f->flags)) {
+    if (TESTANY(FRAG_HAS_SYSCALL, f->flags)) {
         /* Syscalls are signal barriers!
          * Make sure the next syscall (if any) in f is not executed!
          * instead go back to d_r_dispatch right before the syscall
@@ -4526,7 +4527,7 @@ relink_interrupted_fragment(dcontext_t *dcontext, thread_sig_info_t *info)
     if (info->interrupted == NULL)
         return;
     /* i#2066: if we were building a trace, it may already be re-linked */
-    if (!TEST(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
+    if (!TESTANY(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
         LOG(THREAD, LOG_ASYNCH, 3, "\tre-linking outgoing for interrupted F%d\n",
             info->interrupted->id);
         SHARED_FLAGS_RECURSIVE_LOCK(info->interrupted->flags, acquire,
@@ -4534,13 +4535,13 @@ relink_interrupted_fragment(dcontext_t *dcontext, thread_sig_info_t *info)
         /* Double-check flags to ensure some other thread didn't link
          * while we waited for the change_linking_lock.
          */
-        if (!TEST(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
+        if (!TESTANY(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
             link_fragment_outgoing(dcontext, info->interrupted, false);
         }
         SHARED_FLAGS_RECURSIVE_LOCK(info->interrupted->flags, release,
                                     change_linking_lock);
     }
-    if (TEST(FRAG_HAS_SYSCALL, info->interrupted->flags)) {
+    if (TESTANY(FRAG_HAS_SYSCALL, info->interrupted->flags)) {
         /* restore syscall (they're a barrier to signals, so signal
          * handler has cur frag exit before it does a syscall)
          */
@@ -4558,7 +4559,7 @@ interrupted_inlined_syscall(dcontext_t *dcontext, fragment_t *f,
                             byte *pc /*interruption pc*/)
 {
     bool pre_or_post_syscall = false;
-    if (TEST(FRAG_HAS_SYSCALL, f->flags)) {
+    if (TESTANY(FRAG_HAS_SYSCALL, f->flags)) {
         /* PR 596147: if the thread is currently in an inlined
          * syscall when a signal comes in, we can't delay and bound the
          * delivery time: we need to deliver now.  Should decode
@@ -4622,7 +4623,7 @@ adjust_syscall_for_restart(dcontext_t *dcontext, thread_sig_info_t *info, int si
     }
     /* Don't restart if the app's handler says not to */
     if (info->sighand->action[sig] != NULL &&
-        !TEST(SA_RESTART, info->sighand->action[sig]->flags)) {
+        !TESTANY(SA_RESTART, info->sighand->action[sig]->flags)) {
         return false;
     }
     /* XXX i#1145: some syscalls are never restarted when interrupted by a signal.
@@ -4988,7 +4989,7 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
             } else {
                 f = fragment_pclookup(dcontext, pc, &wrapper);
                 ASSERT(f != NULL);
-                ASSERT(!TEST(FRAG_COARSE_GRAIN, f->flags)); /* checked above */
+                ASSERT(!TESTANY(FRAG_COARSE_GRAIN, f->flags)); /* checked above */
                 LOG(THREAD, LOG_ASYNCH, 2, "\tdelaying until exit F%d\n", f->id);
                 if (interrupted_inlined_syscall(dcontext, f, pc)) {
                     /* PR 596147: if delayable signal arrives after syscall-skipping
@@ -5084,7 +5085,7 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
          */
         if (info->interrupted == NULL && !get_at_syscall(dcontext)) {
             f = find_next_fragment_from_gencode(dcontext, sc);
-            if (f != NULL && !TEST(FRAG_COARSE_GRAIN, f->flags)) {
+            if (f != NULL && !TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
                 if (unlink_fragment_for_signal(dcontext, f, FCACHE_ENTRY_PC(f))) {
                     info->interrupted = f;
                     info->interrupted_pc = FCACHE_ENTRY_PC(f);
@@ -5473,8 +5474,8 @@ compute_memory_target(dcontext_t *dcontext, cache_pc instr_cache_pc,
             } else {
                 in_maps = get_memory_info_from_os(target, NULL, NULL, &prot);
             }
-            if ((!in_maps || !TEST(MEMPROT_READ, prot)) ||
-                (*write && !TEST(MEMPROT_WRITE, prot))) {
+            if ((!in_maps || !TESTANY(MEMPROT_READ, prot)) ||
+                (*write && !TESTANY(MEMPROT_WRITE, prot))) {
                 found_target = true;
                 break;
             }
@@ -5484,7 +5485,7 @@ compute_memory_target(dcontext_t *dcontext, cache_pc instr_cache_pc,
     if (!found_target) {
         /* probably an NX fault: how tell whether kernel enforcing? */
         in_maps = get_memory_info_from_os(instr_cache_pc, NULL, NULL, &prot);
-        if (!in_maps || !TEST(MEMPROT_EXEC, prot)) {
+        if (!in_maps || !TESTANY(MEMPROT_EXEC, prot)) {
             target = instr_cache_pc;
             found_target = true;
         }
@@ -5939,7 +5940,7 @@ main_signal_handler_C(byte *xsp)
             LOG(THREAD, LOG_ALL, level, "TRY fault at " PFX "\n", pc);
             ASSERT(dynamo_initialized || global_try_except.try_except_state == NULL ||
                    global_try_tid == get_sys_thread_id());
-            if (TEST(DUMPCORE_TRY_EXCEPT, DYNAMO_OPTION(dumpcore_mask)))
+            if (TESTANY(DUMPCORE_TRY_EXCEPT, DYNAMO_OPTION(dumpcore_mask)))
                 os_dump_core("try/except fault");
 
             if (is_safe_read_ucxt(ucxt)) {
@@ -6070,7 +6071,7 @@ main_signal_handler_C(byte *xsp)
                     /* Since we have no sigreturn we have to restore the mask manually */
                     unblock_all_signals(NULL);
                     /* Let's pass it back to the application - memory is unreadable */
-                    if (TEST(DUMPCORE_FORGE_UNREAD_EXEC, DYNAMO_OPTION(dumpcore_mask)))
+                    if (TESTANY(DUMPCORE_FORGE_UNREAD_EXEC, DYNAMO_OPTION(dumpcore_mask)))
                         os_dump_core("Warning: Racy app execution (decode unreadable)");
                     os_forge_exception(target, UNREADABLE_MEMORY_EXECUTION_EXCEPTION);
                     ASSERT_NOT_REACHED();
@@ -6487,7 +6488,7 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
      */
 #if defined(MACOS64) && defined(AARCH64)
     mcontext->r0 = (reg_t)info->sighand->action[sig]->handler;
-    int infostyle = TEST(SA_SIGINFO, info->sighand->action[sig]->flags)
+    int infostyle = TESTANY(SA_SIGINFO, info->sighand->action[sig]->flags)
         ? SIGHAND_STYLE_UC_FLAVOR
         : SIGHAND_STYLE_UC_TRAD;
     mcontext->r1 = infostyle;
@@ -6497,7 +6498,7 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
     mcontext->lr = (reg_t)dynamorio_sigreturn;
 #elif defined(MACOS64) && defined(X86)
     mcontext->xdi = (reg_t)info->sighand->action[sig]->handler;
-    int infostyle = TEST(SA_SIGINFO, info->sighand->action[sig]->flags)
+    int infostyle = TESTANY(SA_SIGINFO, info->sighand->action[sig]->flags)
         ? SIGHAND_STYLE_UC_FLAVOR
         : SIGHAND_STYLE_UC_TRAD;
     mcontext->xsi = infostyle;
@@ -6753,7 +6754,7 @@ execute_native_handler(dcontext_t *dcontext, int sig, sigframe_rt_t *our_frame,
     /* Get the signals that are supposed to be blocked during handling of sig. */
     kernel_sigset_t blocked;
     blocked = info->sighand->action[sig]->mask;
-    if (!TEST(SA_NOMASK, (info->sighand->action[sig]->flags)))
+    if (!TESTANY(SA_NOMASK, (info->sighand->action[sig]->flags)))
         kernel_sigaddset(&blocked, sig);
 
     if (reuse_cur_frame) {
@@ -6877,7 +6878,7 @@ execute_native_handler(dcontext_t *dcontext, int sig, sigframe_rt_t *our_frame,
     LOG(THREAD, LOG_ASYNCH, 2, "%s: set pc to handler %p with xsp=%p\n", __FUNCTION__,
         SIGACT_PRIMARY_HANDLER(info->sighand->action[sig]), new_xsp);
 
-    if (TEST(SA_ONESHOT, detached_sigact[sig].flags)) {
+    if (TESTANY(SA_ONESHOT, detached_sigact[sig].flags)) {
         /* XXX: When we remove DR's handler from the final thread we'll ignore this
          * delivery: but we can't safely access that data struct here.  The best we
          * can do is avoid delivering twice ourselves.
@@ -6977,7 +6978,7 @@ os_terminate_via_signal(dcontext_t *dcontext, terminate_flags_t flags, int sig)
             ASSERT(res);
         }
     }
-    if (TEST(TERMINATE_CLEANUP, flags)) {
+    if (TESTANY(TERMINATE_CLEANUP, flags)) {
         /* we enter from several different places, so rewind until top-level kstat */
         KSTOP_REWIND_UNTIL(thread_measured);
         ASSERT(dcontext != NULL);
@@ -7538,7 +7539,7 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
      * XXX i#3182: It did happen but it is not clear how.
      */
     if (info->sighand->action[sig] != NULL &&
-        TEST(SA_ONESHOT, info->sighand->action[sig]->flags)) {
+        TESTANY(SA_ONESHOT, info->sighand->action[sig]->flags)) {
         ASSERT(info->sighand->action[sig]->handler == (handler_t)SIG_DFL);
         if (!info->sighand->we_intercept[sig]) {
             /* let kernel do default independent of us */
@@ -7577,7 +7578,8 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
      * pre_syscall, prior to entering cache)
      */
     dcontext->asynch_target = canonicalize_pc_target(
-        dcontext, (app_pc)(sc->SC_XIP IF_ARM(| (TEST(EFLAGS_T, sc->SC_XFLAGS) ? 1 : 0))));
+        dcontext,
+        (app_pc)(sc->SC_XIP IF_ARM(| (TESTANY(EFLAGS_T, sc->SC_XFLAGS) ? 1 : 0))));
     DEBUG_DECLARE(app_pc next_pc = dcontext->asynch_target;)
 
 #ifdef VMX86_SERVER
@@ -7838,7 +7840,7 @@ os_dump_core(const char *msg)
 {
     /* XXX Case 3408: fork stack dump crashes on 2.6 kernel, so moving the getchar
      * ahead to aid in debugging */
-    if (TEST(DUMPCORE_WAIT_FOR_DEBUGGER, dynamo_options.dumpcore_mask)) {
+    if (TESTANY(DUMPCORE_WAIT_FOR_DEBUGGER, dynamo_options.dumpcore_mask)) {
         SYSLOG_INTERNAL_ERROR("looping so you can use gdb to attach to pid %s",
                               get_application_pid());
         SYSLOG(SYSLOG_CRITICAL, WAITING_FOR_DEBUGGER, 2, get_application_name(),
@@ -7854,7 +7856,7 @@ os_dump_core(const char *msg)
         os_request_live_coredump(msg);
     }
 
-    if (TEST(DUMPCORE_INCLUDE_STACKDUMP, dynamo_options.dumpcore_mask)) {
+    if (TESTANY(DUMPCORE_INCLUDE_STACKDUMP, dynamo_options.dumpcore_mask)) {
         /* fork, dump core, then use gdb to get a stack dump
          * we can get into an infinite loop if there's a seg fault
          * in the process of doing this -- so we have a do-once test,
@@ -8722,7 +8724,7 @@ handle_suspend_signal(dcontext_t *dcontext, kernel_siginfo_t *siginfo,
 
     if (is_sigqueue_supported() && SUSPEND_SIGNAL == NUDGESIG_SIGNUM) {
         nudge_arg_t *arg = (nudge_arg_t *)siginfo;
-        if (!TEST(NUDGE_IS_SUSPEND, arg->flags)) {
+        if (!TESTANY(NUDGE_IS_SUSPEND, arg->flags)) {
             return handle_nudge_signal(dcontext, siginfo, ucxt);
         }
     }
@@ -8907,7 +8909,7 @@ handle_nudge_signal(dcontext_t *dcontext, kernel_siginfo_t *siginfo,
         return true; /* pass to app */
 #ifndef VMX86_SERVER
     DODEBUG({
-        if (TEST(NUDGE_GENERIC(client), arg->nudge_action_mask) &&
+        if (TESTANY(NUDGE_GENERIC(client), arg->nudge_action_mask) &&
             !is_valid_client_id(arg->client_id)) {
             SYSLOG_INTERNAL_WARNING("received client nudge for invalid id=0x%x",
                                     arg->client_id);

--- a/core/unix/signal_linux.c
+++ b/core/unix/signal_linux.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -445,13 +445,13 @@ handle_pre_signalfd(dcontext_t *dcontext, int fd, kernel_sigset_t *mask, size_t 
         /* Keep our write fd in the private fd space */
         pipe->write_fd = fd_priv_dup(fds[1]);
         os_close(fds[1]);
-        if (TEST(SFD_CLOEXEC, flags))
+        if (TESTANY(SFD_CLOEXEC, flags))
             fd_mark_close_on_exec(pipe->write_fd);
         fd_table_add(pipe->write_fd, 0 /*keep across fork*/);
 
         /* We need an un-closable copy of the read fd in case we need to dup it */
         pipe->read_fd = fd_priv_dup(fds[0]);
-        if (TEST(SFD_CLOEXEC, flags))
+        if (TESTANY(SFD_CLOEXEC, flags))
             fd_mark_close_on_exec(pipe->read_fd);
         fd_table_add(pipe->read_fd, 0 /*keep across fork*/);
 

--- a/core/unix/signal_linux_x86.c
+++ b/core/unix/signal_linux_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -130,7 +130,7 @@ twd_fxsr_to_i387(struct i387_fxsave_struct *fxsave)
     uint ret = 0xffff0000;
     int i;
     for (i = 0; i < 8; i++) {
-        if (TEST(0x1, twd)) {
+        if (TESTANY(0x1, twd)) {
             st = (kernel_fpxreg_t *)&fxsave->st_space[i * 4];
 
             switch (st->exponent & 0x7fff) {
@@ -146,7 +146,7 @@ twd_fxsr_to_i387(struct i387_fxsave_struct *fxsave)
                 }
                 break;
             default:
-                if (TEST(0x8000, st->significand[3])) {
+                if (TESTANY(0x8000, st->significand[3])) {
                     tag = 0; /* Valid */
                 } else {
                     tag = 2; /* Special */
@@ -447,7 +447,7 @@ dump_fpstate(dcontext_t *dcontext, kernel_fpstate_t *fp)
              * is obtained via cpuid, which is the xstate size of 64-bit arch.
              */
             ASSERT(fp->sw_reserved.extended_size >= sizeof(*xstate));
-            ASSERT(TEST(XCR0_AVX, fp->sw_reserved.xstate_bv));
+            ASSERT(TESTANY(XCR0_AVX, fp->sw_reserved.xstate_bv));
             LOG(THREAD, LOG_ASYNCH, 1, "\txstate_bv = 0x" HEX64_FORMAT_STRING "\n",
                 xstate->xstate_hdr.xstate_bv);
             for (i = 0; i < proc_num_simd_sse_avx_registers(); i++) {
@@ -528,7 +528,7 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
                  * is obtained via cpuid, which is the xstate size of 64-bit arch.
                  */
                 ASSERT(sc->fpstate->sw_reserved.extended_size >= sizeof(*xstate));
-                ASSERT(TEST(XCR0_AVX, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_AVX, sc->fpstate->sw_reserved.xstate_bv));
                 for (i = 0; i < proc_num_simd_sse_avx_registers(); i++) {
                     memcpy(&mc->simd[i].u32[4], &xstate->ymmh.ymmh_space[i * 4],
                            YMMH_REG_SIZE);
@@ -542,9 +542,9 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
                 /* The following three XCR0 bits should have been checked already
                  * in ZMM_ENABLED().
                  */
-                ASSERT(TEST(XCR0_ZMM_HI256, sc->fpstate->sw_reserved.xstate_bv));
-                ASSERT(TEST(XCR0_HI16_ZMM, sc->fpstate->sw_reserved.xstate_bv));
-                ASSERT(TEST(XCR0_OPMASK, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_ZMM_HI256, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_HI16_ZMM, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_OPMASK, sc->fpstate->sw_reserved.xstate_bv));
                 for (i = 0; i < proc_num_simd_sse_avx_registers(); i++) {
                     memcpy(&mc->simd[i].u32[8],
                            (byte *)xstate + proc_xstate_area_zmm_hi256_offs() +
@@ -557,7 +557,7 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
                                i * ZMM_REG_SIZE,
                            ZMM_REG_SIZE);
                 }
-                ASSERT(TEST(XCR0_OPMASK, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_OPMASK, sc->fpstate->sw_reserved.xstate_bv));
                 for (i = 0; i < proc_num_opmask_registers(); i++) {
                     memcpy(&mc->opmask[i],
                            (byte *)xstate + proc_xstate_area_kmask_offs() +
@@ -591,7 +591,7 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
                  * is obtained via cpuid, which is the xstate size of 64-bit arch.
                  */
                 ASSERT(sc->fpstate->sw_reserved.extended_size >= sizeof(*xstate));
-                ASSERT(TEST(XCR0_AVX, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_AVX, sc->fpstate->sw_reserved.xstate_bv));
                 for (i = 0; i < proc_num_simd_sse_avx_registers(); i++) {
                     memcpy(&xstate->ymmh.ymmh_space[i * 4], &mc->simd[i].u32[4],
                            YMMH_REG_SIZE);
@@ -622,9 +622,9 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
                 /* The following three XCR0 bits should have been checked already
                  * in ZMM_ENABLED().
                  */
-                ASSERT(TEST(XCR0_ZMM_HI256, sc->fpstate->sw_reserved.xstate_bv));
-                ASSERT(TEST(XCR0_HI16_ZMM, sc->fpstate->sw_reserved.xstate_bv));
-                ASSERT(TEST(XCR0_OPMASK, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_ZMM_HI256, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_HI16_ZMM, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_OPMASK, sc->fpstate->sw_reserved.xstate_bv));
                 for (i = 0; i < proc_num_simd_sse_avx_registers(); i++) {
                     memcpy((byte *)xstate + proc_xstate_area_zmm_hi256_offs() +
                                i * ZMMH_REG_SIZE,
@@ -636,7 +636,7 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
                            &mc->simd[i + proc_num_simd_sse_avx_registers()],
                            ZMM_REG_SIZE);
                 }
-                ASSERT(TEST(XCR0_OPMASK, sc->fpstate->sw_reserved.xstate_bv));
+                ASSERT(TESTANY(XCR0_OPMASK, sc->fpstate->sw_reserved.xstate_bv));
                 for (i = 0; i < proc_num_opmask_registers(); i++) {
                     memcpy((byte *)xstate + proc_xstate_area_kmask_offs() +
                                i * OPMASK_AVX512BW_REG_SIZE,

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -599,13 +599,13 @@ libc_sigismember(const sigset_t *set, int _sig)
     int sig = _sig - 1; /* go to 0-based */
 #if defined(MACOS) || defined(ANDROID32)
     /* sigset_t is just a uint32 */
-    return TEST(1UL << sig, *set);
+    return TESTANY(1UL << sig, *set);
 #else
     /* "set->__val" would be cleaner, but is glibc specific (e.g. musl libc
      * uses __bits as the field name on sigset_t).
      */
     uint bits_per = 8 * sizeof(ulong);
-    return TEST(1UL << (sig % bits_per), ((const ulong *)set)[sig / bits_per]);
+    return TESTANY(1UL << (sig % bits_per), ((const ulong *)set)[sig / bits_per]);
 #endif
 }
 

--- a/core/unix/tls_linux_x86.c
+++ b/core/unix/tls_linux_x86.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -658,12 +658,12 @@ tls_get_fs_gs_segment_base(uint seg)
     uint selector = read_thread_register(seg);
     uint index = SELECTOR_INDEX(selector);
     LOG(THREAD_GET, LOG_THREADS, 4, "%s selector %x index %d ldt %d\n", __func__,
-        selector, index, TEST(SELECTOR_IS_LDT, selector));
+        selector, index, TESTANY(SELECTOR_IS_LDT, selector));
 
     if (seg != SEG_FS && seg != SEG_GS)
         return (byte *)POINTER_MAX;
 
-    if (TEST(SELECTOR_IS_LDT, selector)) {
+    if (TESTANY(SELECTOR_IS_LDT, selector)) {
         LOG(THREAD_GET, LOG_THREADS, 4, "selector is LDT\n");
         /* we have to read the entire ldt from 0 to the index */
         size_t sz = sizeof(raw_ldt_entry_t) * (index + 1);

--- a/core/unix/tls_macos_x86.c
+++ b/core/unix/tls_macos_x86.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -323,9 +323,9 @@ tls_get_fs_gs_segment_base(uint seg)
     selector = read_thread_register(seg);
     index = SELECTOR_INDEX(selector);
     LOG(THREAD_GET, LOG_THREADS, 4, "%s selector %x index %d ldt %d\n", __FUNCTION__,
-        selector, index, TEST(SELECTOR_IS_LDT, selector));
+        selector, index, TESTANY(SELECTOR_IS_LDT, selector));
 
-    if (!TEST(SELECTOR_IS_LDT, selector) && selector != 0) {
+    if (!TESTANY(SELECTOR_IS_LDT, selector) && selector != 0) {
         ASSERT_NOT_IMPLEMENTED(false);
         return (byte *)POINTER_MAX;
     }

--- a/core/utils.c
+++ b/core/utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2017 ARM Limited. All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
@@ -610,7 +610,7 @@ deadlock_avoidance_lock(mutex_t *lock, bool acquired, bool ownable)
                         d_r_get_thread_id());
                     dump_owned_locks(dcontext);
                     /* like syslog don't synchronize options for dumpcore_mask */
-                    if (TEST(DUMPCORE_DEADLOCK, DYNAMO_OPTION(dumpcore_mask)))
+                    if (TESTANY(DUMPCORE_DEADLOCK, DYNAMO_OPTION(dumpcore_mask)))
                         os_dump_core("rank order violation");
                 }
                 ASSERT((dcontext->thread_owned_locks->last_lock->rank < lock->rank ||
@@ -1897,9 +1897,9 @@ d_r_notify(syslog_event_type_t priority, bool internal, bool synch,
     LOG(THREAD_GET, LOG_ALL, 1, "%s: %s\n", prefix, msgbuf);
 
 #ifdef WINDOWS
-    if (TEST(priority, dynamo_options.syslog_mask)) {
+    if (TESTANY(priority, dynamo_options.syslog_mask)) {
         if (internal) {
-            if (TEST(priority, INTERNAL_OPTION(syslog_internal_mask))) {
+            if (TESTANY(priority, INTERNAL_OPTION(syslog_internal_mask))) {
                 do_syslog(priority, message_id, 3, get_application_name(),
                           get_application_pid(), msgbuf);
             }
@@ -1913,10 +1913,10 @@ d_r_notify(syslog_event_type_t priority, bool internal, bool synch,
     /* syslog not yet implemented on linux, XXX */
 #endif
 
-    if (TEST(priority, dynamo_options.stderr_mask))
+    if (TESTANY(priority, dynamo_options.stderr_mask))
         print_file(STDERR, "<%s>\n", msgbuf);
 
-    if (TEST(priority, dynamo_options.msgbox_mask)) {
+    if (TESTANY(priority, dynamo_options.msgbox_mask)) {
 #ifdef WINDOWS
         /* XXX: could use os_countdown_msgbox (if ever implemented) here to
          * do a timed out messagebox, could then also replace the os_timeout in
@@ -2102,7 +2102,7 @@ set_display_version(const char *ver)
 }
 
 /* Fine to pass NULL for dcontext, will obtain it for you.
- * If TEST(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag), does a full SYSLOG;
+ * If TESTANY(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag), does a full SYSLOG;
  * else, does a SYSLOG_INTERNAL_ERROR.
  * Fine to pass NULL for report_ebp: will use current ebp for you.
  */
@@ -2179,7 +2179,7 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
         curbuf += (len == -1 ? REPORT_LEN_STACK_EACH : (len < 0 ? 0 : len));
     }
     /* Only walk the module list if we think the data structs are safe */
-    if (!TEST(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag)) {
+    if (!TESTANY(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag)) {
         size_t sofar = 0;
         /* We decided it's better to include the paths even if it means we may
          * not fit all the modules (i#968).  We plan to add the modules to the
@@ -2197,24 +2197,25 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
     *curbuf = '\0';
     /* now done with reportbuf */
 
-    if (TEST(dumpcore_flag, DYNAMO_OPTION(dumpcore_mask)) && DYNAMO_OPTION(live_dump)) {
+    if (TESTANY(dumpcore_flag, DYNAMO_OPTION(dumpcore_mask)) &&
+        DYNAMO_OPTION(live_dump)) {
         /* non-fatal coredumps attempted before printing further diagnostics */
         os_dump_core(reportbuf);
     }
 
     /* we already synchronized the options at the top of this function and we
      * might be stack critical so use _NO_OPTION_SYNCH */
-    if (TEST(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag) ||
-        TEST(DUMPCORE_CLIENT_EXCEPTION, dumpcore_flag)) {
+    if (TESTANY(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag) ||
+        TESTANY(DUMPCORE_CLIENT_EXCEPTION, dumpcore_flag)) {
         char saddr[IF_X64_ELSE(19, 11)];
         snprintf(saddr, BUFFER_SIZE_ELEMENTS(saddr), PFX, exception_addr);
         NULL_TERMINATE_BUFFER(saddr);
-        if (TEST(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag)) {
+        if (TESTANY(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag)) {
             SYSLOG_NO_OPTION_SYNCH(
                 SYSLOG_CRITICAL, EXCEPTION, 7 /*#args*/, get_application_name(),
                 get_application_pid(), exception_label_core,
-                TEST(DUMPCORE_STACK_OVERFLOW, dumpcore_flag) ? STACK_OVERFLOW_NAME
-                                                             : CRASH_NAME,
+                TESTANY(DUMPCORE_STACK_OVERFLOW, dumpcore_flag) ? STACK_OVERFLOW_NAME
+                                                                : CRASH_NAME,
                 saddr, exception_report_url,
                 /* skip the prefix since the event log string
                  * already has it */
@@ -2223,18 +2224,18 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
             SYSLOG_NO_OPTION_SYNCH(
                 SYSLOG_CRITICAL, CLIENT_EXCEPTION, 7 /*#args*/, get_application_name(),
                 get_application_pid(), exception_label_client,
-                TEST(DUMPCORE_STACK_OVERFLOW, dumpcore_flag) ? STACK_OVERFLOW_NAME
-                                                             : CRASH_NAME,
+                TESTANY(DUMPCORE_STACK_OVERFLOW, dumpcore_flag) ? STACK_OVERFLOW_NAME
+                                                                : CRASH_NAME,
                 saddr, exception_report_url,
                 reportbuf + report_client_exception_skip_prefix());
         }
-    } else if (TEST(DUMPCORE_ASSERTION, dumpcore_flag)) {
+    } else if (TESTANY(DUMPCORE_ASSERTION, dumpcore_flag)) {
         /* We need to report ASSERTS in DEBUG=1 INTERNAL=0 builds since we're still
          * going to kill the process. Xref PR 232783. d_r_internal_error() already
          * obfuscated the which file info. */
         SYSLOG_NO_OPTION_SYNCH(SYSLOG_ERROR, INTERNAL_SYSLOG_ERROR, 3,
                                get_application_name(), get_application_pid(), reportbuf);
-    } else if (TEST(DUMPCORE_CURIOSITY, dumpcore_flag)) {
+    } else if (TESTANY(DUMPCORE_CURIOSITY, dumpcore_flag)) {
         SYSLOG_INTERNAL_NO_OPTION_SYNCH(SYSLOG_WARNING, "%s", reportbuf);
     } else {
         SYSLOG_INTERNAL_NO_OPTION_SYNCH(SYSLOG_ERROR, "%s", reportbuf);
@@ -2256,7 +2257,7 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
      * for client and app crashes but not DR crashes.
      */
     DOLOG(1, LOG_ALL, {
-        if (TEST(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag))
+        if (TESTANY(DUMPCORE_INTERNAL_EXCEPTION, dumpcore_flag))
             dump_callstack(exception_addr, report_ebp, THREAD, DUMP_NOT_XML);
         else
             dump_dr_callstack(THREAD);
@@ -2276,7 +2277,8 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
         });
     }
 
-    if (TEST(dumpcore_flag, DYNAMO_OPTION(dumpcore_mask)) && !DYNAMO_OPTION(live_dump)) {
+    if (TESTANY(dumpcore_flag, DYNAMO_OPTION(dumpcore_mask)) &&
+        !DYNAMO_OPTION(live_dump)) {
         /* fatal coredump goes last */
         os_dump_core(reportbuf);
     }
@@ -2291,7 +2293,7 @@ report_app_problem(dcontext_t *dcontext, uint appfault_flag, app_pc pc, app_pc r
     va_list ap;
     char excpt_addr[IF_X64_ELSE(20, 12)];
 
-    if (!TEST(appfault_flag, DYNAMO_OPTION(appfault_mask)))
+    if (!TESTANY(appfault_flag, DYNAMO_OPTION(appfault_mask)))
         return;
 
     snprintf(excpt_addr, BUFFER_SIZE_ELEMENTS(excpt_addr), PFX, pc);
@@ -2316,7 +2318,7 @@ report_app_problem(dcontext_t *dcontext, uint appfault_flag, app_pc pc, app_pc r
 
     report_diagnostics(buf, NULL, NO_VIOLATION_OK_INTERNAL_STATE);
 
-    if (TEST(DUMPCORE_APP_EXCEPTION, DYNAMO_OPTION(dumpcore_mask)))
+    if (TESTANY(DUMPCORE_APP_EXCEPTION, DYNAMO_OPTION(dumpcore_mask)))
         os_dump_core("application fault");
 }
 
@@ -2443,12 +2445,12 @@ safe_write_try_except(void *base, size_t size, const void *in_buf, size_t *bytes
         if (is_readable_without_exception(base, size) &&
             IF_UNIX_ELSE(get_memory_info_from_os, get_memory_info)(base, &region_base,
                                                                    &region_size, &prot) &&
-            TEST(MEMPROT_WRITE, prot)) {
+            TESTANY(MEMPROT_WRITE, prot)) {
             size_t bytes_checked = region_size - ((byte *)base - region_base);
             while (bytes_checked < size) {
                 if (!IF_UNIX_ELSE(get_memory_info_from_os, get_memory_info)(
                         region_base + region_size, &region_base, &region_size, &prot) ||
-                    !TEST(MEMPROT_WRITE, prot))
+                    !TESTANY(MEMPROT_WRITE, prot))
                     return false;
                 bytes_checked += region_size;
             }
@@ -3259,13 +3261,13 @@ dump_buffer_as_ascii(file_t logfile, char *buffer, size_t len)
 void
 dump_buffer_as_bytes(file_t logfile, void *buffer, size_t len, int flags)
 {
-    bool octal = TEST(DUMP_OCTAL, flags);
-    bool raw = TEST(DUMP_RAW, flags);
-    bool usechars = !raw && !TEST(DUMP_NO_CHARS, flags);
-    bool replayable = usechars && !TEST(DUMP_NO_QUOTING, flags);
-    bool dword = TEST(DUMP_DWORD, flags);
-    bool prepend_address = TEST(DUMP_ADDRESS, flags);
-    bool append_ascii = TEST(DUMP_APPEND_ASCII, flags);
+    bool octal = TESTANY(DUMP_OCTAL, flags);
+    bool raw = TESTANY(DUMP_RAW, flags);
+    bool usechars = !raw && !TESTANY(DUMP_NO_CHARS, flags);
+    bool replayable = usechars && !TESTANY(DUMP_NO_QUOTING, flags);
+    bool dword = TESTANY(DUMP_DWORD, flags);
+    bool prepend_address = TESTANY(DUMP_ADDRESS, flags);
+    bool append_ascii = TESTANY(DUMP_APPEND_ASCII, flags);
 
     unsigned char *buf = (unsigned char *)buffer;
 

--- a/core/utils.h
+++ b/core/utils.h
@@ -933,8 +933,8 @@ dr_modload_hook_exists(void); /* hard to include instrument.h here */
             d_r_mutex_unlock(&(bb_building_lock));                                      \
     } while (0)
 /* we assume dynamo_resetting is only done w/ all threads suspended */
-#define NEED_SHARED_LOCK(flags)                                             \
-    (TEST(FRAG_SHARED, (flags)) && !INTERNAL_OPTION(single_thread_in_DR) && \
+#define NEED_SHARED_LOCK(flags)                                                \
+    (TESTANY(FRAG_SHARED, (flags)) && !INTERNAL_OPTION(single_thread_in_DR) && \
      !dynamo_exited && !dynamo_resetting)
 #define SHARED_FLAGS_MUTEX(flags, operation, lock) \
     do {                                           \
@@ -2055,14 +2055,15 @@ d_r_notify(syslog_event_type_t priority, bool internal, bool synch,
         SYSLOG_INTERNAL_ERROR(__VA_ARGS__); \
         ASSERT_NOT_REACHED();               \
     } while (0)
-#define FATAL_USAGE_ERROR(id, sub, ...)                                                \
-    do {                                                                               \
-        /* synchronize dynamic options for dumpcore_mask */                            \
-        synchronize_dynamic_options();                                                 \
-        if (TEST(DUMPCORE_FATAL_USAGE_ERROR, DYNAMO_OPTION_NOT_STRING(dumpcore_mask))) \
-            os_dump_core("fatal usage error");                                         \
-        SYSLOG(SYSLOG_CRITICAL, id, sub, __VA_ARGS__);                                 \
-        os_terminate(NULL, TERMINATE_PROCESS);                                         \
+#define FATAL_USAGE_ERROR(id, sub, ...)                       \
+    do {                                                      \
+        /* synchronize dynamic options for dumpcore_mask */   \
+        synchronize_dynamic_options();                        \
+        if (TESTANY(DUMPCORE_FATAL_USAGE_ERROR,               \
+                    DYNAMO_OPTION_NOT_STRING(dumpcore_mask))) \
+            os_dump_core("fatal usage error");                \
+        SYSLOG(SYSLOG_CRITICAL, id, sub, __VA_ARGS__);        \
+        os_terminate(NULL, TERMINATE_PROCESS);                \
     } while (0)
 #define OPTION_PARSE_ERROR(id, sub, ...)                            \
     do {                                                            \

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -141,7 +141,7 @@ enum {
 
 /* Because VM_MADE_READONLY == VM_WRITABLE it's not sufficient on its own */
 #define DR_MADE_READONLY(flags) \
-    (INTERNAL_OPTION(hw_cache_consistency) && TEST(VM_MADE_READONLY, flags))
+    (INTERNAL_OPTION(hw_cache_consistency) && TESTANY(VM_MADE_READONLY, flags))
 
 /* Fields only used for written_areas */
 typedef struct _ro_vs_sandbox_data_t {
@@ -231,8 +231,8 @@ typedef struct thread_data_t {
 #endif
 } thread_data_t;
 
-#define SHOULD_LOCK_VECTOR(v)                                                \
-    (TEST(VECTOR_SHARED, (v)->flags) && !TEST(VECTOR_NO_LOCK, (v)->flags) && \
+#define SHOULD_LOCK_VECTOR(v)                                                      \
+    (TESTANY(VECTOR_SHARED, (v)->flags) && !TESTANY(VECTOR_NO_LOCK, (v)->flags) && \
      !self_owns_write_lock(&(v)->lock))
 
 #define LOCK_VECTOR(v, release_lock, RW) \
@@ -244,14 +244,14 @@ typedef struct thread_data_t {
             (release_lock) = false;      \
     } while (0);
 
-#define UNLOCK_VECTOR(v, release_lock, RW)               \
-    do {                                                 \
-        if ((release_lock)) {                            \
-            ASSERT(TEST(VECTOR_SHARED, (v)->flags));     \
-            ASSERT(!TEST(VECTOR_NO_LOCK, (v)->flags));   \
-            ASSERT_OWN_READWRITE_LOCK(true, &(v)->lock); \
-            d_r_##RW##_unlock(&v->lock);                 \
-        }                                                \
+#define UNLOCK_VECTOR(v, release_lock, RW)                \
+    do {                                                  \
+        if ((release_lock)) {                             \
+            ASSERT(TESTANY(VECTOR_SHARED, (v)->flags));   \
+            ASSERT(!TESTANY(VECTOR_NO_LOCK, (v)->flags)); \
+            ASSERT_OWN_READWRITE_LOCK(true, &(v)->lock);  \
+            d_r_##RW##_unlock(&v->lock);                  \
+        }                                                 \
     } while (0);
 
 /* these two global vectors store all executable areas and all dynamo
@@ -417,20 +417,20 @@ DECLARE_CXTSWPROT_VAR(static mutex_t lazy_delete_lock, INIT_LOCK_FREE(lazy_delet
 
 /* multi_entry_t allocation is either global or local heap */
 #define MULTI_ALLOC_DC(dc, flags) FRAGMENT_ALLOC_DC(dc, flags)
-#define GET_DATA(dc, flags)                                  \
-    (((dc) == GLOBAL_DCONTEXT || TEST(FRAG_SHARED, (flags))) \
-         ? shared_data                                       \
+#define GET_DATA(dc, flags)                                     \
+    (((dc) == GLOBAL_DCONTEXT || TESTANY(FRAG_SHARED, (flags))) \
+         ? shared_data                                          \
          : (thread_data_t *)(dc)->vm_areas_field)
-#define GET_VECTOR(dc, flags)                                             \
-    (((dc) == GLOBAL_DCONTEXT || TEST(FRAG_SHARED, (flags)))              \
-         ? (TEST(FRAG_WAS_DELETED, (flags)) ? NULL : &shared_data->areas) \
+#define GET_VECTOR(dc, flags)                                                \
+    (((dc) == GLOBAL_DCONTEXT || TESTANY(FRAG_SHARED, (flags)))              \
+         ? (TESTANY(FRAG_WAS_DELETED, (flags)) ? NULL : &shared_data->areas) \
          : (&((thread_data_t *)(dc)->vm_areas_field)->areas))
-#define SHARED_VECTOR_RWLOCK(v, rw, op)         \
-    do {                                        \
-        if (TEST(VECTOR_SHARED, (v)->flags)) {  \
-            ASSERT(SHARED_FRAGMENTS_ENABLED()); \
-            d_r_##rw##_##op(&(v)->lock);        \
-        }                                       \
+#define SHARED_VECTOR_RWLOCK(v, rw, op)           \
+    do {                                          \
+        if (TESTANY(VECTOR_SHARED, (v)->flags)) { \
+            ASSERT(SHARED_FRAGMENTS_ENABLED());   \
+            d_r_##rw##_##op(&(v)->lock);          \
+        }                                         \
     } while (0)
 #define ASSERT_VMAREA_DATA_PROTECTED(data, RW)                          \
     ASSERT_OWN_##RW##_LOCK(                                             \
@@ -570,81 +570,81 @@ typedef struct _multi_entry_t {
 } multi_entry_t;
 
 /* macros to make dealing with both fragment_t and multi_entry_t easier */
-#define FRAG_MULTI(f) (TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags))
+#define FRAG_MULTI(f) (TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags))
 
 #define FRAG_MULTI_INIT(f) \
     (TESTALL((FRAG_IS_EXTRA_VMAREA | FRAG_IS_EXTRA_VMAREA_INIT), (f)->flags))
 
-#define FRAG_NEXT(f)                                                                \
-    ((TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? ((multi_entry_t *)(f))->next_vmarea \
-                                              : (f)->next_vmarea)
+#define FRAG_NEXT(f)                                                                   \
+    ((TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? ((multi_entry_t *)(f))->next_vmarea \
+                                                 : (f)->next_vmarea)
 
 #define FRAG_NEXT_ASSIGN(f, val)                         \
     do {                                                 \
-        if (TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags))      \
+        if (TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags))   \
             ((multi_entry_t *)(f))->next_vmarea = (val); \
         else                                             \
             (f)->next_vmarea = (val);                    \
     } while (0)
 
-#define FRAG_PREV(f)                                                                \
-    ((TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? ((multi_entry_t *)(f))->prev_vmarea \
-                                              : (f)->prev_vmarea)
+#define FRAG_PREV(f)                                                                   \
+    ((TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? ((multi_entry_t *)(f))->prev_vmarea \
+                                                 : (f)->prev_vmarea)
 
 #define FRAG_PREV_ASSIGN(f, val)                         \
     do {                                                 \
-        if (TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags))      \
+        if (TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags))   \
             ((multi_entry_t *)(f))->prev_vmarea = (val); \
         else                                             \
             (f)->prev_vmarea = (val);                    \
     } while (0)
 
 /* Case 8419: also_vmarea is invalid once we 1st-stage-delete a fragment */
-#define FRAG_ALSO(f)                           \
-    ((TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags))  \
-         ? ((multi_entry_t *)(f))->also_vmarea \
-         : (ASSERT(!TEST(FRAG_WAS_DELETED, (f)->flags)), (f)->also.also_vmarea))
+#define FRAG_ALSO(f)                             \
+    ((TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags)) \
+         ? ((multi_entry_t *)(f))->also_vmarea   \
+         : (ASSERT(!TESTANY(FRAG_WAS_DELETED, (f)->flags)), (f)->also.also_vmarea))
 /* Only call this one to avoid the assert when you know it's safe */
-#define FRAG_ALSO_DEL_OK(f)                                                         \
-    ((TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? ((multi_entry_t *)(f))->also_vmarea \
-                                              : (f)->also.also_vmarea)
+#define FRAG_ALSO_DEL_OK(f)                                                            \
+    ((TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? ((multi_entry_t *)(f))->also_vmarea \
+                                                 : (f)->also.also_vmarea)
 
-#define FRAG_ALSO_ASSIGN(f, val)                         \
-    do {                                                 \
-        if (TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags))      \
-            ((multi_entry_t *)(f))->also_vmarea = (val); \
-        else {                                           \
-            ASSERT(!TEST(FRAG_WAS_DELETED, (f)->flags)); \
-            (f)->also.also_vmarea = (val);               \
-        }                                                \
+#define FRAG_ALSO_ASSIGN(f, val)                            \
+    do {                                                    \
+        if (TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags))      \
+            ((multi_entry_t *)(f))->also_vmarea = (val);    \
+        else {                                              \
+            ASSERT(!TESTANY(FRAG_WAS_DELETED, (f)->flags)); \
+            (f)->also.also_vmarea = (val);                  \
+        }                                                   \
     } while (0)
 
 /* assumption: if multiple units, fragment_t is on list of region owning tag */
 #define FRAG_PC(f) \
-    ((TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? ((multi_entry_t *)(f))->pc : (f)->tag)
+    ((TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? ((multi_entry_t *)(f))->pc : (f)->tag)
 
-#define FRAG_PC_ASSIGN(f, val)                      \
-    do {                                            \
-        if (TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags)) \
-            ((multi_entry_t *)(f))->pc = (val);     \
-        else                                        \
-            ASSERT_NOT_REACHED();                   \
+#define FRAG_PC_ASSIGN(f, val)                         \
+    do {                                               \
+        if (TESTANY(FRAG_IS_EXTRA_VMAREA, (f)->flags)) \
+            ((multi_entry_t *)(f))->pc = (val);        \
+        else                                           \
+            ASSERT_NOT_REACHED();                      \
     } while (0)
 
 #define FRAG_FRAG(fr) \
-    ((TEST(FRAG_IS_EXTRA_VMAREA, (fr)->flags)) ? ((multi_entry_t *)(fr))->f : (fr))
+    ((TESTANY(FRAG_IS_EXTRA_VMAREA, (fr)->flags)) ? ((multi_entry_t *)(fr))->f : (fr))
 
-#define FRAG_FRAG_ASSIGN(fr, val)                    \
-    do {                                             \
-        if (TEST(FRAG_IS_EXTRA_VMAREA, (fr)->flags)) \
-            ((multi_entry_t *)(fr))->f = (val);      \
-        else                                         \
-            ASSERT_NOT_REACHED();                    \
+#define FRAG_FRAG_ASSIGN(fr, val)                       \
+    do {                                                \
+        if (TESTANY(FRAG_IS_EXTRA_VMAREA, (fr)->flags)) \
+            ((multi_entry_t *)(fr))->f = (val);         \
+        else                                            \
+            ASSERT_NOT_REACHED();                       \
     } while (0)
 
-#define FRAG_ID(fr)                                                             \
-    ((TEST(FRAG_IS_EXTRA_VMAREA, (fr)->flags)) ? ((multi_entry_t *)(fr))->f->id \
-                                               : (fr)->id)
+#define FRAG_ID(fr)                                                                \
+    ((TESTANY(FRAG_IS_EXTRA_VMAREA, (fr)->flags)) ? ((multi_entry_t *)(fr))->f->id \
+                                                  : (fr)->id)
 
 /***************************************************/
 
@@ -717,9 +717,9 @@ print_vm_flags(uint vm_flags, uint frag_flags, file_t outf)
     print_file(outf, " %s%s%s%s", (vm_flags & VM_WRITABLE) != 0 ? "W" : "-",
                (vm_flags & VM_WAS_FUTURE) != 0 ? "F" : "-",
                (frag_flags & FRAG_SELFMOD_SANDBOXED) != 0 ? "S" : "-",
-               TEST(FRAG_COARSE_GRAIN, frag_flags) ? "C" : "-");
+               TESTANY(FRAG_COARSE_GRAIN, frag_flags) ? "C" : "-");
 #ifdef PROGRAM_SHEPHERDING
-    print_file(outf, "%s%s", TEST(VM_PATTERN_REVERIFY, vm_flags) ? "P" : "-",
+    print_file(outf, "%s%s", TESTANY(VM_PATTERN_REVERIFY, vm_flags) ? "P" : "-",
                (frag_flags & FRAG_DYNGEN) != 0 ? "D" : "-");
 #endif
 }
@@ -730,7 +730,7 @@ print_vm_area(vm_area_vector_t *v, vm_area_t *area, file_t outf, const char *pre
 {
     print_file(outf, "%s" PFX "-" PFX, prefix, area->start, area->end);
     print_vm_flags(area->vm_flags, area->frag_flags, outf);
-    if (v == executable_areas && TEST(FRAG_COARSE_GRAIN, area->frag_flags)) {
+    if (v == executable_areas && TESTANY(FRAG_COARSE_GRAIN, area->frag_flags)) {
         coarse_info_t *info = (coarse_info_t *)area->custom.client;
         if (info != NULL) {
             if (info->persisted)
@@ -835,7 +835,7 @@ print_pending_list(file_t outf)
 static bool
 writelock_if_not_already(vm_area_vector_t *v)
 {
-    if (TEST(VECTOR_SHARED, v->flags) && !self_owns_write_lock(&v->lock)) {
+    if (TESTANY(VECTOR_SHARED, v->flags) && !self_owns_write_lock(&v->lock)) {
         SHARED_VECTOR_RWLOCK(v, write, lock);
         return true;
     }
@@ -940,12 +940,12 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
             (start <= v->buf[i].end && end >= v->buf[i].start &&
              vm_flags == v->buf[i].vm_flags && frag_flags == v->buf[i].frag_flags &&
              /* never merge coarse-grain */
-             !TEST(FRAG_COARSE_GRAIN, v->buf[i].frag_flags) &&
-             !TEST(VECTOR_NEVER_MERGE_ADJACENT, v->flags) &&
+             !TESTANY(FRAG_COARSE_GRAIN, v->buf[i].frag_flags) &&
+             !TESTANY(VECTOR_NEVER_MERGE_ADJACENT, v->flags) &&
              (v->should_merge_func == NULL ||
               v->should_merge_func(true /*adjacent*/, data, v->buf[i].custom.client)))) {
             ASSERT(!(start < v->buf[i].end && end > v->buf[i].start) ||
-                   !TEST(VECTOR_NEVER_OVERLAP, v->flags));
+                   !TESTANY(VECTOR_NEVER_OVERLAP, v->flags));
             if (overlap_start == -1) {
                 /* assume we'll simply expand an existing area rather than
                  * add a new one -- we'll reset this if we hit merge conflicts */
@@ -969,7 +969,7 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
                  * for executable/written areas
                  */
                 if (v != dynamo_areas &&
-                    (!TEST(VECTOR_SHARED, v->flags) || v == &shared_data->areas)) {
+                    (!TESTANY(VECTOR_SHARED, v->flags) || v == &shared_data->areas)) {
                     LOG(GLOBAL, LOG_VMAREAS, 1, "\nexecutable areas:\n");
                     print_executable_areas(GLOBAL);
                     LOG(GLOBAL, LOG_VMAREAS, 1, "\nwritten areas:\n");
@@ -986,8 +986,8 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
              * not was future and old region is then should drop from old
              * region XXX : partial overlap? we don't really care about
              * this flag anyways */
-            if (TEST(VM_WAS_FUTURE, v->buf[i].vm_flags) &&
-                !TEST(VM_WAS_FUTURE, vm_flags)) {
+            if (TESTANY(VM_WAS_FUTURE, v->buf[i].vm_flags) &&
+                !TESTANY(VM_WAS_FUTURE, vm_flags)) {
                 v->buf[i].vm_flags &= ~VM_WAS_FUTURE;
                 LOG(GLOBAL, LOG_VMAREAS, 1,
                     "Warning : removing was_future flag from area " PFX "-" PFX
@@ -998,7 +998,8 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
             /* no restrictions on ONCE_ONLY flag, but if new region is not
              * should drop fom existing region XXX : partial overlap? is
              * not much of an additional security risk */
-            if (TEST(VM_ONCE_ONLY, v->buf[i].vm_flags) && !TEST(VM_ONCE_ONLY, vm_flags)) {
+            if (TESTANY(VM_ONCE_ONLY, v->buf[i].vm_flags) &&
+                !TESTANY(VM_ONCE_ONLY, vm_flags)) {
                 v->buf[i].vm_flags &= ~VM_ONCE_ONLY;
                 LOG(GLOBAL, LOG_VMAREAS, 1,
                     "Warning : removing once_only flag from area " PFX "-" PFX
@@ -1008,13 +1009,13 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
             }
             /* shouldn't be adding unmod image over existing not unmod image,
              * reverse could happen with os region merging though */
-            ASSERT(TEST(VM_UNMOD_IMAGE, v->buf[i].vm_flags) ||
-                   !TEST(VM_UNMOD_IMAGE, vm_flags));
+            ASSERT(TESTANY(VM_UNMOD_IMAGE, v->buf[i].vm_flags) ||
+                   !TESTANY(VM_UNMOD_IMAGE, vm_flags));
             /* for VM_WRITABLE only allow new region to not be writable and
              * existing region to be writable to handle cases of os region
              * merging due to our consistency protection changes */
-            ASSERT(TEST(VM_WRITABLE, v->buf[i].vm_flags) ||
-                   !TEST(VM_WRITABLE, vm_flags) ||
+            ASSERT(TESTANY(VM_WRITABLE, v->buf[i].vm_flags) ||
+                   !TESTANY(VM_WRITABLE, vm_flags) ||
                    !INTERNAL_OPTION(hw_cache_consistency));
             /* XXX: case 7877: if new is VM_MADE_READONLY and old is not, we
              * must mark old overlapping portion as VM_MADE_READONLY.  Things only
@@ -1040,8 +1041,8 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
             ASSERT((v->buf[i].vm_flags & ~flagignore) == (vm_flags & ~flagignore));
 
             /* new region must be more innocent with respect to selfmod */
-            ASSERT(TEST(FRAG_SELFMOD_SANDBOXED, v->buf[i].frag_flags) ||
-                   !TEST(FRAG_SELFMOD_SANDBOXED, frag_flags));
+            ASSERT(TESTANY(FRAG_SELFMOD_SANDBOXED, v->buf[i].frag_flags) ||
+                   !TESTANY(FRAG_SELFMOD_SANDBOXED, frag_flags));
             /* disallow other frag_flag differences */
 #ifndef PROGRAM_SHEPHERDING
             ASSERT((v->buf[i].frag_flags & ~FRAG_SELFMOD_SANDBOXED) ==
@@ -1060,12 +1061,12 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
 #    endif
             /* shouldn't add non-dyngen overlapping existing dyngen, XXX
              * is the reverse possible? right now we allow it */
-            ASSERT(TEST(FRAG_DYNGEN, frag_flags) ||
-                   !TEST(FRAG_DYNGEN, v->buf[i].frag_flags));
+            ASSERT(TESTANY(FRAG_DYNGEN, frag_flags) ||
+                   !TESTANY(FRAG_DYNGEN, v->buf[i].frag_flags));
 #endif
             /* Never split FRAG_COARSE_GRAIN */
-            ASSERT(TEST(FRAG_COARSE_GRAIN, frag_flags) ||
-                   !TEST(FRAG_COARSE_GRAIN, v->buf[i].frag_flags));
+            ASSERT(TESTANY(FRAG_COARSE_GRAIN, frag_flags) ||
+                   !TESTANY(FRAG_COARSE_GRAIN, v->buf[i].frag_flags));
 
             /* for overlapping region: must overlap same type -- else split */
             if ((vm_flags != v->buf[i].vm_flags || frag_flags != v->buf[i].frag_flags) &&
@@ -1254,7 +1255,7 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
              * vm_area_clean_fraglist() on each merge, but we could then get
              * rid of VECTOR_FRAGMENT_LIST.
              */
-            if (TEST(VECTOR_FRAGMENT_LIST, v->flags) && v->buf[i].custom.frags != NULL)
+            if (TESTANY(VECTOR_FRAGMENT_LIST, v->flags) && v->buf[i].custom.frags != NULL)
                 vm_area_merge_fraglists(&v->buf[overlap_start], &v->buf[i]);
         }
         diff = overlap_end - (overlap_start + 1);
@@ -1262,7 +1263,7 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, uint vm_flags, uint f
             v->buf[i] = v->buf[i + diff];
         v->length -= diff;
         i = overlap_start; /* for return value */
-        if (TEST(VECTOR_FRAGMENT_LIST, v->flags) && v->buf[i].custom.frags != NULL) {
+        if (TESTANY(VECTOR_FRAGMENT_LIST, v->flags) && v->buf[i].custom.frags != NULL) {
             dcontext_t *dcontext = get_thread_private_dcontext();
             ASSERT(dcontext != NULL);
             /* have to remove all alsos that are now in same area as frag */
@@ -1276,7 +1277,7 @@ static void
 adjust_coarse_unit_bounds(vm_area_t *area, bool if_invalid)
 {
     coarse_info_t *info = (coarse_info_t *)area->custom.client;
-    ASSERT(TEST(FRAG_COARSE_GRAIN, area->frag_flags));
+    ASSERT(TESTANY(FRAG_COARSE_GRAIN, area->frag_flags));
     ASSERT(!RUNNING_WITHOUT_CODE_CACHE());
     ASSERT(info != NULL);
     if (info == NULL) /* be paranoid */
@@ -1288,9 +1289,9 @@ adjust_coarse_unit_bounds(vm_area_t *area, bool if_invalid)
      * exec areas write lock so we're ok there.
      */
     ASSERT(dynamo_all_threads_synched ||
-           (!TEST(VM_EXECUTED_FROM, area->vm_flags) &&
+           (!TESTANY(VM_EXECUTED_FROM, area->vm_flags) &&
             READWRITE_LOCK_HELD(&executable_areas->lock)));
-    if (!if_invalid && TEST(PERSCACHE_CODE_INVALID, info->flags)) {
+    if (!if_invalid && TESTANY(PERSCACHE_CODE_INVALID, info->flags)) {
         /* Don't change bounds of primary or secondary; we expect vm_area_t to
          * be merged back to this size post-rebind; if not, we'll throw out this
          * pcache at validation time due to not matching the vm_area_t.
@@ -1371,7 +1372,7 @@ remove_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, bool restore_prot)
         }
         v->buf[overlap_start].end = start;
         /* XXX: add a vmvector callback function for changing bounds? */
-        if (TEST(FRAG_COARSE_GRAIN, v->buf[overlap_start].frag_flags) &&
+        if (TESTANY(FRAG_COARSE_GRAIN, v->buf[overlap_start].frag_flags) &&
             official_coarse_vector) {
             adjust_coarse_unit_bounds(&v->buf[overlap_start], false /*leave invalid*/);
         }
@@ -1388,7 +1389,7 @@ remove_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, bool restore_prot)
         }
         v->buf[overlap_end - 1].start = end;
         /* XXX: add a vmvector callback function for changing bounds? */
-        if (TEST(FRAG_COARSE_GRAIN, v->buf[overlap_end - 1].frag_flags) &&
+        if (TESTANY(FRAG_COARSE_GRAIN, v->buf[overlap_end - 1].frag_flags) &&
             official_coarse_vector) {
             adjust_coarse_unit_bounds(&v->buf[overlap_end - 1], false /*leave invalid*/);
         }
@@ -1407,7 +1408,8 @@ remove_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, bool restore_prot)
              * VM_EXECUTED_FROM.  Could add bounds to callback params, but
              * vm_flags are not exposed to vmvector interface...
              */
-            if (TEST(FRAG_COARSE_GRAIN, v->buf[i].frag_flags) && official_coarse_vector) {
+            if (TESTANY(FRAG_COARSE_GRAIN, v->buf[i].frag_flags) &&
+                official_coarse_vector) {
                 coarse_info_t *info = (coarse_info_t *)v->buf[i].custom.client;
                 coarse_info_t *next_info;
                 ASSERT(info != NULL);
@@ -1423,7 +1425,7 @@ remove_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, bool restore_prot)
                      */
                     if (info->cache != NULL) {
                         ASSERT(info->persisted);
-                        ASSERT(!TEST(VM_EXECUTED_FROM, v->buf[i].vm_flags));
+                        ASSERT(!TESTANY(VM_EXECUTED_FROM, v->buf[i].vm_flags));
                         ASSERT(info->non_frozen != NULL);
                         ASSERT(coarse_to_delete != NULL);
                         /* Both primary and secondary must be un-executed */
@@ -1449,7 +1451,7 @@ remove_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, bool restore_prot)
 #endif
             /* frags list should always be null here (flush should have happened,
              * etc.) */
-            ASSERT(!TEST(VECTOR_FRAGMENT_LIST, v->flags) ||
+            ASSERT(!TESTANY(VECTOR_FRAGMENT_LIST, v->flags) ||
                    v->buf[i].custom.frags == NULL);
         }
         diff = overlap_end - overlap_start;
@@ -2135,7 +2137,7 @@ vmvector_reset_vector(dcontext_t *dcontext, vm_area_vector_t *v)
         /* walk areas and delete coarse info and comments */
         for (i = 0; i < v->length; i++) {
             /* XXX: this code is duplicated in remove_vm_area() */
-            if (TEST(FRAG_COARSE_GRAIN, v->buf[i].frag_flags) &&
+            if (TESTANY(FRAG_COARSE_GRAIN, v->buf[i].frag_flags) &&
                 /* XXX: cleaner test? shared_data copies flags, but uses
                  * custom.frags and not custom.client
                  */
@@ -2179,7 +2181,7 @@ static void
 vmvector_free_vector(dcontext_t *dcontext, vm_area_vector_t *v)
 {
     vmvector_reset_vector(dcontext, v);
-    if (!TEST(VECTOR_NO_LOCK, v->flags))
+    if (!TESTANY(VECTOR_NO_LOCK, v->flags))
         DELETE_READWRITE_LOCK(v->lock);
 }
 
@@ -2448,7 +2450,7 @@ add_executable_vm_area_check_IAT(app_pc *start /*IN/OUT*/, app_pc *end /*IN/OUT*
             "NOT adjusting exec area " PFX "-" PFX " vs IAT " PFX "-" PFX "\n",
             orig_start, *end, IAT_start, IAT_end);
     }
-    if (TEST(VM_UNMOD_IMAGE, vm_flags))
+    if (TESTANY(VM_UNMOD_IMAGE, vm_flags))
         keep_coarse = true;
     else {
         /* Keep the coarse-grain flag for modified pages only if IAT pages.
@@ -2472,14 +2474,14 @@ add_executable_vm_area_check_IAT(app_pc *start /*IN/OUT*/, app_pc *end /*IN/OUT*
             ASSERT(IAT_start != NULL); /* should have found bounds above */
             if (all_new &&             /* elseif assumes next call happened */
                 lookup_addr(executable_areas, *end, &area) &&
-                TEST(FRAG_COARSE_GRAIN, area->frag_flags) &&
+                TESTANY(FRAG_COARSE_GRAIN, area->frag_flags) &&
                 /* Only merge if no execution has yet occurred: else this
                  * must not be normal rebinding */
-                !TEST(VM_EXECUTED_FROM, area->vm_flags) &&
+                !TESTANY(VM_EXECUTED_FROM, area->vm_flags) &&
                 /* Should be marked invalid; else no loader +rw => not rebinding */
                 area->custom.client != NULL &&
-                TEST(PERSCACHE_CODE_INVALID,
-                     ((coarse_info_t *)area->custom.client)->flags)) {
+                TESTANY(PERSCACHE_CODE_INVALID,
+                        ((coarse_info_t *)area->custom.client)->flags)) {
                 /* Case 8640: merge IAT page back in to coarse area.
                  * Easier to merge here than in add_vm_area.
                  */
@@ -2541,11 +2543,11 @@ add_executable_vm_area_check_IAT(app_pc *start /*IN/OUT*/, app_pc *end /*IN/OUT*
                     orig_start, orig_end);
                 DOCHECK(1, {
                     if (all_new && area != NULL &&
-                        TEST(FRAG_COARSE_GRAIN, area->frag_flags) &&
-                        TEST(VM_EXECUTED_FROM, area->vm_flags)) {
+                        TESTANY(FRAG_COARSE_GRAIN, area->frag_flags) &&
+                        TESTANY(VM_EXECUTED_FROM, area->vm_flags)) {
                         coarse_info_t *info = (coarse_info_t *)area->custom.client;
                         ASSERT(!info->persisted);
-                        ASSERT(!TEST(PERSCACHE_CODE_INVALID, info->flags));
+                        ASSERT(!TESTANY(PERSCACHE_CODE_INVALID, info->flags));
                     }
                 });
             }
@@ -2573,7 +2575,7 @@ add_executable_vm_area_helper(app_pc start, app_pc end, uint vm_flags, uint frag
     add_vm_area(executable_areas, start, end, vm_flags, frag_flags,
                 NULL _IF_DEBUG(comment));
 
-    if (TEST(VM_WRITABLE, vm_flags)) {
+    if (TESTANY(VM_WRITABLE, vm_flags)) {
         /* N.B.: the writable flag indicates the natural state of the memory,
          * not what we have made it be -- we make it read-only before adding
          * to the executable list!
@@ -2591,7 +2593,8 @@ add_executable_vm_area_helper(app_pc start, app_pc end, uint vm_flags, uint frag
 #endif
     }
 #ifdef PROGRAM_SHEPHERDING
-    if (!DYNAMO_OPTION(selfmod_futureexec) && TEST(FRAG_SELFMOD_SANDBOXED, frag_flags)) {
+    if (!DYNAMO_OPTION(selfmod_futureexec) &&
+        TESTANY(FRAG_SELFMOD_SANDBOXED, frag_flags)) {
         /* We do not need future entries for selfmod regions.  We mark
          * the futures as once-only when they are selfmod at future add time, and
          * here we catch those who weren't selfmod then but are now.
@@ -2599,7 +2602,7 @@ add_executable_vm_area_helper(app_pc start, app_pc end, uint vm_flags, uint frag
         remove_futureexec_vm_area(start, end);
     }
 #endif
-    if (TEST(FRAG_COARSE_GRAIN, frag_flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, frag_flags)) {
         vm_area_t *area = NULL;
         DEBUG_DECLARE(bool found =)
         lookup_addr(executable_areas, start, &area);
@@ -2685,7 +2688,7 @@ vm_area_load_coarse_unit(app_pc *start DR_PARAM_INOUT, app_pc *end DR_PARAM_INOU
          * mark valid only at 1st execution when we do md5 checks;
          * for 4.3 we're valid until a rebind action.
          */
-        ASSERT(!TEST(PERSCACHE_CODE_INVALID, info->flags));
+        ASSERT(!TESTANY(PERSCACHE_CODE_INVALID, info->flags));
         /* We must add to shared_data, but we cannot here due to lock
          * rank issues (shared_vm_areas lock is higher rank than
          * executable_areas, and we have callers doing flushes and
@@ -2710,8 +2713,8 @@ add_executable_vm_area(app_pc start, app_pc end, uint vm_flags, uint frag_flags,
     coarse_info_t *tofree = NULL;
     app_pc delay_start = NULL, delay_end = NULL;
     /* only expect to see the *_READONLY flags on WRITABLE regions */
-    ASSERT(!TEST(VM_DELAY_READONLY, vm_flags) || TEST(VM_WRITABLE, vm_flags));
-    ASSERT(!TEST(VM_MADE_READONLY, vm_flags) || TEST(VM_WRITABLE, vm_flags));
+    ASSERT(!TESTANY(VM_DELAY_READONLY, vm_flags) || TESTANY(VM_WRITABLE, vm_flags));
+    ASSERT(!TESTANY(VM_MADE_READONLY, vm_flags) || TESTANY(VM_WRITABLE, vm_flags));
 #ifdef DEBUG /* can't use DODEBUG b/c of ifdef inside */
     {
         /* we only expect certain flags */
@@ -2736,17 +2739,17 @@ add_executable_vm_area(app_pc start, app_pc end, uint vm_flags, uint frag_flags,
      * to first grab hotp lock, we don't support perscache in those cases.
      * We expect to only be adding a coarse-grain area for module loads.
      */
-    ASSERT(!TEST(FRAG_COARSE_GRAIN, frag_flags) || !have_writelock);
-    if (TEST(FRAG_COARSE_GRAIN, frag_flags) && !have_writelock) {
+    ASSERT(!TESTANY(FRAG_COARSE_GRAIN, frag_flags) || !have_writelock);
+    if (TESTANY(FRAG_COARSE_GRAIN, frag_flags) && !have_writelock) {
 #ifdef WINDOWS
         if (!add_executable_vm_area_check_IAT(&start, &end, vm_flags, &existing_area,
                                               &info, &tofree, &delay_start, &delay_end))
             frag_flags &= ~FRAG_COARSE_GRAIN;
 #else
-        ASSERT(TEST(VM_UNMOD_IMAGE, vm_flags));
+        ASSERT(TESTANY(VM_UNMOD_IMAGE, vm_flags));
 #endif
         ASSERT(!RUNNING_WITHOUT_CODE_CACHE());
-        if (TEST(FRAG_COARSE_GRAIN, frag_flags) && DYNAMO_OPTION(use_persisted) &&
+        if (TESTANY(FRAG_COARSE_GRAIN, frag_flags) && DYNAMO_OPTION(use_persisted) &&
             info == NULL
             /* if clients are present, don't load until after they're initialized
              */
@@ -2768,10 +2771,10 @@ add_executable_vm_area(app_pc start, app_pc end, uint vm_flags, uint frag_flags,
                                       info _IF_DEBUG(comment));
     } else {
         /* we shouldn't need the other parts of _helper() */
-        ASSERT(!TEST(VM_WRITABLE, vm_flags));
+        ASSERT(!TESTANY(VM_WRITABLE, vm_flags));
 #ifdef PROGRAM_SHEPHERDING
         ASSERT(DYNAMO_OPTION(selfmod_futureexec) ||
-               !TEST(FRAG_SELFMOD_SANDBOXED, frag_flags));
+               !TESTANY(FRAG_SELFMOD_SANDBOXED, frag_flags));
 #endif
     }
 
@@ -2861,7 +2864,7 @@ vm_area_delay_load_coarse_units(void)
         return;
     d_r_write_lock(&executable_areas->lock);
     for (i = 0; i < executable_areas->length; i++) {
-        if (TEST(FRAG_COARSE_GRAIN, executable_areas->buf[i].frag_flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, executable_areas->buf[i].frag_flags)) {
             vm_area_t *a = &executable_areas->buf[i];
             /* store cur_info b/c a might be blown away */
             coarse_info_t *cur_info = (coarse_info_t *)a->custom.client;
@@ -3057,10 +3060,10 @@ get_coarse_info_internal(app_pc addr, bool init, bool have_shvm_lock)
         ASSERT(area != NULL);
         /* The custom field is initialized to 0 in add_vm_area */
         coarse = (coarse_info_t *)area->custom.client;
-        DEBUG_DECLARE(bool is_coarse = TEST(FRAG_COARSE_GRAIN, area->frag_flags);)
+        DEBUG_DECLARE(bool is_coarse = TESTANY(FRAG_COARSE_GRAIN, area->frag_flags);)
         /* We always create coarse_info_t up front in add_executable_vm_area */
         ASSERT((is_coarse && coarse != NULL) || (!is_coarse && coarse == NULL));
-        if (init && coarse != NULL && TEST(PERSCACHE_CODE_INVALID, coarse->flags)) {
+        if (init && coarse != NULL && TESTANY(PERSCACHE_CODE_INVALID, coarse->flags)) {
             /* Reset the unit as the validating event did not occur
              * (can't do it here due to lock rank order vs exec areas lock) */
             reset_unit = true;
@@ -3076,7 +3079,7 @@ get_coarse_info_internal(app_pc addr, bool init, bool have_shvm_lock)
         /* We cannot add to shared_data when we load in a persisted unit
          * due to lock rank issues, so we delay until first asked about.
          */
-        if (init && TEST(VM_ADD_TO_SHARED_DATA, area->vm_flags)) {
+        if (init && TESTANY(VM_ADD_TO_SHARED_DATA, area->vm_flags)) {
             add_to_shared = true;
             area->vm_flags &= ~VM_ADD_TO_SHARED_DATA;
             area->vm_flags |= VM_EXECUTED_FROM;
@@ -3140,7 +3143,7 @@ mark_executable_area_coarse_frozen(coarse_info_t *frozen)
         ASSERT(area != NULL);
         /* The custom field is initialized to 0 in add_vm_area */
         if (area->custom.client != NULL) {
-            ASSERT(TEST(FRAG_COARSE_GRAIN, area->frag_flags));
+            ASSERT(TESTANY(FRAG_COARSE_GRAIN, area->frag_flags));
             info = (coarse_info_t *)area->custom.client;
             ASSERT(info == frozen && frozen->non_frozen == NULL);
             info = coarse_unit_create(frozen->base_pc, frozen->end_pc,
@@ -3149,7 +3152,7 @@ mark_executable_area_coarse_frozen(coarse_info_t *frozen)
                 info->module, frozen->base_pc, frozen->end_pc);
             frozen->non_frozen = info;
         } else
-            ASSERT(!TEST(FRAG_COARSE_GRAIN, area->frag_flags));
+            ASSERT(!TESTANY(FRAG_COARSE_GRAIN, area->frag_flags));
     }
     d_r_write_unlock(&executable_areas->lock);
 }
@@ -3401,8 +3404,8 @@ vm_area_coarse_iter_find_next(vmvector_iterator_t *vmvi, app_pc end, bool mutate
     for (forw = 1; vmvi->index + forw < vmvi->vector->length; forw++) {
         if (end != NULL && executable_areas->buf[vmvi->index + forw].start >= end)
             break;
-        if (TEST(FRAG_COARSE_GRAIN,
-                 executable_areas->buf[vmvi->index + forw].frag_flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN,
+                    executable_areas->buf[vmvi->index + forw].frag_flags)) {
             coarse_info_t *info = executable_areas->buf[vmvi->index + forw].custom.client;
             if (mutate)
                 vmvi->index = vmvi->index + forw;
@@ -3480,7 +3483,7 @@ was_executable_area_writable(app_pc addr)
     if (!found_area) {
         uint prot;
         if (get_memory_info(addr, NULL, NULL, &prot))
-            was_writable = TEST(MEMPROT_WRITE, prot) && !is_dynamo_address(addr);
+            was_writable = TESTANY(MEMPROT_WRITE, prot) && !is_dynamo_address(addr);
     }
     d_r_read_unlock(&executable_areas->lock);
     return was_writable;
@@ -3494,7 +3497,7 @@ is_executable_area_selfmod(app_pc addr)
 {
     uint flags;
     if (get_executable_area_flags(addr, &flags))
-        return TEST(FRAG_SELFMOD_SANDBOXED, flags);
+        return TESTANY(FRAG_SELFMOD_SANDBOXED, flags);
     else
         return false;
 }
@@ -3506,7 +3509,7 @@ is_executable_area_dyngen(app_pc addr)
 {
     uint flags;
     if (get_executable_area_flags(addr, &flags))
-        return TEST(FRAG_DYNGEN, flags);
+        return TESTANY(FRAG_DYNGEN, flags);
     else
         return false;
 }
@@ -3661,7 +3664,7 @@ bool
 add_dynamo_vm_area(app_pc start, app_pc end, uint prot,
                    bool unmod_image _IF_DEBUG(const char *comment))
 {
-    uint vm_flags = (TEST(MEMPROT_WRITE, prot) ? VM_WRITABLE : 0) |
+    uint vm_flags = (TESTANY(MEMPROT_WRITE, prot) ? VM_WRITABLE : 0) |
         (unmod_image ? VM_UNMOD_IMAGE : 0);
     /* case 3045: areas inside the vmheap reservation are not added to the list */
     ASSERT(!is_vmm_reserved_address(start, end - start, NULL, NULL));
@@ -3745,7 +3748,7 @@ remove_dynamo_heap_areas(void)
     LOG(GLOBAL, LOG_VMAREAS, 4, "remove_dynamo_heap_areas:\n");
     /* walk backwards to avoid O(n^2) */
     for (i = dynamo_areas->length - 1; i >= 0; i--) {
-        if (TEST(VM_DR_HEAP, dynamo_areas->buf[i].vm_flags)) {
+        if (TESTANY(VM_DR_HEAP, dynamo_areas->buf[i].vm_flags)) {
             app_pc start = dynamo_areas->buf[i].start;
             app_pc end = dynamo_areas->buf[i].end;
             /* ASSUMPTION: remove_vm_area, given exact bounds, simply shifts later
@@ -3938,7 +3941,7 @@ is_driver_address(app_pc addr)
 {
     uint vm_flags;
     if (get_executable_area_vm_flags(addr, &vm_flags)) {
-        return TEST(VM_DRIVER_ADDRESS, vm_flags);
+        return TESTANY(VM_DRIVER_ADDRESS, vm_flags);
     }
     return false;
 }
@@ -4163,7 +4166,7 @@ security_violation_report(app_pc addr, security_violation_t violation_type,
     }
 
     /* options already synchronized by security_violation() */
-    if ((TEST(DUMPCORE_SECURITY_VIOLATION, DYNAMO_OPTION(dumpcore_mask))
+    if ((TESTANY(DUMPCORE_SECURITY_VIOLATION, DYNAMO_OPTION(dumpcore_mask))
 #    ifdef HOT_PATCHING_INTERFACE /* Part of fix for 5367. */
          && violation_type != HOT_PATCH_DETECTOR_VIOLATION &&
          violation_type != HOT_PATCH_PROTECTOR_VIOLATION
@@ -4173,9 +4176,9 @@ security_violation_report(app_pc addr, security_violation_t violation_type,
         /* Dump core if violation was for hot patch detector/protector and
          * the corresponding dumpcore_mask flag was set.
          */
-        || (TEST(DUMPCORE_HOTP_DETECTION, DYNAMO_OPTION(dumpcore_mask)) &&
+        || (TESTANY(DUMPCORE_HOTP_DETECTION, DYNAMO_OPTION(dumpcore_mask)) &&
             violation_type == HOT_PATCH_DETECTOR_VIOLATION) ||
-        (TEST(DUMPCORE_HOTP_PROTECTION, DYNAMO_OPTION(dumpcore_mask)) &&
+        (TESTANY(DUMPCORE_HOTP_PROTECTION, DYNAMO_OPTION(dumpcore_mask)) &&
          violation_type == HOT_PATCH_PROTECTOR_VIOLATION)
 #    endif
     ) {
@@ -4352,7 +4355,7 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
     });
 
     if (DYNAMO_OPTION(detect_mode) &&
-        !TEST(OPTION_BLOCK_IGNORE_DETECT, type_handling)
+        !TESTANY(OPTION_BLOCK_IGNORE_DETECT, type_handling)
         /* As of today, detect mode for hot patches is set using modes files. */
         IF_HOTP(&&violation_type != HOT_PATCH_DETECTOR_VIOLATION &&
                 violation_type != HOT_PATCH_PROTECTOR_VIOLATION)) {
@@ -4392,9 +4395,9 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
         }
     }
 
-    /* XXX: case 2144 we need to TEST(OPTION_BLOCK early on so that
+    /* XXX: case 2144 we need to TESTANY(OPTION_BLOCK early on so that
      * we do not impact the counters, in addition we need to
-     * TEST(OPTION_HANDLING to specify an alternative attack handling
+     * TESTANY(OPTION_HANDLING to specify an alternative attack handling
      * (e.g. -throw_exception if default is -kill_thread)
      * XXX: We may also want a different message to allow 'staging' events to be
      * considered differently, maybe with a DO_ONCE semantics...
@@ -4495,7 +4498,7 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
     }
 
     /* now we know what is the chosen action and we can report */
-    if (TEST(OPTION_REPORT, type_handling))
+    if (TESTANY(OPTION_REPORT, type_handling))
         security_violation_report(addr, violation_type, name, action);
 
     /* XXX: walking the loader data structures at arbitrary
@@ -4509,17 +4512,17 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
          * check isn't actually sufficient to ensure we get a dump file
          * (if for instance already got several violations) but it's good
          * enough */
-        if (TEST(DUMPCORE_UNSUPPORTED_APP, DYNAMO_OPTION(dumpcore_mask)) &&
-            !TEST(DUMPCORE_SECURITY_VIOLATION, DYNAMO_OPTION(dumpcore_mask))) {
+        if (TESTANY(DUMPCORE_UNSUPPORTED_APP, DYNAMO_OPTION(dumpcore_mask)) &&
+            !TESTANY(DUMPCORE_SECURITY_VIOLATION, DYNAMO_OPTION(dumpcore_mask))) {
             os_dump_core("unsupported module");
         }
     }
 
 #    ifdef WINDOWS
     if (ACTION_TERMINATE_PROCESS == action &&
-        (TEST(DETACH_UNHANDLED_VIOLATION, DYNAMO_OPTION(internal_detach_mask)) ||
+        (TESTANY(DETACH_UNHANDLED_VIOLATION, DYNAMO_OPTION(internal_detach_mask)) ||
          (found_unsupported &&
-          TEST(DETACH_UNSUPPORTED_MODULE, DYNAMO_OPTION(internal_detach_mask))))) {
+          TESTANY(DETACH_UNSUPPORTED_MODULE, DYNAMO_OPTION(internal_detach_mask))))) {
         /* set pc to right value and detach */
         get_mcontext(dcontext)->pc = addr;
         /* XXX - currently detach_internal creates a new thread to do the
@@ -4708,7 +4711,7 @@ is_dyngen_code(app_pc addr)
     uint flags;
     if (get_executable_area_flags(addr, &flags)) {
         /* assuming only true DGC is marked DYNGEN  */
-        return TEST(FRAG_DYNGEN, flags);
+        return TESTANY(FRAG_DYNGEN, flags);
     }
 
     return is_in_futureexec_area(addr);
@@ -4729,7 +4732,7 @@ is_direct_jmp_to_image(dcontext_t *dcontext, instr_t *in)
              * loader touch-ups, which can happen for any dll!
              * so we test FRAG_DYNGEN instead
              */
-            ok = !TEST(FRAG_DYNGEN, flags);
+            ok = !TESTANY(FRAG_DYNGEN, flags);
         }
     }
     return ok;
@@ -5120,7 +5123,7 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                 check_origins_trim_region_helper(base, size, fut_area->start,
                                                  fut_area->end);
             }
-            once_only = TEST(VM_ONCE_ONLY, fut_area->vm_flags);
+            once_only = TESTANY(VM_ONCE_ONLY, fut_area->vm_flags);
             /* now done w/ fut_area */
             d_r_read_unlock(&futureexec_areas->lock);
             fut_area = NULL;
@@ -5191,7 +5194,8 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                      * there) so we also check here. */
                     if (DYNAMO_OPTION(executable_if_rx_text) &&
                         get_memory_info(addr, NULL, NULL, &memprot) &&
-                        (TEST(MEMPROT_EXEC, memprot) && !TEST(MEMPROT_WRITE, memprot))) {
+                        (TESTANY(MEMPROT_EXEC, memprot) &&
+                         !TESTANY(MEMPROT_WRITE, memprot))) {
                         /* matches -executable_if_rx_text */
                         /* case 9799: we don't mark exempted for default-on options */
                         allow = true;
@@ -5308,7 +5312,7 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                     ;
                 }
                 if (!allow && get_memory_info(addr, NULL, NULL, &memprot) &&
-                    TEST(MEMPROT_EXEC, memprot)) {
+                    TESTANY(MEMPROT_EXEC, memprot)) {
                     /* check the _x versions */
                     if (!DYNAMO_OPTION(executable_if_dot_data_x) &&
                         DYNAMO_OPTION(exempt_dot_data_x) &&
@@ -5531,7 +5535,7 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
     }
 
     if (DYNAMO_OPTION(executable_if_driver)) {
-        if (TEST(VM_DRIVER_ADDRESS, *vm_flags)) {
+        if (TESTANY(VM_DRIVER_ADDRESS, *vm_flags)) {
             ASSERT(*size == PAGE_SIZE);
             LOG(THREAD, LOG_INTERP | LOG_VMAREAS, 2,
                 "check origins: pc = " PFX " is in a new driver area\n", addr);
@@ -5608,9 +5612,9 @@ check_origins(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *size, uin
          * XXX: xref case 3742
          */
         ASSERT_BUG_NUM(3742,
-                       !DYNAMO_OPTION(executable_if_x) || !TEST(MEMPROT_EXEC, prot));
-        ASSERT(!DYNAMO_OPTION(executable_if_rx) || !TEST(MEMPROT_EXEC, prot) ||
-               TEST(MEMPROT_WRITE, prot));
+                       !DYNAMO_OPTION(executable_if_x) || !TESTANY(MEMPROT_EXEC, prot));
+        ASSERT(!DYNAMO_OPTION(executable_if_rx) || !TESTANY(MEMPROT_EXEC, prot) ||
+               TESTANY(MEMPROT_WRITE, prot));
     }
     if (modname != NULL && modname != modname_buf)
         dr_strfree(modname HEAPACCT(ACCT_VMAREAS));
@@ -5743,10 +5747,10 @@ simulate_attack(dcontext_t *dcontext, app_pc pc)
 
     bool attack = false;
 
-    if (TEST(SIMULATE_AT_FRAGNUM, action)) {
+    if (TESTANY(SIMULATE_AT_FRAGNUM, action)) {
         attack = GLOBAL_STAT(num_fragments) > next_frag;
     }
-    if (TEST(SIMULATE_AT_ADDR, action)) {
+    if (TESTANY(SIMULATE_AT_ADDR, action)) {
         if (pc == (app_pc)next_frag)
             attack = true;
     }
@@ -5755,7 +5759,7 @@ simulate_attack(dcontext_t *dcontext, app_pc pc)
         LOG(GLOBAL, LOG_VMAREAS, 1, "SIMULATE ATTACK for " PFX " @%d frags\n", pc,
             GLOBAL_STAT(num_fragments));
 
-        if (TEST(SIMULATE_WIPE_STACK, action)) {
+        if (TESTANY(SIMULATE_WIPE_STACK, action)) {
             reg_t esp = get_mcontext(dcontext)->xsp;
             uint overflow_size = 1024;
             LOG(THREAD_GET, LOG_VMAREAS, 1,
@@ -5843,7 +5847,7 @@ print_fraglist(dcontext_t *dcontext, vm_area_t *area, const char *prefix)
                     fragment_t *f = FRAG_FRAG(also);
                     LOG(THREAD, LOG_VMAREAS, 1,
                         "WARNING: self-also frag F%d(" PFX ")%s\n", f->id, f->tag,
-                        TEST(FRAG_IS_TRACE, f->flags) ? " trace" : "");
+                        TESTANY(FRAG_IS_TRACE, f->flags) ? " trace" : "");
                 }
                 /* not an assertion b/c we sometimes print prior to cleaning */
             }
@@ -5909,7 +5913,8 @@ prepend_entry_to_fraglist(vm_area_t *area, fragment_t *entry)
         "%s: putting fragment @" PFX " (%s) on vmarea " PFX "-" PFX "\n",
         /* i#1215: FRAG_ID(entry) can crash if entry->f hold tag temporarily */
         __FUNCTION__, FRAG_PC(entry),
-        TEST(FRAG_SHARED, entry->flags) ? "shared" : "private", area->start, area->end);
+        TESTANY(FRAG_SHARED, entry->flags) ? "shared" : "private", area->start,
+        area->end);
     FRAG_NEXT_ASSIGN(entry, area->custom.frags);
     /* prev wraps around, but not next */
     if (area->custom.frags != NULL) {
@@ -6111,7 +6116,7 @@ app_memory_allocation(dcontext_t *dcontext, app_pc base, size_t size, uint prot,
 #endif
 
     /* no current policies allow non-x code at allocation time onto exec list */
-    if (!TEST(MEMPROT_EXEC, prot))
+    if (!TESTANY(MEMPROT_EXEC, prot))
         return false;
 
     /* Do not add our own code cache and other data structures
@@ -6130,7 +6135,7 @@ app_memory_allocation(dcontext_t *dcontext, app_pc base, size_t size, uint prot,
     LOG(GLOBAL, LOG_VMAREAS, 1, "New +x app memory region: " PFX "-" PFX " %s\n", base,
         base + size, memprot_string(prot));
 
-    if (!TEST(MEMPROT_WRITE, prot)) {
+    if (!TESTANY(MEMPROT_WRITE, prot)) {
         uint frag_flags = 0;
         if (DYNAMO_OPTION(coarse_units) && image && !RUNNING_WITHOUT_CODE_CACHE()) {
             /* all images start out with coarse-grain management */
@@ -6349,7 +6354,7 @@ is_jit_managed_area(app_pc addr)
 {
     uint vm_flags;
     if (get_executable_area_vm_flags(addr, &vm_flags))
-        return TEST(VM_JIT_MANAGED, vm_flags);
+        return TESTANY(VM_JIT_MANAGED, vm_flags);
     else
         return false;
 }
@@ -6365,8 +6370,8 @@ set_region_jit_managed(app_pc start, size_t len)
         LOG(GLOBAL, LOG_VMAREAS, 1, "set_region_jit_managed(" PFX " +0x%x)\n", start,
             len);
         ASSERT(region->start == start && region->end == (start + len));
-        if (!TEST(VM_JIT_MANAGED, region->vm_flags)) {
-            if (TEST(VM_MADE_READONLY, region->vm_flags))
+        if (!TESTANY(VM_JIT_MANAGED, region->vm_flags)) {
+            if (TESTANY(VM_MADE_READONLY, region->vm_flags))
                 vm_make_writable(region->start, region->end - region->start);
             region->vm_flags |= VM_JIT_MANAGED;
             region->vm_flags &= ~(VM_MADE_READONLY | VM_DELAY_READONLY);
@@ -6555,7 +6560,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
                 page_base = (app_pc)PAGE_START(base);
                 page_size = ALIGN_FORWARD(base + size, PAGE_SIZE) - (size_t)page_base;
                 d_r_write_lock(&pretend_writable_areas->lock);
-                if (TEST(MEMPROT_WRITE, prot)) {
+                if (TESTANY(MEMPROT_WRITE, prot)) {
                     LOG(THREAD, LOG_VMAREAS, 2,
                         "adding pretend-writable region " PFX "-" PFX "\n", page_base,
                         page_base + page_size);
@@ -6595,7 +6600,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
     }
 
     /* DR areas may have changed, but we still have to remove from pretend list */
-    if (USING_PRETEND_WRITABLE() && !TEST(MEMPROT_WRITE, prot) &&
+    if (USING_PRETEND_WRITABLE() && !TESTANY(MEMPROT_WRITE, prot) &&
         pretend_writable_vm_area_overlap(base, base + size)) {
         ASSERT_NOT_TESTED();
         /* XXX: again we have the race -- if we could go from read to write
@@ -6611,7 +6616,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
 #ifdef PROGRAM_SHEPHERDING
     if (USING_FUTURE_EXEC_LIST && futureexec_vm_area_overlap(base, base + size)) {
         /* something changed */
-        if (!TEST(MEMPROT_EXEC, prot)) {
+        if (!TESTANY(MEMPROT_EXEC, prot)) {
             /* we DO remove future regions just b/c they're now marked non-x
              * but we may want to re-consider this -- some hooks briefly go to rw, e.g.
              * although we MUST do this for executable_if_exec
@@ -6676,7 +6681,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
      * deadlock issues w/ thread_initexit_lock
      */
     is_executable = executable_vm_area_overlap(base, base + size, false /*have no lock*/);
-    if (is_executable && TEST(MEMPROT_WRITE, prot) && !TEST(MEMPROT_EXEC, prot) &&
+    if (is_executable && TESTANY(MEMPROT_WRITE, prot) && !TESTANY(MEMPROT_EXEC, prot) &&
         INTERNAL_OPTION(hw_cache_consistency)) {
 #ifdef WINDOWS
         app_pc IAT_start, IAT_end;
@@ -6715,7 +6720,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
              * since we may have adjusted the exec area bounds to be post-IAT.
              */
             get_executable_area_flags(base + size - 1, &frag_flags) &&
-            TEST(FRAG_COARSE_GRAIN, frag_flags)) {
+            TESTANY(FRAG_COARSE_GRAIN, frag_flags)) {
             coarse_info_t *info =
                 get_coarse_info_internal(IAT_end, false /*no init*/, false /*no lock*/);
             /* loader rebinding
@@ -6736,7 +6741,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
                 /* Do not reset/free during flush as we hope to see a validating
                  * event soon.
                  */
-                ASSERT(!TEST(PERSCACHE_CODE_INVALID, info->flags));
+                ASSERT(!TESTANY(PERSCACHE_CODE_INVALID, info->flags));
                 info->flags |= PERSCACHE_CODE_INVALID;
                 STATS_INC(coarse_marked_invalid);
             }
@@ -6826,7 +6831,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
             flush_and_remove_executable_vm_area(dcontext, base, size);
         /* we flush_fragments_finish after security checks to keep them atomic */
     } else if (is_executable && is_executable_area_writable(base) &&
-               !TEST(MEMPROT_WRITE, prot) && TEST(MEMPROT_EXEC, prot) &&
+               !TESTANY(MEMPROT_WRITE, prot) && TESTANY(MEMPROT_EXEC, prot) &&
                INTERNAL_OPTION(hw_cache_consistency)) {
         /* executable & writable region being made read-only
          * make sure any future write faults are given to app, not us
@@ -6851,9 +6856,9 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
      * XXX: perhaps should do a write_keep for this is_executable, to bind
      * to the subsequent exec areas changes -- though case 2833 would still be there
      */
-    else if (!is_executable && TEST(MEMPROT_EXEC, prot) &&
+    else if (!is_executable && TESTANY(MEMPROT_EXEC, prot) &&
              INTERNAL_OPTION(hw_cache_consistency)) {
-        if (TEST(MEMPROT_WRITE, prot)) {
+        if (TESTANY(MEMPROT_WRITE, prot)) {
             /* do NOT add to executable list if writable */
             LOG(THREAD, LOG_SYSCALLS | LOG_VMAREAS, 1,
                 "WARNING: data region " PFX "-" PFX " made executable and "
@@ -6955,7 +6960,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
                     frag_flags_pfx |= FRAG_COARSE_GRAIN;
                 }
                 /* XXX : see note at top of function about bug 2833 */
-                ASSERT(!TEST(MEMPROT_WRITE, prot)); /* sanity check */
+                ASSERT(!TESTANY(MEMPROT_WRITE, prot)); /* sanity check */
                 add_executable_vm_area(base, base + size, image ? VM_UNMOD_IMAGE : 0,
                                        frag_flags_pfx,
                                        false /*no lock*/ _IF_DEBUG(comment));
@@ -6995,7 +7000,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
     /* Make sure weaker policies are considered first, so that
      * the region is kept on the futureexec list with the least restrictions
      */
-    if (DYNAMO_OPTION(executable_if_x) && TEST(MEMPROT_EXEC, prot)) {
+    if (DYNAMO_OPTION(executable_if_x) && TESTANY(MEMPROT_EXEC, prot)) {
         /* The executable_if_x policy considers all code marked ..x to be executable */
 
         /* Note that executable_if_rx may have added a region directly
@@ -7008,7 +7013,7 @@ app_memory_protection_change_internal(dcontext_t *dcontext, bool update_areas,
         STATS_INC(num_mark_if_x);
         add_futureexec_vm_area(base, base + size,
                                false /*permanent*/
-                               _IF_DEBUG(TEST(MEMPROT_WRITE, prot)
+                               _IF_DEBUG(TESTANY(MEMPROT_WRITE, prot)
                                              ? "executable_if_x protect exec .wx"
                                              : "executable_if_x protect exec .-x"));
         mark_module_exempted(base);
@@ -7174,7 +7179,7 @@ app_memory_flush(dcontext_t *dcontext, app_pc base, size_t size, uint prot)
             DOSTATS({
                 if (is_executable_area_writable(base))
                     STATS_INC(num_NT_flush_w2r); /* pretend writable (we made RO) */
-                if (TEST(MEMPROT_WRITE, prot))
+                if (TESTANY(MEMPROT_WRITE, prot))
                     STATS_INC(num_NT_flush_w);
                 else
                     STATS_INC(num_NT_flush_r);
@@ -7222,7 +7227,7 @@ handle_delay_readonly(dcontext_t *dcontext, app_pc pc, vm_area_t *area)
     /* should never get a selfmod region here, to be marked selfmod
      * would already have had to execute (to get faulting write)
      * so region would already have had to go through here */
-    ASSERT(!TEST(FRAG_SELFMOD_SANDBOXED, area->frag_flags));
+    ASSERT(!TESTANY(FRAG_SELFMOD_SANDBOXED, area->frag_flags));
     if (!is_on_stack(dcontext, pc, NULL) && INTERNAL_OPTION(hw_cache_consistency)) {
         vm_make_unwritable(area->start, area->end - area->start);
         area->vm_flags |= VM_MADE_READONLY;
@@ -7301,7 +7306,7 @@ check_thread_vm_area_abort(dcontext_t *dcontext, void **vmlist, uint flags)
 {
     thread_data_t *data;
     if (DYNAMO_OPTION(shared_bbs) &&
-        !TEST(FRAG_SHARED, flags)) { /* yes, reverse logic, see comment above */
+        !TESTANY(FRAG_SHARED, flags)) { /* yes, reverse logic, see comment above */
         data = shared_data;
     } else {
         data = (thread_data_t *)dcontext->vm_areas_field;
@@ -7330,8 +7335,8 @@ allow_xfer_for_frag_flags(dcontext_t *dcontext, app_pc pc, uint src_flags, uint 
          */
         (src_cmp == 0 /* we removed FRAG_COARSE_GRAIN to make this fine */
          && tgt_cmp == FRAG_COARSE_GRAIN /* still in coarse region though */
-         && TEST(FRAG_HAS_SYSCALL, src_flags));
-    if (TEST(FRAG_COARSE_GRAIN, src_flags)) {
+         && TESTANY(FRAG_HAS_SYSCALL, src_flags));
+    if (TESTANY(FRAG_COARSE_GRAIN, src_flags)) {
         /* XXX case 8606: we can allow intra-module xfers but we have no
          * way of checking here -- would have to check in
          * interp.c:check_new_page_jmp().  So for now we disallow all xfers.
@@ -7347,9 +7352,9 @@ allow_xfer_for_frag_flags(dcontext_t *dcontext, app_pc pc, uint src_flags, uint 
         LOG(THREAD, LOG_VMAREAS, 3,
             "change in vm area flags (0x%08x vs. 0x%08x %d): "
             "stopping at " PFX "\n",
-            src_flags, tgt_flags, TEST(FRAG_COARSE_GRAIN, src_flags), pc);
+            src_flags, tgt_flags, TESTANY(FRAG_COARSE_GRAIN, src_flags), pc);
         DOSTATS({
-            if (TEST(FRAG_COARSE_GRAIN, tgt_flags))
+            if (TESTANY(FRAG_COARSE_GRAIN, tgt_flags))
                 STATS_INC(elisions_prevented_for_coarse);
         });
     }
@@ -7425,8 +7430,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
      */
     if (DYNAMO_OPTION(shared_bbs) &&
         /* for TEMP_PRIVATE we make private up front */
-        !TEST(FRAG_TEMP_PRIVATE, *flags) &&
-        !TEST(FRAG_SHARED, *flags)) { /* yes, reverse logic, see comment above */
+        !TESTANY(FRAG_TEMP_PRIVATE, *flags) &&
+        !TESTANY(FRAG_SHARED, *flags)) { /* yes, reverse logic, see comment above */
         data = shared_data;
         DODEBUG({ new_area_prefix = "new shared vm area: "; });
         if (vmlist == NULL) { /* not making any state changes to vm lists */
@@ -7443,7 +7448,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         DODEBUG({ new_area_prefix = "new vm area for thread: "; });
         data = (thread_data_t *)dcontext->vm_areas_field;
 #ifdef PROGRAM_SHEPHERDING
-        if (DYNAMO_OPTION(shared_bbs) && TEST(FRAG_SHARED, *flags))
+        if (DYNAMO_OPTION(shared_bbs) && TESTANY(FRAG_SHARED, *flags))
             shared_to_private = true;
 #endif
     }
@@ -7486,7 +7491,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         if (!own_execareas_writelock)
             d_r_read_lock(&executable_areas->lock);
         ok = lookup_addr(executable_areas, pc, &area);
-        if (ok && TEST(VM_DELAY_READONLY, area->vm_flags)) {
+        if (ok && TESTANY(VM_DELAY_READONLY, area->vm_flags)) {
             /* need to mark region read only for consistency
              * need to upgrade to write lock, have to release lock first
              * then recheck conditions after grabbing hotp + write lock */
@@ -7505,10 +7510,11 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                 own_execareas_writelock = true;
                 ok = lookup_addr(executable_areas, pc, &area);
             }
-            if (ok && TEST(VM_DELAY_READONLY, area->vm_flags))
+            if (ok && TESTANY(VM_DELAY_READONLY, area->vm_flags))
                 handle_delay_readonly(dcontext, pc, area);
         }
-        if ((!ok || (ok && vmlist != NULL && !TEST(VM_EXECUTED_FROM, area->vm_flags))) &&
+        if ((!ok ||
+             (ok && vmlist != NULL && !TESTANY(VM_EXECUTED_FROM, area->vm_flags))) &&
             !own_execareas_writelock) {
             /* we must hold the write lock until we add the new region, as we
              * may want to give it selfmod or other properties that will not mix
@@ -7528,7 +7534,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
             ok = lookup_addr(executable_areas, pc, &area);
         }
         if (ok) {
-            if (vmlist != NULL && !TEST(VM_EXECUTED_FROM, area->vm_flags)) {
+            if (vmlist != NULL && !TESTANY(VM_EXECUTED_FROM, area->vm_flags)) {
                 ASSERT(self_owns_write_lock(&executable_areas->lock));
                 area->vm_flags |= VM_EXECUTED_FROM;
             }
@@ -7563,7 +7569,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
          * so we have to get protection value right now
          */
 #ifdef WINDOWS
-        if (TEST(DR_MEMPROT_GUARD, prot)) {
+        if (TESTANY(DR_MEMPROT_GUARD, prot)) {
             /* remove protection so as to go on */
             if (unmark_page_as_guard(pc, prot)) {
                 /* We test that there was still the guard protection to remove.
@@ -7604,7 +7610,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
              * XXX i#852: should we instead have some dr_appcode_alloc() or
              * dr_appcode_mark() API?
              */
-            if (is_in_dr && INTERNAL_OPTION(code_api) && TEST(MEMPROT_EXEC, prot) &&
+            if (is_in_dr && INTERNAL_OPTION(code_api) && TESTANY(MEMPROT_EXEC, prot) &&
                 !in_fcache(pc))
                 is_in_dr = false; /* allow it */
 
@@ -7799,7 +7805,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                         own_execareas_writelock, caller_execareas_writelock);
 
                     /* Create an exception record for this failure */
-                    if (TEST(DUMPCORE_FORGE_UNREAD_EXEC, DYNAMO_OPTION(dumpcore_mask))) {
+                    if (TESTANY(DUMPCORE_FORGE_UNREAD_EXEC,
+                                DYNAMO_OPTION(dumpcore_mask))) {
                         os_dump_core("Warning: App trying to execute from unreadable "
                                      "memory");
                     }
@@ -7841,8 +7848,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         }
     }
     if (area != NULL) {
-        ASSERT_CURIOSITY(vmlist == NULL || !TEST(VM_DELETE_ME, area->vm_flags));
-        if (vmlist != NULL && TEST(FRAG_COARSE_GRAIN, area->frag_flags)) {
+        ASSERT_CURIOSITY(vmlist == NULL || !TESTANY(VM_DELETE_ME, area->vm_flags));
+        if (vmlist != NULL && TESTANY(FRAG_COARSE_GRAIN, area->frag_flags)) {
             /* We assume get_executable_area_coarse_info() is called prior to
              * execution in a coarse region.  We go ahead and initialize here
              * though we could wait if a xfer since the bb will not cross.
@@ -7851,21 +7858,21 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
             get_coarse_info_internal(pc, true /*init*/, true /*have shvm lock*/);
             ASSERT(info != NULL);
         }
-        ASSERT(!TEST(FRAG_COARSE_GRAIN, area->frag_flags) ||
+        ASSERT(!TESTANY(FRAG_COARSE_GRAIN, area->frag_flags) ||
                get_coarse_info_internal(pc, false /*no init*/, false /*no lock*/) !=
                    NULL);
         frag_flags |= area->frag_flags;
 
 #ifdef PROGRAM_SHEPHERDING
         if (vmlist != NULL && /* only for bb building */
-            TEST(VM_PATTERN_REVERIFY, area->vm_flags) &&
+            TESTANY(VM_PATTERN_REVERIFY, area->vm_flags) &&
             !shared_to_private /* ignore shared-to-private conversion */) {
             /* case 8168: sandbox2ro_threshold can turn into a non-sandboxed region,
              * and our re-verify won't change that as the region is already on the
              * executable list.  It will all work fine though.
              */
             ASSERT(DYNAMO_OPTION(sandbox2ro_threshold) > 0 ||
-                   TEST(FRAG_SELFMOD_SANDBOXED, area->frag_flags));
+                   TESTANY(FRAG_SELFMOD_SANDBOXED, area->frag_flags));
             /* Re-verify the code origins policies, unless we are ensuring that
              * the end of the pattern is ok.  This fixes case 4020 where another
              * thread can use a pattern region for non-pattern code.
@@ -7893,7 +7900,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
      * here it gets executed multiple times until actually switch to sandboxing
      */
     if (area == NULL && DYNAMO_OPTION(ro2sandbox_threshold) > 0 &&
-        TEST(MEMPROT_WRITE, prot) && !TEST(FRAG_SELFMOD_SANDBOXED, frag_flags)) {
+        TESTANY(MEMPROT_WRITE, prot) && !TESTANY(FRAG_SELFMOD_SANDBOXED, frag_flags)) {
         vm_area_t *w_area; /* can't clobber area here */
         ro_vs_sandbox_data_t *ro2s = NULL;
         /* even though area==NULL this can still be an exec-writable area
@@ -7977,7 +7984,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
     /* N.B.: ibl entry removal (case 9636) assumes coarse fragments
      * stay bounded within a single FRAG_COARSE_GRAIN region
      */
-    if (TEST(FRAG_COARSE_GRAIN, frag_flags) && pc != tag /*don't cmp to nothing*/ &&
+    if (TESTANY(FRAG_COARSE_GRAIN, frag_flags) && pc != tag /*don't cmp to nothing*/ &&
         ((*flags & FRAG_COARSE_GRAIN) != (frag_flags & FRAG_COARSE_GRAIN) ||
          area == NULL || area->start > tag)) {
         *flags &= ~FRAG_COARSE_GRAIN;
@@ -8077,14 +8084,14 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
              * someone else could have added the region since we checked above.
              * see if we need to handle the DELAY_READONLY flag.
              */
-            if (TEST(VM_DELAY_READONLY, area->vm_flags))
+            if (TESTANY(VM_DELAY_READONLY, area->vm_flags))
                 handle_delay_readonly(dcontext, pc, area);
             else {
 #endif
 #ifdef PROGRAM_SHEPHERDING
                 /* else, this can only happen for pattern reverification: no races! */
-                ASSERT(TEST(VM_PATTERN_REVERIFY, area->vm_flags) &&
-                       TEST(FRAG_SELFMOD_SANDBOXED, area->frag_flags));
+                ASSERT(TESTANY(VM_PATTERN_REVERIFY, area->vm_flags) &&
+                       TESTANY(FRAG_SELFMOD_SANDBOXED, area->frag_flags));
 #else
             ASSERT_NOT_REACHED();
 #endif
@@ -8093,7 +8100,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
 #endif
         } else {
             /* need to add the region */
-            if (TEST(MEMPROT_WRITE, prot)) {
+            if (TESTANY(MEMPROT_WRITE, prot)) {
                 vm_flags |= VM_WRITABLE;
                 STATS_INC(num_writable_code_regions);
                 /* Now that new area bounds are finalized, see if it should be
@@ -8125,7 +8132,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                     }
                 }
 
-                if (TEST(FRAG_SELFMOD_SANDBOXED, frag_flags)) {
+                if (TESTANY(FRAG_SELFMOD_SANDBOXED, frag_flags)) {
                     LOG(GLOBAL, LOG_VMAREAS, 2,
                         "\tNew executable region " PFX "-" PFX
                         " is writable, but selfmod, "
@@ -8153,7 +8160,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                 }
             }
             /* now add the new region to the global list */
-            ASSERT(!TEST(FRAG_COARSE_GRAIN, frag_flags)); /* else no pre-exec query */
+            ASSERT(!TESTANY(FRAG_COARSE_GRAIN, frag_flags)); /* else no pre-exec query */
             add_executable_vm_area(base_pc, base_pc + size, vm_flags | VM_EXECUTED_FROM,
                                    frag_flags,
                                    true /*own lock*/
@@ -8177,7 +8184,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
     }
     if (local_area == NULL) {
         /* new area for this thread */
-        ASSERT(TEST(VM_EXECUTED_FROM, area->vm_flags)); /* marked above */
+        ASSERT(TESTANY(VM_EXECUTED_FROM, area->vm_flags)); /* marked above */
 #ifdef DGC_DIAGNOSTICS
         if (!TESTANY(VM_UNMOD_IMAGE | VM_WAS_FUTURE, area->vm_flags)) {
             LOG(GLOBAL, LOG_VMAREAS, 1,
@@ -8187,8 +8194,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
 #endif
 #ifdef PROGRAM_SHEPHERDING
         DOSTATS({
-            if (!TEST(VM_UNMOD_IMAGE, area->vm_flags) &&
-                TEST(VM_WAS_FUTURE, area->vm_flags)) {
+            if (!TESTANY(VM_UNMOD_IMAGE, area->vm_flags) &&
+                TESTANY(VM_WAS_FUTURE, area->vm_flags)) {
                 /* increment for other threads (1st thread will be inc-ed in
                  * check_origins_helper)
                  */
@@ -8201,8 +8208,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         });
 #    ifdef WINDOWS
         DOSTATS({
-            if (!TEST(VM_UNMOD_IMAGE, area->vm_flags) &&
-                !TEST(VM_WAS_FUTURE, area->vm_flags))
+            if (!TESTANY(VM_UNMOD_IMAGE, area->vm_flags) &&
+                !TESTANY(VM_WAS_FUTURE, area->vm_flags))
                 STATS_INC(num_exec_after_load);
         });
 #    endif
@@ -8324,8 +8331,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
     DOCHECK(IF_MACOS64_ELSE(3, IF_AARCH64_ELSE(3, IF_RISCV64_ELSE(3, 1))), {
         uint prot2;
         ok = get_memory_info(pc, NULL, NULL, &prot2);
-        ASSERT(!ok || !TEST(MEMPROT_WRITE, prot2) ||
-               TEST(FRAG_SELFMOD_SANDBOXED, *flags) ||
+        ASSERT(!ok || !TESTANY(MEMPROT_WRITE, prot2) ||
+               TESTANY(FRAG_SELFMOD_SANDBOXED, *flags) ||
                !INTERNAL_OPTION(hw_cache_consistency));
         ASSERT(is_readable_without_exception_try(pc, 1));
     });
@@ -8456,12 +8463,12 @@ remove_shared_vmlist(dcontext_t *dcontext, void *vmlist, fragment_t *f,
          * list(s).
          */
         remove = (local_vmlist != NULL && FRAG_PREV(entry) == entry &&
-                  !TEST(FRAG_COARSE_GRAIN, f->flags));
+                  !TESTANY(FRAG_COARSE_GRAIN, f->flags));
         if (remove) {
             DEBUG_DECLARE(bool ok =)
             lookup_addr(&shared_data->areas, FRAG_PC(entry), &area);
             ASSERT(ok && area != NULL);
-            if (TEST(FRAG_COARSE_GRAIN, area->frag_flags)) {
+            if (TESTANY(FRAG_COARSE_GRAIN, area->frag_flags)) {
                 /* Case 9806: do NOT remove the coarse area even if this
                  * particular fragment is fine-grained.  We also test f->flags
                  * up front to avoid the lookup cost as an optimization.
@@ -8505,7 +8512,7 @@ vm_area_add_fragment(dcontext_t *dcontext, fragment_t *f, void *vmlist)
 
     LOG(THREAD, LOG_VMAREAS, 4, "vm_area_add_fragment for F%d(" PFX ")\n", f->id, f->tag);
 
-    if (TEST(FRAG_COARSE_GRAIN, f->flags)) {
+    if (TESTANY(FRAG_COARSE_GRAIN, f->flags)) {
         /* We went ahead and built up vmlist since we might decide later to not
          * make a fragment coarse-grain.  If it is emitted as coarse-grain,
          * we need to clean up the vmlist as it is not needed.
@@ -8514,7 +8521,7 @@ vm_area_add_fragment(dcontext_t *dcontext, fragment_t *f, void *vmlist)
         return;
     }
 
-    if (TEST(FRAG_SHARED, f->flags)) {
+    if (TESTANY(FRAG_SHARED, f->flags)) {
         data = shared_data;
         /* need write lock since writing area->frags */
         SHARED_VECTOR_RWLOCK(&shared_data->areas, write, lock);
@@ -8530,7 +8537,7 @@ vm_area_add_fragment(dcontext_t *dcontext, fragment_t *f, void *vmlist)
          */
         ASSERT(dcontext != GLOBAL_DCONTEXT);
         /* only bbs do we build shared and then switch to private */
-        ASSERT(!TEST(FRAG_IS_TRACE, f->flags));
+        ASSERT(!TESTANY(FRAG_IS_TRACE, f->flags));
         data = (thread_data_t *)dcontext->vm_areas_field;
         LOG(THREAD, LOG_VMAREAS, 4,
             "\tbb not shared, shifting vm data to thread-local\n");
@@ -8689,7 +8696,8 @@ exec_area_bounds_match(dcontext_t *dcontext, thread_data_t *data)
               thread_area->end <= exec_area->end)) {
             DOLOG(1, LOG_VMAREAS, {
                 LOG(THREAD, LOG_VMAREAS, 1, "%s: bounds mismatch on %s vmvector\n",
-                    __FUNCTION__, (TEST(VECTOR_SHARED, v->flags) ? "shared" : "private"));
+                    __FUNCTION__,
+                    (TESTANY(VECTOR_SHARED, v->flags) ? "shared" : "private"));
                 print_vm_area(v, thread_area, THREAD, "thread area: ");
                 print_vm_area(v, exec_area, THREAD, "exec area: ");
                 LOG(THREAD, 1, LOG_VMAREAS, "executable_areas:\n");
@@ -8728,8 +8736,8 @@ vm_area_add_to_list(dcontext_t *dcontext, app_pc tag, void **vmlist, uint list_f
     if (!have_locks)
         SHARED_FLAGS_RECURSIVE_LOCK(f->flags, acquire, change_linking_lock);
     else {
-        ASSERT((!TEST(VECTOR_SHARED, tgt_data->areas.flags) &&
-                !TEST(VECTOR_SHARED, src_data->areas.flags)) ||
+        ASSERT((!TESTANY(VECTOR_SHARED, tgt_data->areas.flags) &&
+                !TESTANY(VECTOR_SHARED, src_data->areas.flags)) ||
                self_owns_recursive_lock(&change_linking_lock));
     }
     /* support caller already owning write lock */
@@ -8739,16 +8747,16 @@ vm_area_add_to_list(dcontext_t *dcontext, app_pc tag, void **vmlist, uint list_f
          * and we thus grab only one lock in this routine:
          * otherwise we need to do more work to avoid deadlocks here!
          */
-        ASSERT(!TEST(VECTOR_SHARED, tgt_data->areas.flags) ||
-               !TEST(VECTOR_SHARED, src_data->areas.flags));
-        if (TEST(VECTOR_SHARED, tgt_data->areas.flags)) {
+        ASSERT(!TESTANY(VECTOR_SHARED, tgt_data->areas.flags) ||
+               !TESTANY(VECTOR_SHARED, src_data->areas.flags));
+        if (TESTANY(VECTOR_SHARED, tgt_data->areas.flags)) {
             ASSERT(!lock);
             lock = writelock_if_not_already(&tgt_data->areas);
         }
     }
     ASSERT((lock && !have_locks) || (!lock && have_locks) ||
-           (!TEST(VECTOR_SHARED, tgt_data->areas.flags) &&
-            !TEST(VECTOR_SHARED, src_data->areas.flags)));
+           (!TESTANY(VECTOR_SHARED, tgt_data->areas.flags) &&
+            !TESTANY(VECTOR_SHARED, src_data->areas.flags)));
     DOCHECK(CHKLVL_ASSERTS, {
         LOG(THREAD, 1, LOG_VMAREAS, "checking src_data\n");
         exec_area_bounds_match(dcontext, src_data);
@@ -8756,7 +8764,7 @@ vm_area_add_to_list(dcontext_t *dcontext, app_pc tag, void **vmlist, uint list_f
         exec_area_bounds_match(dcontext, tgt_data);
     });
     /* If deleted, the also field is invalid and we cannot handle that! */
-    if (TEST(FRAG_WAS_DELETED, f->flags)) {
+    if (TESTANY(FRAG_WAS_DELETED, f->flags)) {
         success = false;
         goto vm_area_add_to_list_done;
     }
@@ -8899,7 +8907,8 @@ remove_fraglist_entry(dcontext_t *dcontext, fragment_t *entry, vm_area_t *area)
     /* entry is only in shared vector if still live -- if not
      * we shouldn't get here
      */
-    ASSERT(!TEST(VECTOR_SHARED, vector->flags) || !TEST(FRAG_WAS_DELETED, entry->flags));
+    ASSERT(!TESTANY(VECTOR_SHARED, vector->flags) ||
+           !TESTANY(FRAG_WAS_DELETED, entry->flags));
     ASSERT(area_contains_frag_pc(area, entry));
 
     prev = FRAG_PREV(entry);
@@ -9302,7 +9311,7 @@ add_to_lazy_deletion_list(dcontext_t *dcontext, fragment_t *f)
     }
     for (tail = f; tail != NULL; prev = tail, tail = tail->next_vmarea) {
         ASSERT(tail->also.also_vmarea == NULL);
-        ASSERT(TEST(FRAG_SHARED, tail->flags));
+        ASSERT(TESTANY(FRAG_SHARED, tail->flags));
         tail->also.flushtime = flushtime;
         todelete->lazy_delete_count++;
     }
@@ -9357,7 +9366,7 @@ check_lazy_deletion_list(dcontext_t *dcontext, uint flushtime)
                     STATS_INC(num_lazy_deletion_frees);
             });
             /* XXX: separate stats for frees at exit time */
-            ASSERT(TEST(FRAG_SHARED, f->flags));
+            ASSERT(TESTANY(FRAG_SHARED, f->flags));
             /* we assume we're freeing the entire head of the list */
             todelete->lazy_delete_count--;
             todelete->lazy_delete_list = next_f;
@@ -9402,7 +9411,7 @@ unlink_fragments_for_deletion(dcontext_t *dcontext, fragment_t *list,
     fragment_t *f, *next;
     uint num = 0;
     /* only applies to lists of shared fragments -- we check the head now */
-    ASSERT(TEST(FRAG_SHARED, list->flags));
+    ASSERT(TESTANY(FRAG_SHARED, list->flags));
     /* for shared_deletion we have to protect this whole walk w/ a lock so
      * that the flushtime_global value remains higher than any thread's
      * flushtime.
@@ -9505,7 +9514,7 @@ vm_area_unlink_fragments(dcontext_t *dcontext, app_pc start, app_pc end,
              */
             DOCHECK(CHKLVL_DEFAULT,
                     { vm_area_check_clean_fraglist(&data->areas.buf[i]); });
-            ASSERT(!TEST(FRAG_COARSE_GRAIN, data->areas.buf[i].frag_flags));
+            ASSERT(!TESTANY(FRAG_COARSE_GRAIN, data->areas.buf[i].frag_flags));
             for (entry = data->areas.buf[i].custom.frags; entry != NULL; entry = next) {
                 fragment_t *f = FRAG_FRAG(entry);
                 next = FRAG_NEXT(entry);
@@ -9520,7 +9529,7 @@ vm_area_unlink_fragments(dcontext_t *dcontext, app_pc start, app_pc end,
                 /* case 9118: call fragment_unlink_for_deletion() even if fragment
                  * is already unlinked
                  */
-                if (!TEST(FRAG_WAS_DELETED, f->flags) || data == shared_data) {
+                if (!TESTANY(FRAG_WAS_DELETED, f->flags) || data == shared_data) {
                     LOG(thread_log, LOG_FRAGMENT | LOG_VMAREAS, 5,
                         "\tunlinking " PFX "%s F%d(" PFX ")\n", entry,
                         FRAG_MULTI(entry) ? " multi" : "", FRAG_ID(entry),
@@ -9647,7 +9656,7 @@ vm_area_unlink_incoming(dcontext_t *dcontext, app_pc pc)
             for (entry = data->areas.buf[i].custom.frags; entry != NULL;
                  entry = FRAG_NEXT(entry)) {
                 fragment_t *f = FRAG_FRAG(entry);
-                ASSERT(!TEST(FRAG_SHARED, f->flags));
+                ASSERT(!TESTANY(FRAG_SHARED, f->flags));
 
                 /* Note that we aren't unlinking or ibl-invalidating
                  * (i.e., making unreachable) any fragments in other
@@ -9831,7 +9840,7 @@ vm_area_check_shared_pending(dcontext_t *dcontext, fragment_t *was_I_flushed)
             /* vm_area_unlink_fragments should have removed all multis/alsos */
             ASSERT(!FRAG_MULTI(entry));
             /* FRAG_ALSO is used by lazy list so it may not be NULL */
-            ASSERT(TEST(FRAG_WAS_DELETED, FRAG_FRAG(entry)->flags));
+            ASSERT(TESTANY(FRAG_WAS_DELETED, FRAG_FRAG(entry)->flags));
             /* do NOT call vm_area_remove_fragment, as it will freak out trying
              * to look up the area this fragment is in
              */
@@ -9902,7 +9911,7 @@ vm_area_flush_fragments(dcontext_t *dcontext, fragment_t *was_I_flushed)
     for (i = v->length - 1; i >= 0; i--) {
         LOG(THREAD, LOG_FRAGMENT | LOG_VMAREAS, 2,
             "  Considering %d == " PFX ".." PFX "\n", i, v->buf[i].start, v->buf[i].end);
-        if (TEST(VM_DELETE_ME, v->buf[i].vm_flags)) {
+        if (TESTANY(VM_DELETE_ME, v->buf[i].vm_flags)) {
             LOG(THREAD, LOG_FRAGMENT | LOG_VMAREAS, 2,
                 "\tdeleting all fragments in region " PFX ".." PFX "\n", v->buf[i].start,
                 v->buf[i].end);
@@ -9916,7 +9925,7 @@ vm_area_flush_fragments(dcontext_t *dcontext, fragment_t *was_I_flushed)
                     if (was_I_flushed == dcontext->last_fragment)
                         last_exit_deleted(dcontext);
                 }
-                ASSERT(TEST(FRAG_WAS_DELETED, FRAG_FRAG(entry)->flags));
+                ASSERT(TESTANY(FRAG_WAS_DELETED, FRAG_FRAG(entry)->flags));
                 ASSERT(FRAG_ALSO_DEL_OK(entry) == NULL);
                 fragment_delete(dcontext, FRAG_FRAG(entry),
                                 /* We used to leave link, vmarea, and htable removal
@@ -10009,7 +10018,7 @@ vm_area_flush_coarse_unit(dcontext_t *dcontext, coarse_info_t *info_in, vm_area_
     while (info != NULL) { /* loop over primary and secondary unit */
         next_info = info->non_frozen;
         ASSERT(info->frozen || info->non_frozen == NULL);
-        if (!entire && TEST(PERSCACHE_CODE_INVALID, info->flags)) {
+        if (!entire && TESTANY(PERSCACHE_CODE_INVALID, info->flags)) {
             /* Do not reset yet as it may become valid again.
              * Assumption: if !entire, we will leave this info there.
              */
@@ -10094,7 +10103,7 @@ vm_area_allsynch_flush_fragments(dcontext_t *dcontext, dcontext_t *del_dcontext,
 #endif
         d_r_read_lock(&executable_areas->lock); /* no need to write */
         for (i = 0; i < executable_areas->length; i++) {
-            if (TEST(FRAG_COARSE_GRAIN, executable_areas->buf[i].frag_flags) &&
+            if (TESTANY(FRAG_COARSE_GRAIN, executable_areas->buf[i].frag_flags) &&
                 start < executable_areas->buf[i].end &&
                 end > executable_areas->buf[i].start) {
                 coarse_info_t *coarse =
@@ -10128,7 +10137,8 @@ vm_area_allsynch_flush_fragments(dcontext_t *dcontext, dcontext_t *del_dcontext,
                                               start <= executable_areas->buf[i].start &&
                                                   end >= executable_areas->buf[i].end);
                     DODEBUG({ num_coarse++; });
-                    if (TEST(VM_ADD_TO_SHARED_DATA, executable_areas->buf[i].vm_flags)) {
+                    if (TESTANY(VM_ADD_TO_SHARED_DATA,
+                                executable_areas->buf[i].vm_flags)) {
                         LOG(THREAD, LOG_FRAGMENT | LOG_VMAREAS, 2,
                             "\tdeleting coarse unit not yet in shared vector " PFX
                             ".." PFX "\n",
@@ -10248,7 +10258,7 @@ vm_area_coarse_units_reset_free(void)
      * not grab executable_areas_lock here and rely on reset synch.
      */
     for (i = 0; i < v->length; i++) {
-        if (TEST(FRAG_COARSE_GRAIN, v->buf[i].frag_flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, v->buf[i].frag_flags)) {
             coarse_info_t *info_start = (coarse_info_t *)v->buf[i].custom.client;
             coarse_info_t *info = info_start, *next_info;
             ASSERT(info != NULL);
@@ -10374,7 +10384,7 @@ vm_area_coarse_region_freeze(dcontext_t *dcontext, coarse_info_t *info, vm_area_
         ASSERT(info->non_frozen == NULL);
     }
     if (unfrozen_info != NULL && unfrozen_info->cache != NULL /*skip empty units*/ &&
-        !TEST(PERSCACHE_CODE_INVALID, unfrozen_info->flags) &&
+        !TESTANY(PERSCACHE_CODE_INVALID, unfrozen_info->flags) &&
         /* we only freeze a unit in presence of a frozen unit if we're merging
          * (we don't support side-by-side frozen units) */
         (DYNAMO_OPTION(coarse_freeze_merge) || frozen_info == NULL)) {
@@ -10449,7 +10459,7 @@ vm_area_coarse_region_freeze(dcontext_t *dcontext, coarse_info_t *info, vm_area_
         }
     } else if (frozen_info != NULL && frozen_info->cache != NULL && !in_place &&
                !frozen_info->persisted) {
-        ASSERT(!TEST(PERSCACHE_CODE_INVALID, frozen_info->flags));
+        ASSERT(!TESTANY(PERSCACHE_CODE_INVALID, frozen_info->flags));
         if (coarse_region_should_persist(dcontext, frozen_info))
             coarse_unit_persist(dcontext, frozen_info);
     }
@@ -10486,7 +10496,7 @@ vm_area_coarse_units_freeze(bool in_place)
      * Could make executable_areas_lock recursive and grab all locks here?
      */
     for (i = 0; i < v->length; i++) {
-        if (TEST(FRAG_COARSE_GRAIN, v->buf[i].frag_flags)) {
+        if (TESTANY(FRAG_COARSE_GRAIN, v->buf[i].frag_flags)) {
             coarse_info_t *info = (coarse_info_t *)v->buf[i].custom.client;
             ASSERT(info != NULL);
             if (info != NULL)
@@ -10631,7 +10641,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
         disassemble_app_bb(dcontext, instr_app_pc, THREAD);
     });
 #endif
-    if (TEST(MEMPROT_WRITE, prot)) {
+    if (TESTANY(MEMPROT_WRITE, prot)) {
         LOG(THREAD, LOG_VMAREAS, 1,
             "\tWARNING: region now writable: assuming another thread already flushed it\n"
             "\tgoing to flush again just to make sure\n");
@@ -10679,11 +10689,11 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
          * return value.
          */
         (vm_list_overlaps(dcontext, (void *)f, base_pc, base_pc + size) ||
-         TEST(FRAG_WAS_DELETED, f->flags))) {
+         TESTANY(FRAG_WAS_DELETED, f->flags))) {
         fragment_overlaps(dcontext, f, instr_app_pc, instr_app_pc + 1,
                           false /* fine-grain! */, &info, &bb_start);
         /* if did fast check and it said overlap, slow check should too */
-        ASSERT(TEST(FRAG_WAS_DELETED, f->flags) || info.overlap);
+        ASSERT(TESTANY(FRAG_WAS_DELETED, f->flags) || info.overlap);
     }
     if (info.overlap) {
         /* instr_t may be in region, but could also be from a different region
@@ -10728,7 +10738,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
 
         DOSTATS({
             /* race condition case of another thread flushing 1st */
-            if (TEST(MEMPROT_WRITE, prot))
+            if (TESTANY(MEMPROT_WRITE, prot))
                 STATS_INC(num_write_fault_races_selfmod);
         });
 
@@ -10825,7 +10835,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
             DOLOG(3, LOG_VMAREAS, { print_vm_areas(executable_areas, GLOBAL); });
             flush_fragments_in_region_finish(dcontext,
                                              false /*don't keep initexit_lock*/);
-            if (DYNAMO_OPTION(opt_jit) && !TEST(MEMPROT_WRITE, prot) &&
+            if (DYNAMO_OPTION(opt_jit) && !TESTANY(MEMPROT_WRITE, prot) &&
                 is_jit_managed_area((app_pc)tgt_pstart)) {
                 jitopt_clear_span((app_pc)tgt_pstart,
                                   (app_pc)(tgt_pend + PAGE_SIZE - tgt_pstart));
@@ -10862,7 +10872,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
                 flush_start + flush_size);
         }
     } else {
-        ASSERT(!info.overlap || (f != NULL && TEST(FRAG_IS_TRACE, f->flags)));
+        ASSERT(!info.overlap || (f != NULL && TESTANY(FRAG_IS_TRACE, f->flags)));
         /* instr not in region, so move entire region off the executable list */
         flush_start = base_pc;
         flush_size = size;
@@ -10967,7 +10977,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
      * XXX - Redoing the write would be more efficient then going back to
      * d_r_dispatch and should be the common case. */
     flush_fragments_in_region_finish(dcontext, false /*don't keep initexit_lock*/);
-    if (DYNAMO_OPTION(opt_jit) && !TEST(MEMPROT_WRITE, prot) &&
+    if (DYNAMO_OPTION(opt_jit) && !TESTANY(MEMPROT_WRITE, prot) &&
         is_jit_managed_area(flush_start))
         jitopt_clear_span(flush_start, flush_start + flush_size);
     return instr_app_pc;
@@ -11129,7 +11139,7 @@ vm_area_selfmod_check_clear_exec_count(dcontext_t *dcontext, fragment_t *f)
         /* flush_* grabbed executable_areas lock for us */
         ok = lookup_addr(executable_areas, f->tag, &exec_area);
         if (ok) {
-            if (TEST(FRAG_SELFMOD_SANDBOXED, exec_area->frag_flags)) {
+            if (TESTANY(FRAG_SELFMOD_SANDBOXED, exec_area->frag_flags)) {
                 /* XXX: if exec area is larger than flush area, it's
                  * ok since marking fragments in a ro region as selfmod
                  * is not a correctness problem.  Current flush impl, though,
@@ -11141,7 +11151,7 @@ vm_area_selfmod_check_clear_exec_count(dcontext_t *dcontext, fragment_t *f)
                     "\tconverting " PFX "-" PFX " from sandbox to ro\n", exec_area->start,
                     exec_area->end);
                 exec_area->frag_flags &= ~FRAG_SELFMOD_SANDBOXED;
-                /* can't ASSERT(!TEST(VM_MADE_READONLY, area->vm_flags)) (case 7877) */
+                /* can't ASSERT(!TESTANY(VM_MADE_READONLY, area->vm_flags)) (case 7877) */
                 vm_make_unwritable(exec_area->start, exec_area->end - exec_area->start);
                 exec_area->vm_flags |= VM_MADE_READONLY;
                 /* i#942: Remove the sandboxed area and re-add it to merge it
@@ -11474,7 +11484,7 @@ apc_thread_policy_helper(app_pc *apc_target_location, /* IN/OUT */
     }
 
     /* target is a non-executable area, but we may want to be more specific */
-    if (TEST(OPTION_CUSTOM, target_policy)) {
+    if (TESTANY(OPTION_CUSTOM, target_policy)) {
         match = true; /* no matter what is in the shellcode */
     } else {
         if (injected_code == PIC_SHELLCODE_MATCH)
@@ -11486,11 +11496,11 @@ apc_thread_policy_helper(app_pc *apc_target_location, /* IN/OUT */
         char injected_threat_buf[MAXIMUM_VIOLATION_NAME_LENGTH] = "APCS.XXXX.B";
         const char *name = injected_threat_buf;
 
-        bool block = TEST(OPTION_BLOCK, target_policy);
+        bool block = TESTANY(OPTION_BLOCK, target_policy);
 
         /* we need the constructed name before deciding to really
          * block, in case we exempt by ID */
-        if (TEST(OPTION_REPORT, target_policy)) {
+        if (TESTANY(OPTION_REPORT, target_policy)) {
             /* mangle injected_code into a name */
             if (injected_code == PIC_SHELLCODE_MATCH) {
                 /* keeping the well known hardcoded ones for VSE */
@@ -11534,7 +11544,7 @@ apc_thread_policy_helper(app_pc *apc_target_location, /* IN/OUT */
              * (since we are not under d_r_dispatch()).  If we want to see a
              * code origins failure, we can just disable this policy.
              */
-            ASSERT(!TEST(OPTION_HANDLING, target_policy) &&
+            ASSERT(!TESTANY(OPTION_HANDLING, target_policy) &&
                    "handling cannot be modified");
 
             SYSLOG_INTERNAL_WARNING(
@@ -11570,7 +11580,7 @@ apc_thread_policy_helper(app_pc *apc_target_location, /* IN/OUT */
                                    _IF_DEBUG(is_apc ? "apc_helper" : "thread_policy"));
         }
 
-        if (TEST(OPTION_REPORT, target_policy)) {
+        if (TESTANY(OPTION_REPORT, target_policy)) {
             /* report a violation adjusted for appropriate action */
             /* XXX: should come up with a new name for this
              * violation otherwise it is pretty inconsistent to say
@@ -11603,7 +11613,7 @@ aslr_report_violation(app_pc execution_fault_pc, security_option_t handling_poli
      * applications where ASLR can be hit natively, the attack
      * handling policy is to throw an exception.
      */
-    ASSERT(TEST(OPTION_BLOCK, handling_policy));
+    ASSERT(TESTANY(OPTION_BLOCK, handling_policy));
 
     /* XXX: yet we should have a choice whether to override the
      * exception that would normally be delivered to the application,
@@ -11611,16 +11621,16 @@ aslr_report_violation(app_pc execution_fault_pc, security_option_t handling_poli
      * corrupt, and to allow the attack handling thresholds to take
      * effect.
      */
-    ASSERT(!TEST(OPTION_HANDLING, handling_policy));
+    ASSERT(!TESTANY(OPTION_HANDLING, handling_policy));
     /* XXX: if using report security_violation() to provide attack
      * handling decisions should make sure it prefers exceptions,
      * XXX: make sure not trying to release locks, XXX: also clean
      * kstats (currently hotp_only is already broken)
      */
 
-    ASSERT(!TEST(OPTION_CUSTOM, handling_policy));
+    ASSERT(!TESTANY(OPTION_CUSTOM, handling_policy));
 
-    if (TEST(OPTION_REPORT, handling_policy)) {
+    if (TESTANY(OPTION_REPORT, handling_policy)) {
         /* report a violation, adjusted for appropriate action */
         char aslr_threat_id[MAXIMUM_VIOLATION_NAME_LENGTH];
 

--- a/core/vmareas.h
+++ b/core/vmareas.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -119,7 +119,7 @@ struct vm_area_vector_t {
 #define VMVECTOR_ALLOC_VECTOR(v, dc, flags, lockname)             \
     do {                                                          \
         v = vmvector_create_vector((dc), (flags));                \
-        if (!TEST(VECTOR_NO_LOCK, (flags)))                       \
+        if (!TESTANY(VECTOR_NO_LOCK, (flags)))                    \
             ASSIGN_INIT_READWRITE_LOCK_FREE((v)->lock, lockname); \
     } while (0);
 

--- a/core/win32/aslr.c
+++ b/core/win32/aslr.c
@@ -212,8 +212,8 @@ aslr_init(void)
      * ASLR_HANDLING|ASLR_NORMALIZE_ID
      */
 
-    ASSERT_CURIOSITY(!TEST(ASLR_RANDOMIZE_EXECUTABLE, DYNAMO_OPTION(aslr_cache)) ||
-                     TEST(ASLR_ALLOW_ORIGINAL_CLOBBER, DYNAMO_OPTION(aslr_cache)) &&
+    ASSERT_CURIOSITY(!TESTANY(ASLR_RANDOMIZE_EXECUTABLE, DYNAMO_OPTION(aslr_cache)) ||
+                     TESTANY(ASLR_ALLOW_ORIGINAL_CLOBBER, DYNAMO_OPTION(aslr_cache)) &&
                          "case 8902 - need to duplicate handle in child");
     /* case 8902 tracks the extra work if we want to support this
      * non-recommended configuration */
@@ -250,7 +250,7 @@ aslr_init(void)
          * we won't risk freeing */
     }
 
-    if (TEST(ASLR_HEAP, DYNAMO_OPTION(aslr))) {
+    if (TESTANY(ASLR_HEAP, DYNAMO_OPTION(aslr))) {
         /* we only reserve a random padding from the beginning of memory
          * and let the OS handle all other allocations normally
          */
@@ -297,7 +297,7 @@ aslr_init(void)
      * done in a high privilege process (e.g. winlogon.exe) that may
      * otherwise have no other role to serve in ASLR_SHARED_CONTENTS
      */
-    if (TEST(ASLR_SHARED_INITIALIZE, DYNAMO_OPTION(aslr_cache))) {
+    if (TESTANY(ASLR_SHARED_INITIALIZE, DYNAMO_OPTION(aslr_cache))) {
         HANDLE initialize_directory;
         NTSTATUS res =
             nt_initialize_shared_directory(&initialize_directory, true /* permanent */);
@@ -330,7 +330,7 @@ aslr_init(void)
              * release builds as well
              */
             ASSERT_CURIOSITY(res == STATUS_PRIVILEGE_NOT_HELD);
-            if (TEST(ASLR_SHARED_INITIALIZE_NONPERMANENT, DYNAMO_OPTION(aslr_cache))) {
+            if (TESTANY(ASLR_SHARED_INITIALIZE_NONPERMANENT, DYNAMO_OPTION(aslr_cache))) {
                 res = nt_initialize_shared_directory(&initialize_directory,
                                                      false /* temporary */);
                 ASSERT(NT_SUCCESS(res) && "unable to initialize");
@@ -350,7 +350,7 @@ aslr_init(void)
         /* XXX: this should change to become SID related */
         NTSTATUS res = nt_open_object_directory(
             &shared_object_directory, DYNAMORIO_SHARED_OBJECT_DIRECTORY,
-            TEST(ASLR_SHARED_PUBLISHER, DYNAMO_OPTION(aslr_cache)));
+            TESTANY(ASLR_SHARED_PUBLISHER, DYNAMO_OPTION(aslr_cache)));
         /* Only trusted publishers should be allowed to publish in the
          * SharedCache */
         /* Note  */
@@ -398,7 +398,7 @@ aslr_init(void)
          */
     }
 
-    if (TEST(ASLR_SHARED_WORKLIST, DYNAMO_OPTION(aslr_cache))) {
+    if (TESTANY(ASLR_SHARED_WORKLIST, DYNAMO_OPTION(aslr_cache))) {
         aslr_process_worklist();
     }
 
@@ -418,7 +418,7 @@ aslr_init(void)
 void
 aslr_exit(void)
 {
-    if (TEST(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action)) &&
+    if (TESTANY(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action)) &&
         is_module_list_initialized()) {
         /* doublecheck and print entries to make sure they match */
         DOLOG(1, LOG_VMAREAS, { print_modules_safe(GLOBAL, DUMP_NOT_XML); });
@@ -434,18 +434,18 @@ aslr_exit(void)
     vmvector_delete_vector(GLOBAL_DCONTEXT, aslr_heap_pad_areas);
 
     if (shared_object_directory != INVALID_HANDLE_VALUE) {
-        ASSERT_CURIOSITY(TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
+        ASSERT_CURIOSITY(TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
         nt_close_object_directory(shared_object_directory);
     }
 
     if (known_dlls_object_directory != INVALID_HANDLE_VALUE) {
         ASSERT_CURIOSITY(DYNAMO_OPTION(track_module_filenames) ||
-                         TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
+                         TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
         nt_close_object_directory(known_dlls_object_directory);
     }
 
     if (relocated_dlls_filecache_initial != INVALID_HANDLE_VALUE) {
-        ASSERT_CURIOSITY(TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
+        ASSERT_CURIOSITY(TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
         close_handle(relocated_dlls_filecache_initial);
     }
 
@@ -645,7 +645,7 @@ aslr_update_view_size(app_pc view_base, size_t view_size)
      * rebase and giving up all the time.
      */
 
-    if (TEST(ASLR_INTERNAL_SAME_STRESS, INTERNAL_OPTION(aslr_internal))) {
+    if (TESTANY(ASLR_INTERNAL_SAME_STRESS, INTERNAL_OPTION(aslr_internal))) {
         return;
     }
 
@@ -680,7 +680,7 @@ aslr_track_randomized_dlls(dcontext_t *dcontext, app_pc base, size_t size, bool 
         if (our_shared_file) {
             DEBUG_DECLARE(app_pc our_relocated_preferred_base =
                               get_module_preferred_base(base););
-            ASSERT(TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
+            ASSERT(TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
             ASSERT(dcontext->aslr_context.original_section_base !=
                    ASLR_INVALID_SECTION_BASE);
 
@@ -769,7 +769,7 @@ aslr_track_randomized_dlls(dcontext_t *dcontext, app_pc base, size_t size, bool 
              * see case 8507
              */
             ASSERT(preferred_base == get_module_preferred_base(base) ||
-                   TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
+                   TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
 
             /* XXX: if multiple DLLs preferred regions overlap we
              * wouldn't know not to remove a hole, need refcounting, but
@@ -899,7 +899,7 @@ aslr_pre_process_mapview(dcontext_t *dcontext)
          * variable, since offset is user exposed.
          * DLL loading on the other hand doesn't need this argument.
          */
-        ASSERT_NOT_IMPLEMENTED(!TEST(ASLR_MAPPED, DYNAMO_OPTION(aslr)));
+        ASSERT_NOT_IMPLEMENTED(!TESTANY(ASLR_MAPPED, DYNAMO_OPTION(aslr)));
 
         if (psection_offs_unsafe == NULL && prot != PAGE_READONLY) {
             /* XXX: should distinguish SEC_IMAGE for the
@@ -968,7 +968,7 @@ aslr_pre_process_mapview(dcontext_t *dcontext)
             /* assumption: loader never suggests base in 1st map */
             if (requested_base == 0) {
                 DODEBUG({
-                    if (TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
+                    if (TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
                         dcontext->aslr_context.randomized_section_handle !=
                             section_handle) {
                         STATS_INC(aslr_dlls_not_shared);
@@ -999,7 +999,7 @@ aslr_pre_process_mapview(dcontext_t *dcontext)
                     }
                 });
 
-                if (TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
+                if (TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
                     dcontext->aslr_context.randomized_section_handle == section_handle) {
                     /* shared DLL mapping at presumably randomized location,
                      * leave base unset for preferred mapping
@@ -1017,7 +1017,8 @@ aslr_pre_process_mapview(dcontext_t *dcontext)
                     /* XXX: we may want to take a hint from prot and expected size */
                     modified_base = aslr_get_next_base();
 
-                    if (!TEST(ASLR_INTERNAL_RANGE_NONE, INTERNAL_OPTION(aslr_internal))) {
+                    if (!TESTANY(ASLR_INTERNAL_RANGE_NONE,
+                                 INTERNAL_OPTION(aslr_internal))) {
                         /* really modify base now */
                         /* note that pbase_unsafe is an IN/OUT argument,
                          * so it is not likely that the application would
@@ -1060,7 +1061,7 @@ aslr_pre_process_mapview(dcontext_t *dcontext)
                 ASSERT_CURIOSITY(
                     aslr_last_dll_bounds->start == 0 ||           /* given up */
                     aslr_last_dll_bounds->start == requested_base /* may be race? */
-                    || TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache))
+                    || TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache))
                     /* not keeping keep track for shared */);
                 /* XXX: for ASLR_SHARED_CONTENTS would be at the
                  * requested shared preferred mapping address which is
@@ -1245,7 +1246,7 @@ aslr_post_process_mapview(dcontext_t *dcontext)
                      status == STATUS_CONFLICTING_ADDRESSES);
 
     /* handle shared DLL ASLR mapping */
-    if (TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
+    if (TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
         dcontext->aslr_context.randomized_section_handle == section_handle) {
         if (NT_SUCCESS(status)) {
             if (status == STATUS_SUCCESS) {
@@ -1281,7 +1282,7 @@ aslr_post_process_mapview(dcontext_t *dcontext)
              */
 
             /* add to preferred module range */
-            if (TEST(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action))) {
+            if (TESTANY(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action))) {
                 ASSERT(NT_SUCCESS(status));
 
                 /* we assume that since syscall succeeded these dereferences are safe
@@ -1330,7 +1331,7 @@ aslr_post_process_mapview(dcontext_t *dcontext)
         dcontext->aslr_context.randomized_section_handle = INVALID_HANDLE_VALUE;
         dcontext->aslr_context.sys_aslr_clobbered = false;
         return;
-    } else if (TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
+    } else if (TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
                dcontext->aslr_context.randomized_section_handle != section_handle) {
         /* flag that private mapping should be processed in
          * update_module_list()
@@ -1735,8 +1736,8 @@ aslr_post_process_mapview(dcontext_t *dcontext)
                 }
 
                 module_characteristics = get_module_characteristics(base);
-                if (TEST(IMAGE_FILE_DLL, module_characteristics) &&
-                    TEST(IMAGE_FILE_RELOCS_STRIPPED, module_characteristics)) {
+                if (TESTANY(IMAGE_FILE_DLL, module_characteristics) &&
+                    TESTANY(IMAGE_FILE_RELOCS_STRIPPED, module_characteristics)) {
                     /* Note that we still privately ASLR EXEs that are
                      * presumed to not be executable but only loaded
                      * for ther resources */
@@ -1749,7 +1750,7 @@ aslr_post_process_mapview(dcontext_t *dcontext)
                     exempt = true;
                 }
                 DODEBUG({
-                    if (!exempt && !TEST(IMAGE_FILE_DLL, module_characteristics)) {
+                    if (!exempt && !TESTANY(IMAGE_FILE_DLL, module_characteristics)) {
                         /* EXE usually have no PE name, and note that we
                          * see for example in notepad.exe help on (xp sp2)
                          * we get helpctr.exe loaded as
@@ -1764,7 +1765,7 @@ aslr_post_process_mapview(dcontext_t *dcontext)
                 });
 
                 /* add to preferred module range only if MEM_IMAGE */
-                if (TEST(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action)) && !exempt) {
+                if (TESTANY(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action)) && !exempt) {
                     /* XXX: only DLLs that are randomized by us get added,
                      * not any DLL rebased due to other conflicts (even if
                      * due to overlap our own allocations we don't take blame)
@@ -1883,7 +1884,7 @@ aslr_pre_process_unmapview(dcontext_t *dcontext, app_pc base, size_t size)
     reg_t *param_base = dcontext->sys_param_base;
 
     /* remove from preferred module range */
-    if (TEST(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action))) {
+    if (TESTANY(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action))) {
         /* XXX: should move to post processing in
          * aslr_post_process_mapview, for the unlikely case
          * NtUnmapViewOfSection fails, and so that we remove only when
@@ -2066,7 +2067,8 @@ aslr_maybe_pad_stack(dcontext_t *dcontext, HANDLE process_handle)
     LOG(GLOBAL, LOG_SYSCALLS | LOG_VMAREAS, 1,
         "ASLR: check if thread is in new child " PIFX "\n", process_handle);
 
-    if (TEST(ASLR_STACK, DYNAMO_OPTION(aslr)) && DYNAMO_OPTION(aslr_parent_offset) > 0 &&
+    if (TESTANY(ASLR_STACK, DYNAMO_OPTION(aslr)) &&
+        DYNAMO_OPTION(aslr_parent_offset) > 0 &&
         should_inject_into_process(get_thread_private_dcontext(), process_handle, NULL,
                                    NULL)) {
         /* Case 9173: ensure we only do this once, as 3rd party
@@ -2087,7 +2089,7 @@ aslr_maybe_pad_stack(dcontext_t *dcontext, HANDLE process_handle)
         }
     } else {
         DODEBUG({
-            if (TEST(ASLR_STACK, DYNAMO_OPTION(aslr)) &&
+            if (TESTANY(ASLR_STACK, DYNAMO_OPTION(aslr)) &&
                 DYNAMO_OPTION(aslr_parent_offset) > 0) {
                 LOG(GLOBAL, LOG_SYSCALLS | LOG_VMAREAS, 1,
                     "ASLR: child not configured for protection, not padding\n");
@@ -2136,7 +2138,7 @@ aslr_force_dynamorio_rebase(HANDLE process_handle)
      */
 
     /* no need to do both */
-    if (!(TEST(ASLR_STACK, DYNAMO_OPTION(aslr)))) {
+    if (!(TESTANY(ASLR_STACK, DYNAMO_OPTION(aslr)))) {
         /* random padding to have the loader load us in a not so
          * determinstic location */
         DEBUG_DECLARE(ok =)
@@ -2208,7 +2210,7 @@ aslr_post_process_allocate_virtual_memory(dcontext_t *dcontext,
     ASSERT(ALIGNED(last_allocation_base, PAGE_SIZE));
     ASSERT(ALIGNED(last_allocation_size, PAGE_SIZE));
 
-    ASSERT(TEST(ASLR_HEAP_FILL, DYNAMO_OPTION(aslr)));
+    ASSERT(TESTANY(ASLR_HEAP_FILL, DYNAMO_OPTION(aslr)));
     if (DYNAMO_OPTION(aslr_reserve_pad) > 0) {
         /* We need to randomly pad memory around each memory
          * allocation as well.  Conservatively, we reserve a new
@@ -2569,7 +2571,7 @@ open_relocated_dlls_filecache_directory(void)
     wchar_t wbuf[MAXIMUM_PATH];
     HANDLE directory_handle;
     int retval;
-    bool per_user = TEST(ASLR_SHARED_PER_USER, DYNAMO_OPTION(aslr_cache));
+    bool per_user = TESTANY(ASLR_SHARED_PER_USER, DYNAMO_OPTION(aslr_cache));
 
     /* XXX: note a lot of overlap with code in os_create_dir() yet
      * that assumes we'll deal with file names, while I want to avoid
@@ -3081,7 +3083,7 @@ aslr_module_verify_relocated_contents(HANDLE original_file_handle,
     NTSTATUS res;
 
     size_t validation_prefix =
-        (TEST(ASLR_PERSISTENT_PARANOID_PREFIX, DYNAMO_OPTION(aslr_validation))
+        (TESTANY(ASLR_PERSISTENT_PARANOID_PREFIX, DYNAMO_OPTION(aslr_validation))
              ? DYNAMO_OPTION(aslr_section_prefix)
              : POINTER_MAX);
 
@@ -3162,8 +3164,8 @@ aslr_module_verify_relocated_contents(HANDLE original_file_handle,
         }
     });
 
-    if (TEST(ASLR_PERSISTENT_PARANOID_TRANSFORM_EXPLICITLY,
-             DYNAMO_OPTION(aslr_validation))) {
+    if (TESTANY(ASLR_PERSISTENT_PARANOID_TRANSFORM_EXPLICITLY,
+                DYNAMO_OPTION(aslr_validation))) {
         KSTART(aslr_validate_relocate);
         /* note we're transforming our good section into the relocated one
          * including any header modifications
@@ -3261,7 +3263,8 @@ aslr_verify_file_checksum(DR_PARAM_IN HANDLE app_file_handle,
     aslr_persistent_digest_t persistent_digest;
 
     module_digest_t calculated_digest;
-    bool short_only = TEST(ASLR_PERSISTENT_SHORT_DIGESTS, DYNAMO_OPTION(aslr_validation));
+    bool short_only =
+        TESTANY(ASLR_PERSISTENT_SHORT_DIGESTS, DYNAMO_OPTION(aslr_validation));
 
     bool ok;
     ok = os_get_file_size_by_handle(app_file_handle, &app_file_size);
@@ -3328,7 +3331,7 @@ aslr_verify_file_checksum(DR_PARAM_IN HANDLE app_file_handle,
      * Measure for performance problems and may streamline.
      */
 
-    if (TEST(ASLR_PERSISTENT_MODIFIED_TIME, DYNAMO_OPTION(aslr_validation))) {
+    if (TESTANY(ASLR_PERSISTENT_MODIFIED_TIME, DYNAMO_OPTION(aslr_validation))) {
         /* XXX: currently impossible to check application times */
         ASSERT_NOT_IMPLEMENTED(false);
         if (!ok) {
@@ -3338,7 +3341,7 @@ aslr_verify_file_checksum(DR_PARAM_IN HANDLE app_file_handle,
         }
     }
 
-    if (TEST(ASLR_PERSISTENT_PARANOID, DYNAMO_OPTION(aslr_validation))) {
+    if (TESTANY(ASLR_PERSISTENT_PARANOID, DYNAMO_OPTION(aslr_validation))) {
         ok = aslr_module_verify_relocated_contents(app_file_handle,
                                                    randomized_file_handle);
         if (!ok) {
@@ -3354,7 +3357,7 @@ aslr_verify_file_checksum(DR_PARAM_IN HANDLE app_file_handle,
         }
     }
 
-    if (TEST(ASLR_PERSISTENT_SOURCE_DIGEST, DYNAMO_OPTION(aslr_validation))) {
+    if (TESTANY(ASLR_PERSISTENT_SOURCE_DIGEST, DYNAMO_OPTION(aslr_validation))) {
         /* XXX: note that we should pass the original section to
          * aslr_publish_section_handle() and use
          * aslr_get_section_digest() instead of a private mapping
@@ -3378,7 +3381,7 @@ aslr_verify_file_checksum(DR_PARAM_IN HANDLE app_file_handle,
         }
     }
 
-    if (TEST(ASLR_PERSISTENT_TARGET_DIGEST, DYNAMO_OPTION(aslr_validation))) {
+    if (TESTANY(ASLR_PERSISTENT_TARGET_DIGEST, DYNAMO_OPTION(aslr_validation))) {
         /* XXX: note that this routine should not be completely
          * trusted, if we're trying to prevent a high privileged
          * process from crashing on a bad DLL for extra safety we
@@ -3895,7 +3898,7 @@ calculate_publish_name(wchar_t *generated_name /* OUT */,
 
     _snwprintf(generated_name, max_name_length, L"%s-" L_PFMT, short_name, final_hash);
 
-    if (TEST(ASLR_INTERNAL_SHARED_NONUNIQUE, INTERNAL_OPTION(aslr_internal))) {
+    if (TESTANY(ASLR_INTERNAL_SHARED_NONUNIQUE, INTERNAL_OPTION(aslr_internal))) {
         /* stress testing: temporarily testing multiple file sections by unique
          * within process name */
         static int unique = 0;
@@ -4078,13 +4081,13 @@ aslr_generate_relocated_section(DR_PARAM_IN HANDLE unmodified_section,
      */
     /* check for PE already done by get_module_preferred_base() */
     module_characteristics = get_module_characteristics(base);
-    if (TEST(IMAGE_FILE_RELOCS_STRIPPED, module_characteristics)) {
+    if (TESTANY(IMAGE_FILE_RELOCS_STRIPPED, module_characteristics)) {
         LOG(GLOBAL, LOG_SYSCALLS | LOG_VMAREAS, 1,
             "ASLR: aslr_generate_relocated_section skipping non-relocatable module\n");
         goto unmap_and_exit;
     }
-    if (!TEST(IMAGE_FILE_DLL, module_characteristics)) {
-        if (TEST(ASLR_RANDOMIZE_EXECUTABLE, DYNAMO_OPTION(aslr_cache))) {
+    if (!TESTANY(IMAGE_FILE_DLL, module_characteristics)) {
+        if (TESTANY(ASLR_RANDOMIZE_EXECUTABLE, DYNAMO_OPTION(aslr_cache))) {
             /* note that we have no problem randomizing an executable with
              * relocations, when we're in the parent
              */
@@ -4112,7 +4115,7 @@ aslr_generate_relocated_section(DR_PARAM_IN HANDLE unmodified_section,
     }
 
     /* .NET DLLs */
-    if (TEST(ASLR_AVOID_NET20_NATIVE_IMAGES, DYNAMO_OPTION(aslr_cache)) &&
+    if (TESTANY(ASLR_AVOID_NET20_NATIVE_IMAGES, DYNAMO_OPTION(aslr_cache)) &&
         module_has_cor20_header(base)) {
         /* XXX:case 9164 once we have better capacity management
          * currently only fear of new temporary DLLs generated by ASP.NET */
@@ -4610,7 +4613,7 @@ aslr_produce_randomized_file(DR_PARAM_IN HANDLE original_file_handle,
     LOG(GLOBAL, LOG_SYSCALLS | LOG_VMAREAS, 1,
         "ASLR: aslr_produce_randomized_file for %ls\n", mostly_unique_name);
 
-    if (TEST(ASLR_SHARED_FILE_PRODUCER, DYNAMO_OPTION(aslr_cache))) {
+    if (TESTANY(ASLR_SHARED_FILE_PRODUCER, DYNAMO_OPTION(aslr_cache))) {
         /* Note that SEC_IMAGE is always mapped as
          * PAGE_EXECUTE_WRITECOPY therefore one can't write back
          * relocations to a file mapped as image, rather only
@@ -4665,7 +4668,7 @@ aslr_produce_randomized_file(DR_PARAM_IN HANDLE original_file_handle,
 
         if (ok) {
             NTSTATUS res;
-            bool persistent = TEST(ASLR_PERSISTENT, DYNAMO_OPTION(aslr_cache));
+            bool persistent = TESTANY(ASLR_PERSISTENT, DYNAMO_OPTION(aslr_cache));
 
             /* note that SEC_IMAGE is larger than the real file size,
              * but could use module_size to be slightly more conservative */
@@ -5004,7 +5007,7 @@ aslr_publish_section_handle(DR_PARAM_IN HANDLE original_file_handle,
         });
     }
 
-    if (TEST(ASLR_INTERNAL_SHARED_APPFILE, INTERNAL_OPTION(aslr_internal))) {
+    if (TESTANY(ASLR_INTERNAL_SHARED_APPFILE, INTERNAL_OPTION(aslr_internal))) {
         ASSERT_CURIOSITY(randomized_file_handle == NULL);
         /* stress testing: temporarily testing application file
          * sections instead of our own files, provides original file,
@@ -5194,7 +5197,7 @@ aslr_set_randomized_handle(dcontext_t *dcontext, HANDLE relocated_section_handle
     dcontext->aslr_context.original_section_checksum = original_checksum;
     dcontext->aslr_context.original_section_timestamp = original_timestamp;
 
-    if (TEST(ASLR_INTERNAL_SHARED_AND_PRIVATE, INTERNAL_OPTION(aslr_internal))) {
+    if (TESTANY(ASLR_INTERNAL_SHARED_AND_PRIVATE, INTERNAL_OPTION(aslr_internal))) {
         dcontext->aslr_context.randomized_section_handle = INVALID_HANDLE_VALUE;
     }
 }
@@ -5318,7 +5321,7 @@ aslr_replace_section_handle(DR_PARAM_IN HANDLE original_app_section_handle,
      * Note that each consumer will keep a handle and only when all
      * are done with it the file would be replacable.
      */
-    if (!TEST(ASLR_ALLOW_ORIGINAL_CLOBBER, DYNAMO_OPTION(aslr_cache))) {
+    if (!TESTANY(ASLR_ALLOW_ORIGINAL_CLOBBER, DYNAMO_OPTION(aslr_cache))) {
         /* Since we'll keep the app handle after mangling
          * NtCreateSection/NtOpenSection we'll have to close the old
          * handle the next time we're at NtCreateSection/NtOpenSection.
@@ -5482,7 +5485,7 @@ aslr_post_process_create_section_internal(DR_PARAM_IN HANDLE old_app_section_han
     bool ok;
     HANDLE new_published_handle;
 
-    ASSERT(TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
+    ASSERT(TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)));
     ASSERT(TESTANY(ASLR_SHARED_PUBLISHER | ASLR_SHARED_SUBSCRIBER |
                        ASLR_SHARED_ANONYMOUS_CONSUMER,
                    DYNAMO_OPTION(aslr_cache)));
@@ -5514,7 +5517,7 @@ aslr_post_process_create_section_internal(DR_PARAM_IN HANDLE old_app_section_han
     /* if we are a subscriber, try opening a published section, and
      * verify whether it is from correct DLL
      */
-    if (TEST(ASLR_SHARED_SUBSCRIBER, DYNAMO_OPTION(aslr_cache)) &&
+    if (TESTANY(ASLR_SHARED_SUBSCRIBER, DYNAMO_OPTION(aslr_cache)) &&
         aslr_subscribe_section_handle(old_app_section_handle, file_handle,
                                       mostly_unique_name, new_relocated_handle)) {
         return true;
@@ -5525,10 +5528,10 @@ aslr_post_process_create_section_internal(DR_PARAM_IN HANDLE old_app_section_han
                 DYNAMO_OPTION(aslr_cache)) &&
         aslr_publish_section_handle(
             file_handle, mostly_unique_name,
-            TEST(ASLR_SHARED_ANONYMOUS_CONSUMER, DYNAMO_OPTION(aslr_cache)),
+            TESTANY(ASLR_SHARED_ANONYMOUS_CONSUMER, DYNAMO_OPTION(aslr_cache)),
             &new_published_handle)) {
         /* anonymous publisher==subscriber */
-        if (TEST(ASLR_SHARED_ANONYMOUS_CONSUMER, DYNAMO_OPTION(aslr_cache))) {
+        if (TESTANY(ASLR_SHARED_ANONYMOUS_CONSUMER, DYNAMO_OPTION(aslr_cache))) {
             /* reuses the private section handle, just needs to
              * register the metadata */
             ASSERT(new_published_handle != INVALID_HANDLE_VALUE);
@@ -5550,7 +5553,7 @@ aslr_post_process_create_section_internal(DR_PARAM_IN HANDLE old_app_section_han
          * produced - producer may want to produce only for
          * others' consumption but refrain from using these...
          */
-        if (TEST(ASLR_SHARED_SUBSCRIBER, DYNAMO_OPTION(aslr_cache))) {
+        if (TESTANY(ASLR_SHARED_SUBSCRIBER, DYNAMO_OPTION(aslr_cache))) {
             /* we now reopen the object as a regular subscriber, so
              * that we don't pass to the application a handle that may
              * have higher privileges than necessary.  XXX: this
@@ -5835,10 +5838,10 @@ aslr_post_process_create_or_open_section(dcontext_t *dcontext, bool is_create,
     d_r_safe_read(sysarg_section_handle, sizeof(safe_section_handle),
                   &safe_section_handle);
 
-    ASSERT(TEST(ASLR_DLL, DYNAMO_OPTION(aslr)));
+    ASSERT(TESTANY(ASLR_DLL, DYNAMO_OPTION(aslr)));
     ASSERT(file_handle != NULL && file_handle != INVALID_HANDLE_VALUE);
 
-    if (TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
+    if (TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
         TESTANY(ASLR_SHARED_PUBLISHER | ASLR_SHARED_SUBSCRIBER |
                     ASLR_SHARED_ANONYMOUS_CONSUMER,
                 DYNAMO_OPTION(aslr_cache))) {
@@ -5851,7 +5854,7 @@ aslr_post_process_create_or_open_section(dcontext_t *dcontext, bool is_create,
             /* XXX: see note in aslr_post_process_mapview about handling failures
              * where we may need to preserve the original handle as well
              */
-            if (TEST(ASLR_ALLOW_ORIGINAL_CLOBBER, DYNAMO_OPTION(aslr_cache))) {
+            if (TESTANY(ASLR_ALLOW_ORIGINAL_CLOBBER, DYNAMO_OPTION(aslr_cache))) {
                 /* we can just close the handle to the original file */
                 close_handle(safe_section_handle);
             } else {
@@ -6039,7 +6042,7 @@ gbop_get_num_hooks(void)
         uint set_index = 0;
         size_t total_size = 0;
         while (gbop_hooks_set_sizes[set_index] != GBOP_HOOK_LIST_END_SENTINEL) {
-            if (TEST((1 << set_index), DYNAMO_OPTION(gbop_include_set))) {
+            if (TESTANY((1 << set_index), DYNAMO_OPTION(gbop_include_set))) {
                 gbop_hooks_set_enabled[set_index] = 1;
                 LOG(GLOBAL, LOG_SYSCALLS | LOG_VMAREAS, 1,
                     "gbop_get_num_hooks: 0x%x => %d enabled \n", (1 << set_index),
@@ -6161,8 +6164,8 @@ gbop_is_after_cti(const app_pc ret_addr)
     bool done = false;
     dcontext_t *dcontext;
 
-    ASSERT(TEST(GBOP_CHECK_INSTR_TYPE, DYNAMO_OPTION(gbop)));
-    if (!TEST(GBOP_IS_CALL, DYNAMO_OPTION(gbop))) {
+    ASSERT(TESTANY(GBOP_CHECK_INSTR_TYPE, DYNAMO_OPTION(gbop)));
+    if (!TESTANY(GBOP_IS_CALL, DYNAMO_OPTION(gbop))) {
         DODEBUG_ONCE(LOG(THREAD_GET, LOG_ALL, 1,
                          "GBOP: gbop_is_after_cti: GBOP_CHECK_INSTR_TYPE is "
                          "enabled, but GBOP_IS_CALL is not\n"));
@@ -6381,7 +6384,7 @@ gbop_check_valid_caller(app_pc reg_ebp, app_pc reg_esp, app_pc cur_pc,
 
         reg_t spill_mc_esp;
 
-        bool source_instr_ok = !(TEST(GBOP_CHECK_INSTR_TYPE, DYNAMO_OPTION(gbop)));
+        bool source_instr_ok = !(TESTANY(GBOP_CHECK_INSTR_TYPE, DYNAMO_OPTION(gbop)));
         bool is_call = false;   /* NYI */
         bool is_hp_jmp = false; /* NYI */
         bool is_jmp = false;    /* NYI */
@@ -6428,12 +6431,12 @@ gbop_check_valid_caller(app_pc reg_ebp, app_pc reg_esp, app_pc cur_pc,
          * could make check that it points within the array so can't be
          * overwritten trivially (and assuming DR memory is not writable).
          */
-        if (TEST(GBOP_IS_EXECUTABLE, DYNAMO_OPTION(gbop))) {
+        if (TESTANY(GBOP_IS_EXECUTABLE, DYNAMO_OPTION(gbop))) {
             is_exec = is_executable_address(suspect_shellcode_addr);
         }
 
 #    ifdef PROGRAM_SHEPHERDING
-        if (!is_exec && TEST(GBOP_IS_FUTURE_EXEC, DYNAMO_OPTION(gbop))) {
+        if (!is_exec && TESTANY(GBOP_IS_FUTURE_EXEC, DYNAMO_OPTION(gbop))) {
             /* is_future_exec is cheaper to evaluate policy
              * than the the policies that use query_virtual_memory()
              * so doing before the rest
@@ -6488,10 +6491,10 @@ gbop_check_valid_caller(app_pc reg_ebp, app_pc reg_esp, app_pc cur_pc,
              * somehow managed to make this call - so maybe somebody
              * is fooling with us. */
             DOLOG(2, LOG_VMAREAS, {
-                if (is_x && TEST(GBOP_IS_X, DYNAMO_OPTION(gbop))) {
+                if (is_x && TESTANY(GBOP_IS_X, DYNAMO_OPTION(gbop))) {
                     LOG(THREAD_GET, LOG_VMAREAS, 1, "GBOP: using is GBOP_IS_X\n");
                 }
-                if (is_image && TEST(GBOP_IS_IMAGE, DYNAMO_OPTION(gbop))) {
+                if (is_image && TESTANY(GBOP_IS_IMAGE, DYNAMO_OPTION(gbop))) {
                     /* XXX: all we check for GBOP_IS_IMAGE is whether MEM_IMAGE
                      * is set, note executable_if_image in fact only counts on
                      * getting module base, but should also be checking this.
@@ -6512,24 +6515,24 @@ gbop_check_valid_caller(app_pc reg_ebp, app_pc reg_esp, app_pc cur_pc,
         on_stack = is_address_on_stack(dcontext, purported_ret_addr);
         get_mcontext(dcontext)->xsp = spill_mc_esp;
 
-        ASSERT(!is_exec || TEST(GBOP_IS_EXECUTABLE, DYNAMO_OPTION(gbop)));
-        ASSERT(!is_future_exec || TEST(GBOP_IS_FUTURE_EXEC, DYNAMO_OPTION(gbop)));
+        ASSERT(!is_exec || TESTANY(GBOP_IS_EXECUTABLE, DYNAMO_OPTION(gbop)));
+        ASSERT(!is_future_exec || TESTANY(GBOP_IS_FUTURE_EXEC, DYNAMO_OPTION(gbop)));
 
         /* CAUTION: the order of the source page checks shouldn't be changed! */
         source_page_ok = is_exec || is_future_exec ||
-            (TEST(GBOP_IS_IMAGE, DYNAMO_OPTION(gbop)) && is_image) ||
-            (TEST(GBOP_IS_X, DYNAMO_OPTION(gbop)) && is_x);
+            (TESTANY(GBOP_IS_IMAGE, DYNAMO_OPTION(gbop)) && is_image) ||
+            (TESTANY(GBOP_IS_X, DYNAMO_OPTION(gbop)) && is_x);
 
         /* Allow any target but the current stack; case 8085. */
         if (!source_page_ok &&
-            (TEST(GBOP_IS_NOT_STACK, DYNAMO_OPTION(gbop)) && !on_stack)) {
+            (TESTANY(GBOP_IS_NOT_STACK, DYNAMO_OPTION(gbop)) && !on_stack)) {
             LOG(THREAD_GET, LOG_VMAREAS, 1, "GBOP: using GBOP_IS_NOT_STACK\n");
             source_page_ok = true;
         }
 
         /* Allow any target but the current stack, if a vm is loaded; case 8087. */
         if (!source_page_ok &&
-            (TEST(GBOP_IS_DGC, DYNAMO_OPTION(gbop)) && gbop_vm_loaded && !on_stack)) {
+            (TESTANY(GBOP_IS_DGC, DYNAMO_OPTION(gbop)) && gbop_vm_loaded && !on_stack)) {
             LOG(THREAD_GET, LOG_VMAREAS, 1, "GBOP: using GBOP_IS_DGC\n");
             source_page_ok = true;
         }
@@ -6550,7 +6553,7 @@ gbop_check_valid_caller(app_pc reg_ebp, app_pc reg_esp, app_pc cur_pc,
             /* continuing in case we're walking stack frames */
         }
 
-        if (TEST(GBOP_CHECK_INSTR_TYPE, DYNAMO_OPTION(gbop)))
+        if (TESTANY(GBOP_CHECK_INSTR_TYPE, DYNAMO_OPTION(gbop)))
             source_instr_ok = gbop_is_after_cti(purported_ret_addr);
 
         if (!source_instr_ok) {
@@ -6607,7 +6610,7 @@ gbop_validate_and_act(app_state_at_intercept_t *state, byte fpo_adjustment,
     app_pc bad_addr;
 
     ASSERT(DYNAMO_OPTION(gbop) != GBOP_DISABLED);
-    if (!TEST(GBOP_SET_NTDLL_BASE, DYNAMO_OPTION(gbop_include_set))) {
+    if (!TESTANY(GBOP_SET_NTDLL_BASE, DYNAMO_OPTION(gbop_include_set))) {
         return;
     }
 

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -370,11 +370,11 @@ if (!assume_xsp)
       # app xsp on the switched stack, i.e., dstack; not used after that.
       # i#1685: we use the PC slot as it won't affect a new thread that is in the
       # middle of init on the d_r_initstack and came here during client code.
-    if TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)
+    if TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)
       mov $MCONTEXT_OFFSET(xcx), xcx
     endif
       mov xsp, $PC_OFFSET(xcx)
-    if TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)
+    if TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)
       mov fs:$TLS_DCONTEXT_OFFSET, xcx
     endif
       mov $DSTACK(xcx), xsp
@@ -382,7 +382,7 @@ if (!assume_xsp)
       # now get the app xsp from the dcontext and put it on the dstack; this
       # will serve as the app xsp cache and will be used to send the correct
       # app xsp to the handler and to restore app xsp at exit
-    if TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)
+    if TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)
       mov $MCONTEXT_OFFSET(xcx), xcx
     endif
       mov $PC_OFFSET(xcx), xcx
@@ -960,14 +960,14 @@ emit_intercept_code(dcontext_t *dcontext, byte *pc, intercept_function_t callee,
         }
 
         /* Store the app xsp in dcontext and switch to dstack. */
-        if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+        if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
             APP(&ilist,
                 instr_create_restore_from_dc_via_reg(dcontext, REG_XCX, REG_XCX,
                                                      PROT_OFFS));
         }
         APP(&ilist,
             instr_create_save_to_dc_via_reg(dcontext, REG_XCX, REG_XSP, PC_OFFSET));
-        if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+        if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
             APP(&ilist,
                 INSTR_CREATE_mov_ld(
                     dcontext, opnd_create_reg(REG_XCX),
@@ -980,7 +980,7 @@ emit_intercept_code(dcontext_t *dcontext, byte *pc, intercept_function_t callee,
         /* Get the app xsp from the dcontext and put it on the dstack to serve
          * as the app xsp cache.
          */
-        if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+        if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
             APP(&ilist,
                 instr_create_restore_from_dc_via_reg(dcontext, REG_XCX, REG_XCX,
                                                      PROT_OFFS));
@@ -3280,7 +3280,7 @@ intercept_new_thread(CONTEXT *cxt)
                          check_filter("security-win32.except-execution.exe",
                                       get_short_name(get_application_name())));
         /* check for hooker's shellcode delivered via a remote thread */
-        if (TEST(OPTION_ENABLED, DYNAMO_OPTION(thread_policy))) {
+        if (TESTANY(OPTION_ENABLED, DYNAMO_OPTION(thread_policy))) {
             /* Most new threads (and all of the ones that target injected code
              * so far) have xip targeting one of the start thunks.  For these
              * threads the start address we want to apply the policy to is in
@@ -3626,7 +3626,7 @@ intercept_apc(app_state_at_intercept_t *state)
 
 #ifdef PROGRAM_SHEPHERDING
             /* check for hooker's shellcode delivered via APC */
-            if (TEST(OPTION_ENABLED, DYNAMO_OPTION(apc_policy))) {
+            if (TESTANY(OPTION_ENABLED, DYNAMO_OPTION(apc_policy))) {
                 apc_thread_policy_helper((app_pc *)(state->mc.xsp + APC_TARGET_XSP_OFFS),
                                          DYNAMO_OPTION(apc_policy), APC_TARGET_NATIVE
                                          /* NtQueueApcThread, likely from kernel mode */);
@@ -4204,7 +4204,7 @@ found_modified_code(dcontext_t *dcontext, EXCEPTION_RECORD *pExcptRec, CONTEXT *
     app_pc next_pc = NULL;
     cache_pc instr_cache_pc = (app_pc)pExcptRec->ExceptionAddress;
     app_pc translated_pc;
-    if (!TEST(flags, MOD_CODE_TAKEOVER) || TEST(flags, MOD_CODE_APP_CXT)) {
+    if (!TESTANY(flags, MOD_CODE_TAKEOVER) || TESTANY(flags, MOD_CODE_APP_CXT)) {
         LOG(THREAD, LOG_ASYNCH, 2, "found_modified_code: native/app " PFX "\n",
             instr_cache_pc);
         /* for !takeover: assumption: native pc -- XXX: vs
@@ -4299,7 +4299,7 @@ found_modified_code(dcontext_t *dcontext, EXCEPTION_RECORD *pExcptRec, CONTEXT *
         /* skip the write */
         next_pc = decode_next_pc(dcontext, translated_pc);
         LOG(THREAD, LOG_ASYNCH, 2, "skipping to after write pc " PFX "\n", next_pc);
-    } else if (TEST(flags, MOD_CODE_EMULATE_WRITE)) {
+    } else if (TESTANY(flags, MOD_CODE_EMULATE_WRITE)) {
         app_pc prot_start = (app_pc)PAGE_START(target);
         uint write_size;
         size_t prot_size;
@@ -4400,7 +4400,7 @@ found_modified_code(dcontext_t *dcontext, EXCEPTION_RECORD *pExcptRec, CONTEXT *
     }
     /* if !takeover, re-execute the write no matter what -- the assumption
      * is that the write is native */
-    if (!TEST(flags, MOD_CODE_TAKEOVER) || next_pc == NULL) {
+    if (!TESTANY(flags, MOD_CODE_TAKEOVER) || next_pc == NULL) {
         /* now re-execute the write
          * don't try to go through entire exception route by setting up
          * our own exception handler directly in TIB -- not transparent,
@@ -4493,7 +4493,7 @@ check_for_modified_code(dcontext_t *dcontext, EXCEPTION_RECORD *pExcptRec, CONTE
             /* not an app exception */
             RSTATS_DEC(num_exceptions);
             DOSTATS({
-                if (!TEST(MOD_CODE_TAKEOVER, flags))
+                if (!TESTANY(MOD_CODE_TAKEOVER, flags))
                     STATS_INC(num_native_cachecons_faults);
             });
             LOG(THREAD, LOG_ASYNCH, 2,
@@ -5097,7 +5097,7 @@ client_exception_event(dcontext_t *dcontext, CONTEXT *cxt, EXCEPTION_RECORD *pEx
     if (fragment != NULL && !hide_tag_from_client(fragment->tag)) {
         einfo.fault_fragment_info.tag = fragment->tag;
         einfo.fault_fragment_info.cache_start_pc = FCACHE_ENTRY_PC(fragment);
-        einfo.fault_fragment_info.is_trace = TEST(FRAG_IS_TRACE, fragment->flags);
+        einfo.fault_fragment_info.is_trace = TESTANY(FRAG_IS_TRACE, fragment->flags);
         einfo.fault_fragment_info.app_code_consistent =
             !TESTANY(FRAG_WAS_DELETED | FRAG_SELFMOD_SANDBOXED, fragment->flags);
     }
@@ -5253,7 +5253,7 @@ check_internal_exception(dcontext_t *dcontext, CONTEXT *cxt, EXCEPTION_RECORD *p
                 /* XXX: if necessary, have a separate dump core mask for
                  * in_page_error */
                 /* Let's pass it back to the application - memory is unreadable */
-                if (TEST(DUMPCORE_FORGE_UNREAD_EXEC, DYNAMO_OPTION(dumpcore_mask)))
+                if (TESTANY(DUMPCORE_FORGE_UNREAD_EXEC, DYNAMO_OPTION(dumpcore_mask)))
                     os_dump_core("Warning: Racy app execution (decode unreadable)");
                 os_forge_exception(target_addr, exception_type);
 
@@ -5441,7 +5441,7 @@ intercept_exception(app_state_at_intercept_t *state)
                                      "Hot patch exception, continuing.",
                                      get_application_name(), get_application_pid(),
                                      excpt_addr);
-                if (TEST(DUMPCORE_HOTP_FAILURE, DYNAMO_OPTION(dumpcore_mask)))
+                if (TESTANY(DUMPCORE_HOTP_FAILURE, DYNAMO_OPTION(dumpcore_mask)))
                     os_dump_core("hotp exception");
 
                 /* we don't support filters, so a single pass through
@@ -5469,7 +5469,7 @@ intercept_exception(app_state_at_intercept_t *state)
              * use dr_safe_read() and other mechanisms.
              */
 
-            if (TEST(DUMPCORE_TRY_EXCEPT, DYNAMO_OPTION(dumpcore_mask)))
+            if (TESTANY(DUMPCORE_TRY_EXCEPT, DYNAMO_OPTION(dumpcore_mask)))
                 os_dump_core("try/except fault");
 
             /* The exception interception code did an ENTER so we must EXIT here */
@@ -5650,10 +5650,10 @@ intercept_exception(app_state_at_intercept_t *state)
                                               "in preferred DLL range\n",
                                               execution_addr);
 
-                        if (TEST(ASLR_HANDLING, DYNAMO_OPTION(aslr_action)))
+                        if (TESTANY(ASLR_HANDLING, DYNAMO_OPTION(aslr_action)))
                             handling_policy |= OPTION_HANDLING;
 
-                        if (TEST(ASLR_REPORT, DYNAMO_OPTION(aslr_action)))
+                        if (TESTANY(ASLR_REPORT, DYNAMO_OPTION(aslr_action)))
                             handling_policy |= OPTION_REPORT;
 
                         /* for reporting purposes copy application
@@ -5666,7 +5666,7 @@ intercept_exception(app_state_at_intercept_t *state)
                          * exception to the application, unless we
                          * want to forcefully handle it
                          */
-                        ASSERT(!TEST(OPTION_HANDLING, handling_policy) &&
+                        ASSERT(!TESTANY(OPTION_HANDLING, handling_policy) &&
                                "doesn't return");
                     }
                 }
@@ -7893,7 +7893,7 @@ swap_dcontexts(dcontext_t *d1, dcontext_t *d2)
 {
     dcontext_t temp;
     /* be careful some fields can't be blindly swapped */
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         /* deep swap of upcontext */
         unprotected_context_t uptemp;
         memcpy((void *)&uptemp, (void *)d1->upcontext.separate_upcontext,
@@ -7906,7 +7906,7 @@ swap_dcontexts(dcontext_t *d1, dcontext_t *d2)
     memcpy((void *)&temp, (void *)d1, sizeof(dcontext_t));
     memcpy((void *)d1, (void *)d2, sizeof(dcontext_t));
     memcpy((void *)d2, (void *)&temp, sizeof(dcontext_t));
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
+    if (TESTANY(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         /* must swap upcontext pointers back since code is hardcoded for main one */
         temp.upcontext.separate_upcontext = d2->upcontext.separate_upcontext;
         d2->upcontext.separate_upcontext = d1->upcontext.separate_upcontext;

--- a/core/win32/diagnost.c
+++ b/core/win32/diagnost.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -207,7 +207,7 @@ print_memory_buffer(file_t diagnostics_file, byte *address, uint length,
 {
     byte *start, *end;
 
-    if (TEST(PRINT_MEM_BUF_START, flags)) {
+    if (TESTANY(PRINT_MEM_BUF_START, flags)) {
         start = address;
         end = address + length;
     } else {
@@ -215,7 +215,7 @@ print_memory_buffer(file_t diagnostics_file, byte *address, uint length,
         end = address + length / 2;
     }
 
-    if (!TEST(PRINT_MEM_BUF_NO_ALIGN, flags)) {
+    if (!TESTANY(PRINT_MEM_BUF_NO_ALIGN, flags)) {
         /* Align macros require power of 2 */
         ASSERT((DUMP_PER_LINE_DEFAULT & (DUMP_PER_LINE_DEFAULT - 1)) == 0);
         start = (byte *)ALIGN_BACKWARD(start, DUMP_PER_LINE_DEFAULT);
@@ -230,8 +230,8 @@ print_memory_buffer(file_t diagnostics_file, byte *address, uint length,
             dump_buffer_as_bytes(
                 diagnostics_file, start, cur_end - start,
                 DUMP_RAW | DUMP_ADDRESS |
-                    (TEST(PRINT_MEM_BUF_BYTE, flags) ? 0 : DUMP_DWORD) |
-                    (TEST(PRINT_MEM_BUF_ASCII, flags) ? DUMP_APPEND_ASCII : 0));
+                    (TESTANY(PRINT_MEM_BUF_BYTE, flags) ? 0 : DUMP_DWORD) |
+                    (TESTANY(PRINT_MEM_BUF_ASCII, flags) ? DUMP_APPEND_ASCII : 0));
             print_file(diagnostics_file, "\n");
         } else {
             print_file(diagnostics_file, "Can\'t print 0x%.8x-0x%.8x (unreadable)\n",
@@ -299,7 +299,7 @@ report_src_info(file_t diagnostics_file, dcontext_t *dcontext)
                "\t\t<cache-content\n"
                "\t\t\tflags= \"0x%0x\"",
                f->flags);
-    if (TEST(FRAG_IS_TRACE, f->flags)) {
+    if (TESTANY(FRAG_IS_TRACE, f->flags)) {
         uint i = 0;
         trace_only_t *t = TRACE_FIELDS(f);
         if (t != NULL) {

--- a/core/win32/drwinapi/kernel32_file.c
+++ b/core/win32/drwinapi/kernel32_file.c
@@ -360,31 +360,31 @@ static DWORD
 file_options_to_nt(DWORD winapi, ACCESS_MASK *access DR_PARAM_OUT)
 {
     DWORD options = 0;
-    if (!TEST(FILE_FLAG_OVERLAPPED, winapi))
+    if (!TESTANY(FILE_FLAG_OVERLAPPED, winapi))
         options |= FILE_SYNCHRONOUS_IO_NONALERT;
-    if (TEST(FILE_FLAG_BACKUP_SEMANTICS, winapi)) {
+    if (TESTANY(FILE_FLAG_BACKUP_SEMANTICS, winapi)) {
         options |= FILE_OPEN_FOR_BACKUP_INTENT;
-        if (TEST(GENERIC_WRITE, *access))
+        if (TESTANY(GENERIC_WRITE, *access))
             options |= FILE_OPEN_REMOTE_INSTANCE;
     } else {
         /* FILE_FLAG_BACKUP_SEMANTICS is supposed to be set for directories */
         options |= FILE_NON_DIRECTORY_FILE;
     }
-    if (TEST(FILE_FLAG_DELETE_ON_CLOSE, winapi)) {
+    if (TESTANY(FILE_FLAG_DELETE_ON_CLOSE, winapi)) {
         *access |= DELETE; /* needed for FILE_DELETE_ON_CLOSE */
         options |= FILE_DELETE_ON_CLOSE;
     }
-    if (TEST(FILE_FLAG_NO_BUFFERING, winapi))
+    if (TESTANY(FILE_FLAG_NO_BUFFERING, winapi))
         options |= FILE_NO_INTERMEDIATE_BUFFERING;
-    if (TEST(FILE_FLAG_OPEN_NO_RECALL, winapi))
+    if (TESTANY(FILE_FLAG_OPEN_NO_RECALL, winapi))
         options |= FILE_OPEN_NO_RECALL;
-    if (TEST(FILE_FLAG_OPEN_REPARSE_POINT, winapi))
+    if (TESTANY(FILE_FLAG_OPEN_REPARSE_POINT, winapi))
         options |= FILE_OPEN_REPARSE_POINT;
-    if (TEST(FILE_FLAG_RANDOM_ACCESS, winapi))
+    if (TESTANY(FILE_FLAG_RANDOM_ACCESS, winapi))
         options |= FILE_RANDOM_ACCESS;
-    if (TEST(FILE_FLAG_SEQUENTIAL_SCAN, winapi))
+    if (TESTANY(FILE_FLAG_SEQUENTIAL_SCAN, winapi))
         options |= FILE_SEQUENTIAL_ONLY;
-    if (TEST(FILE_FLAG_WRITE_THROUGH, winapi))
+    if (TESTANY(FILE_FLAG_WRITE_THROUGH, winapi))
         options |= FILE_WRITE_THROUGH;
 
     /* XXX: not sure about FILE_FLAG_POSIX_SEMANTICS or
@@ -400,11 +400,11 @@ file_access_to_nt(ACCESS_MASK winapi)
     ACCESS_MASK access = winapi;
     /* always set these */
     access |= SYNCHRONIZE | FILE_READ_ATTRIBUTES;
-    if (TEST(GENERIC_READ, winapi))
+    if (TESTANY(GENERIC_READ, winapi))
         access |= FILE_GENERIC_READ;
-    if (TEST(GENERIC_WRITE, winapi))
+    if (TESTANY(GENERIC_WRITE, winapi))
         access |= FILE_GENERIC_WRITE;
-    if (TEST(GENERIC_EXECUTE, winapi))
+    if (TESTANY(GENERIC_EXECUTE, winapi))
         access |= FILE_GENERIC_EXECUTE;
     return access;
 }
@@ -441,17 +441,17 @@ create_file_common(__in LPCWSTR nt_file_name, __in DWORD dwDesiredAccess,
     file_attributes = dwFlagsAndAttributes & FILE_ATTRIBUTE_VALID_FLAGS;
     file_attributes &= ~FILE_ATTRIBUTE_DIRECTORY; /* except this one */
 
-    if (TEST(SECURITY_SQOS_PRESENT, dwFlagsAndAttributes)) {
+    if (TESTANY(SECURITY_SQOS_PRESENT, dwFlagsAndAttributes)) {
         sqos_ptr = &sqos;
         sqos.Length = sizeof(sqos);
         /* SECURITY_* flags are from 4-member SECURITY_IMPERSONATION_LEVEL enum <<16 */
         sqos.ImpersonationLevel = (dwFlagsAndAttributes >> 16) & 0x3;
         ;
-        if (TEST(SECURITY_CONTEXT_TRACKING, dwFlagsAndAttributes))
+        if (TESTANY(SECURITY_CONTEXT_TRACKING, dwFlagsAndAttributes))
             sqos.ContextTrackingMode = SECURITY_DYNAMIC_TRACKING;
         else
             sqos.ContextTrackingMode = SECURITY_STATIC_TRACKING;
-        sqos.EffectiveOnly = TEST(SECURITY_EFFECTIVE_ONLY, dwFlagsAndAttributes);
+        sqos.EffectiveOnly = TESTANY(SECURITY_EFFECTIVE_ONLY, dwFlagsAndAttributes);
     }
 
     /* map the non-FILE_ATTRIBUTE_* flags */
@@ -987,10 +987,10 @@ redirect_MapViewOfFileEx(__in HANDLE hFileMappingObject, __in DWORD dwDesiredAcc
      */
     if (TESTANY(FILE_MAP_WRITE | FILE_MAP_COPY, dwDesiredAccess))
         prot |= FILE_MAP_WRITE;
-    if (TEST(FILE_MAP_EXECUTE, dwDesiredAccess))
+    if (TESTANY(FILE_MAP_EXECUTE, dwDesiredAccess))
         prot |= MEMPROT_EXEC;
     prot = memprot_to_osprot(prot);
-    if (TEST(FILE_MAP_COPY, dwDesiredAccess) &&
+    if (TESTANY(FILE_MAP_COPY, dwDesiredAccess) &&
         /* i#1368: not a true bitmask! */
         dwDesiredAccess != FILE_MAP_ALL_ACCESS)
         prot = osprot_add_writecopy(prot);
@@ -1333,9 +1333,9 @@ redirect_GetDriveTypeW(__in_opt LPCWSTR lpRootPathName)
     switch (info.DeviceType) {
     case FILE_DEVICE_DISK:
     case FILE_DEVICE_DISK_FILE_SYSTEM: {
-        if (TEST(FILE_REMOVABLE_MEDIA, info.Characteristics))
+        if (TESTANY(FILE_REMOVABLE_MEDIA, info.Characteristics))
             return DRIVE_REMOVABLE;
-        else if (TEST(FILE_REMOTE_DEVICE, info.Characteristics))
+        else if (TESTANY(FILE_REMOTE_DEVICE, info.Characteristics))
             return DRIVE_REMOTE;
         else
             return DRIVE_FIXED;

--- a/core/win32/drwinapi/kernel32_mem.c
+++ b/core/win32/drwinapi/kernel32_mem.c
@@ -212,7 +212,7 @@ redirect_LocalAlloc(__in UINT uFlags, __in SIZE_T uBytes)
     HANDLE heap = redirect_GetProcessHeap();
     /* for back-compat, LocalAlloc asks for +x */
     uint rtl_flags = HEAP_NO_SERIALIZE | HEAP_CREATE_ENABLE_EXECUTE;
-    if (TEST(LMEM_ZEROINIT, uFlags))
+    if (TESTANY(LMEM_ZEROINIT, uFlags))
         rtl_flags |= HEAP_ZERO_MEMORY;
 
     /* flags should be in ushort range */
@@ -250,7 +250,7 @@ redirect_LocalFree(__deref HLOCAL hMem)
     d_r_mutex_lock(&localheap_lock);
     /* XXX: supposed to raise debug msg + bp if freeing locked object */
     if (hdr->alloc != NULL) {
-        ASSERT(TEST(LMEM_MOVEABLE, hdr->flags));
+        ASSERT(TESTANY(LMEM_MOVEABLE, hdr->flags));
         redirect_RtlFreeHeap(heap, HEAP_NO_SERIALIZE, hdr->alloc);
     }
     redirect_RtlFreeHeap(heap, HEAP_NO_SERIALIZE, hdr);
@@ -266,14 +266,14 @@ redirect_LocalReAlloc(__in HLOCAL hMem, __in SIZE_T uBytes, __in UINT uFlags)
     HANDLE heap = redirect_GetProcessHeap();
     local_header_t *hdr = local_header_from_handle(hMem);
     uint rtl_flags = HEAP_NO_SERIALIZE | HEAP_CREATE_ENABLE_EXECUTE;
-    if (TEST(LMEM_ZEROINIT, uFlags))
+    if (TESTANY(LMEM_ZEROINIT, uFlags))
         rtl_flags |= HEAP_ZERO_MEMORY;
     d_r_mutex_lock(&localheap_lock);
-    if (TEST(LMEM_MODIFY, uFlags)) {
+    if (TESTANY(LMEM_MODIFY, uFlags)) {
         /* no realloc, just update flags */
         if ((uFlags & 0xffff0000) != 0 || /* flags should be in ushort range */
             /* we don't allow turning moveable w/ sep alloc into fixed */
-            (!TEST(LMEM_MOVEABLE, uFlags) && hdr->alloc != NULL)) {
+            (!TESTANY(LMEM_MOVEABLE, uFlags) && hdr->alloc != NULL)) {
             set_last_error(ERROR_INVALID_PARAMETER);
             res = NULL;
             goto redirect_LocalReAlloc_done;
@@ -282,10 +282,10 @@ redirect_LocalReAlloc(__in HLOCAL hMem, __in SIZE_T uBytes, __in UINT uFlags)
         res = hMem;
     } else {
         /* if fixed or locked and LMEM_MOVEABLE is not specified, must realloc in-place */
-        if (!TEST(LMEM_MOVEABLE, uFlags) &&
-            (!TEST(LMEM_MOVEABLE, hdr->flags) || hdr->lock_count > 0))
+        if (!TESTANY(LMEM_MOVEABLE, uFlags) &&
+            (!TESTANY(LMEM_MOVEABLE, hdr->flags) || hdr->lock_count > 0))
             rtl_flags |= HEAP_REALLOC_IN_PLACE_ONLY;
-        else if (TEST(LMEM_MOVEABLE, hdr->flags) && hdr->alloc == NULL) {
+        else if (TESTANY(LMEM_MOVEABLE, hdr->flags) && hdr->alloc == NULL) {
             size_t copy_sz =
                 redirect_RtlSizeHeap(heap, 0, (byte *)hdr) - sizeof(local_header_t);
             copy_sz = MIN(copy_sz, uBytes);
@@ -339,7 +339,7 @@ redirect_LocalLock(__in HLOCAL hMem)
     LPVOID res = NULL;
     local_header_t *hdr = local_header_from_handle(hMem);
     d_r_mutex_lock(&localheap_lock);
-    if (TEST(LMEM_MOVEABLE, hdr->flags))
+    if (TESTANY(LMEM_MOVEABLE, hdr->flags))
         hdr->lock_count++;
     if (hdr->alloc != NULL)
         res = (LPVOID)(hdr->alloc + 1);
@@ -354,7 +354,7 @@ WINAPI
 redirect_LocalHandle(__in LPCVOID pMem)
 {
     local_header_t *hdr = local_header_from_handle((PVOID)pMem);
-    if (TEST(LMEM_INVALID_HANDLE, hdr->flags)) {
+    if (TESTANY(LMEM_INVALID_HANDLE, hdr->flags)) {
         /* separate alloc stores the original header */
         hdr = hdr->alloc;
     }
@@ -391,7 +391,7 @@ redirect_LocalSize(__in HLOCAL hMem)
     HANDLE heap = redirect_GetProcessHeap();
     d_r_mutex_lock(&localheap_lock);
     if (hdr->alloc != NULL) {
-        ASSERT(TEST(LMEM_MOVEABLE, hdr->flags));
+        ASSERT(TESTANY(LMEM_MOVEABLE, hdr->flags));
         res = redirect_RtlSizeHeap(heap, 0, (byte *)hdr->alloc);
     } else
         res = redirect_RtlSizeHeap(heap, 0, (byte *)hdr);
@@ -456,11 +456,11 @@ __bcount(dwSize) LPVOID WINAPI
     /* XXX: are MEM_* values beyond MEM_RESERVE and MEM_COMMIT passed to the kernel? */
     PVOID base = lpAddress;
     NTSTATUS res;
-    if (TEST(MEM_COMMIT, flAllocationType) &&
+    if (TESTANY(MEM_COMMIT, flAllocationType) &&
         /* Any overlap when asking for MEM_RESERVE (even when combined w/ MEM_COMMIT)
          * will fail anyway, so we only have to worry about overlap on plain MEM_COMMIT
          */
-        !TEST(MEM_RESERVE, flAllocationType) && lpAddress != NULL) {
+        !TESTANY(MEM_RESERVE, flAllocationType) && lpAddress != NULL) {
         /* i#1175: NtAllocateVirtualMemory can modify prot on existing pages */
         if (!app_memory_pre_alloc(get_thread_private_dcontext(), lpAddress, dwSize,
                                   osprot_to_memprot(flProtect), false, true /*update*/,
@@ -485,7 +485,7 @@ BOOL WINAPI
 redirect_VirtualFree(__in LPVOID lpAddress, __in SIZE_T dwSize, __in DWORD dwFreeType)
 {
     NTSTATUS res;
-    if (TEST(MEM_DECOMMIT, dwFreeType))
+    if (TESTANY(MEM_DECOMMIT, dwFreeType))
         res = nt_decommit_virtual_memory(lpAddress, dwSize);
     else {
         if (dwSize != 0) {
@@ -599,7 +599,7 @@ test_local(void)
     loc = redirect_LocalReAlloc(loc, 26, LMEM_MOVEABLE | LMEM_ZEROINIT);
     EXPECT(*(int *)loc == 0, true);
     EXPECT(redirect_LocalSize(loc), 26);
-    EXPECT(TEST(LMEM_DISCARDABLE, redirect_LocalFlags(loc)), false);
+    EXPECT(TESTANY(LMEM_DISCARDABLE, redirect_LocalFlags(loc)), false);
 
     /* locking should do nothing since fixed */
     EXPECT(redirect_LocalLock(loc) == (LPVOID)loc, true);
@@ -609,7 +609,7 @@ test_local(void)
 
     loc = redirect_LocalReAlloc(loc, 0, LMEM_MOVEABLE | LMEM_ZEROINIT);
     EXPECT(redirect_LocalSize(loc), 0);
-    EXPECT(TEST(LMEM_DISCARDABLE, redirect_LocalFlags(loc)), true);
+    EXPECT(TESTANY(LMEM_DISCARDABLE, redirect_LocalFlags(loc)), true);
 
     /* test LMEM_MODIFY */
     loc = redirect_LocalReAlloc(loc, 0 /*ignored*/, LMEM_MODIFY | LMEM_MOVEABLE);
@@ -632,7 +632,7 @@ test_local(void)
     EXPECT(p != NULL, true);
     EXPECT(*(int *)p == 0, true);
     EXPECT(redirect_LocalSize(loc), 6);
-    EXPECT(TEST(LMEM_DISCARDABLE, redirect_LocalFlags(loc)), false);
+    EXPECT(TESTANY(LMEM_DISCARDABLE, redirect_LocalFlags(loc)), false);
 
     ok = redirect_LocalUnlock(loc);
     EXPECT(ok, FALSE);
@@ -650,7 +650,7 @@ test_local(void)
 
     loc = redirect_LocalReAlloc(loc, 0, LMEM_MOVEABLE | LMEM_ZEROINIT);
     EXPECT(redirect_LocalSize(loc), 0);
-    EXPECT(TEST(LMEM_DISCARDABLE, redirect_LocalFlags(loc)), true);
+    EXPECT(TESTANY(LMEM_DISCARDABLE, redirect_LocalFlags(loc)), true);
     loc = redirect_LocalFree(loc);
     EXPECT(loc == NULL, true);
 }

--- a/core/win32/drwinapi/ntdll_redir.c
+++ b/core/win32/drwinapi/ntdll_redir.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.   All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.   All rights reserved.
  * Copyright (c) 2009-2010 Derek Bruening   All rights reserved.
  * **********************************************************/
 
@@ -306,7 +306,7 @@ wrapped_dr_alloc(ULONG flags, SIZE_T size)
         ASSERT_NOT_REACHED();
         return NULL;
     }
-    if (TEST(HEAP_ZERO_MEMORY, flags))
+    if (TESTANY(HEAP_ZERO_MEMORY, flags))
         memset(mem, 0, size);
     return mem;
 }
@@ -358,7 +358,7 @@ redirect_RtlReAllocateHeap(HANDLE heap, ULONG flags, byte *ptr, SIZE_T size)
         return NULL;
     if (redirect_heap_call(heap) && is_dynamo_address(ptr)) {
         byte *buf = NULL;
-        if (TEST(HEAP_REALLOC_IN_PLACE_ONLY, flags)) {
+        if (TESTANY(HEAP_REALLOC_IN_PLACE_ONLY, flags)) {
             ASSERT_NOT_IMPLEMENTED(false);
             return NULL;
         }
@@ -561,7 +561,7 @@ redirect_RtlInitializeCriticalSectionEx(RTL_CRITICAL_SECTION *crit, ULONG spinco
            standalone_library);
     if (crit == NULL)
         return STATUS_INVALID_PARAMETER;
-    if (TEST(RTL_CRITICAL_SECTION_FLAG_STATIC_INIT, flags)) {
+    if (TESTANY(RTL_CRITICAL_SECTION_FLAG_STATIC_INIT, flags)) {
         /* We're supposed to use a memory pool but it's not
          * clear whether it really matters so we ignore this flag.
          */
@@ -575,7 +575,7 @@ redirect_RtlInitializeCriticalSectionEx(RTL_CRITICAL_SECTION *crit, ULONG spinco
     else
         crit->SpinCount = (spincount & ~0x80000000);
 
-    if (TEST(RTL_CRITICAL_SECTION_FLAG_NO_DEBUG_INFO, flags))
+    if (TESTANY(RTL_CRITICAL_SECTION_FLAG_NO_DEBUG_INFO, flags))
         crit->DebugInfo = NULL;
     else {
         crit->DebugInfo = wrapped_dr_alloc(0, sizeof(*crit->DebugInfo));

--- a/core/win32/eventlog.c
+++ b/core/win32/eventlog.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -861,7 +861,7 @@ os_eventlog(syslog_event_type_t priority, uint message_id, uint substitutions_nu
     uint res = 0;
 
     /* check mask on event_type whether to log this type of message */
-    if (!TEST(priority, dynamo_options.syslog_mask))
+    if (!TESTANY(priority, dynamo_options.syslog_mask))
         return;
 
     switch (priority) {

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -241,7 +241,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle, char *dynamo_pa
              */
             int i, j;
             /* For x86, ensure we have ExtendedRegisters space (i#1223) */
-            IF_NOT_X64(ASSERT(TEST(CONTEXT_XMM_FLAG, cxt->ContextFlags)));
+            IF_NOT_X64(ASSERT(TESTANY(CONTEXT_XMM_FLAG, cxt->ContextFlags)));
             /* XXX i#1312: This should be proc_num_simd_sse_avx_registers(). */
             ASSERT(MCXT_SIMD_SLOT_SIZE == ZMM_REG_SIZE);
             for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {

--- a/core/win32/inject_shared.c
+++ b/core/win32/inject_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -747,7 +747,7 @@ get_process_qualified_name(HANDLE process_handle, wchar_t *w_exename,
     }
 
     commandline_dispatch = commandline_qualifier_needed(short_name, whichreg);
-    if (TEST(RUNUNDER_COMMANDLINE_DISPATCH, commandline_dispatch)) {
+    if (TESTANY(RUNUNDER_COMMANDLINE_DISPATCH, commandline_dispatch)) {
         wchar_t cmdline_qualifier[MAXIMUM_PATH] = L"-";
         /* XXX: we could do all this processing in w_exename so that
            no other buffer is needed at all, but for the sake of
@@ -770,7 +770,7 @@ get_process_qualified_name(HANDLE process_handle, wchar_t *w_exename,
         get_commandline_qualifier(
             process_commandline, cmdline_qualifier + 1, /* skip the '-' */
             BUFFER_SIZE_ELEMENTS(cmdline_qualifier) - 1,
-            TEST(RUNUNDER_COMMANDLINE_NO_STRIP, commandline_dispatch));
+            TESTANY(RUNUNDER_COMMANDLINE_NO_STRIP, commandline_dispatch));
 
         /* append "qualifier" which already has a '-' and may in fact be only '-' if
          * no qualifier was found (we still want the '-' to separate out the registry
@@ -1398,7 +1398,7 @@ check_for_run_once(HANDLE process, int rununder_mask)
     int size;
     char mask_string[MAX_RUNVALUE_LENGTH];
 
-    if (TEST(rununder_mask, RUNUNDER_ONCE)) {
+    if (TESTANY(rununder_mask, RUNUNDER_ONCE)) {
         rununder_mask &= ~RUNUNDER_ON;
         size =
             snprintf(mask_string, BUFFER_SIZE_ELEMENTS(mask_string), "%d", rununder_mask);

--- a/core/win32/injector.c
+++ b/core/win32/injector.c
@@ -979,9 +979,9 @@ dr_inject_process_inject(void *data, bool force_injection, const char *library_p
     if (!force_injection) {
         int inject_flags = systemwide_should_inject(info->pi.hProcess, NULL);
         bool syswide_will_inject = systemwide_inject_enabled() &&
-            TEST(INJECT_TRUE, inject_flags) && !TEST(INJECT_EXPLICIT, inject_flags);
+            TESTANY(INJECT_TRUE, inject_flags) && !TESTANY(INJECT_EXPLICIT, inject_flags);
         bool should_not_takeover =
-            TEST(INJECT_EXCLUDED, inject_flags) && info->using_debugger_injection;
+            TESTANY(INJECT_EXCLUDED, inject_flags) && info->using_debugger_injection;
         /* case 10794: to support follow_children we inject even if
          * syswide_will_inject.  we use RUNUNDER_EXPLICIT to avoid
          * user32 injection from happening, to get consistent injection.

--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.   All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.   All rights reserved.
  * Copyright (c) 2009-2010 Derek Bruening   All rights reserved.
  * **********************************************************/
 
@@ -649,7 +649,7 @@ swap_peb_pointer_ex(dcontext_t *dcontext, bool to_priv, dr_state_flags_t flags)
     ASSERT(INTERNAL_OPTION(private_peb));
     ASSERT(private_peb_initialized);
     ASSERT(tgt_peb != NULL);
-    if (TEST(DR_STATE_PEB, flags) && should_swap_peb_pointer()) {
+    if (TESTANY(DR_STATE_PEB, flags) && should_swap_peb_pointer()) {
         set_teb_field(dcontext, PEB_TIB_OFFSET, (void *)tgt_peb);
         LOG(THREAD, LOG_LOADER, 2, "set teb->peb to " PFX "\n", tgt_peb);
     }
@@ -663,19 +663,19 @@ swap_peb_pointer_ex(dcontext_t *dcontext, bool to_priv, dr_state_flags_t flags)
         void *cur_rpc = NULL;
         void *cur_nls_cache = NULL;
         void *cur_static_tls = NULL;
-        if (TEST(DR_STATE_TEB_MISC, flags) && should_swap_teb_nonstack_fields()) {
+        if (TESTANY(DR_STATE_TEB_MISC, flags) && should_swap_teb_nonstack_fields()) {
             cur_fls = get_teb_field(dcontext, FLS_DATA_TIB_OFFSET);
             cur_rpc = get_teb_field(dcontext, NT_RPC_TIB_OFFSET);
             cur_nls_cache = get_teb_field(dcontext, NLS_CACHE_TIB_OFFSET);
         }
-        if (TEST(DR_STATE_TEB_MISC, flags) && should_swap_teb_static_tls()) {
+        if (TESTANY(DR_STATE_TEB_MISC, flags) && should_swap_teb_static_tls()) {
             cur_static_tls = get_teb_field(dcontext, STATIC_TLS_TIB_OFFSET);
         }
         DOLOG(3, LOG_LOADER, {
             print_teb_fields(dcontext, to_priv ? "pre swap to priv" : "pre swap to app");
         });
         if (to_priv) {
-            if (TEST(DR_STATE_STACK_BOUNDS, flags) &&
+            if (TESTANY(DR_STATE_STACK_BOUNDS, flags) &&
                 dynamo_initialized /* on app stack until init finished */) {
                 if (SWAP_TEB_STACKLIMIT() &&
                     /* Handle two in a row, using an exact cmp b/c
@@ -695,7 +695,7 @@ swap_peb_pointer_ex(dcontext_t *dcontext, bool to_priv, dr_state_flags_t flags)
                     set_teb_field(dcontext, TOP_STACK_TIB_OFFSET, dcontext->dstack);
                 }
             }
-            if (TEST(DR_STATE_TEB_MISC, flags) && should_swap_teb_nonstack_fields()) {
+            if (TESTANY(DR_STATE_TEB_MISC, flags) && should_swap_teb_nonstack_fields()) {
                 /* note: two calls in a row will clobber app_errno w/ wrong value! */
                 dcontext->app_errno =
                     (int)(ptr_int_t)get_teb_field(dcontext, ERRNO_TIB_OFFSET);
@@ -713,7 +713,7 @@ swap_peb_pointer_ex(dcontext_t *dcontext, bool to_priv, dr_state_flags_t flags)
                                   dcontext->priv_nls_cache);
                 }
             }
-            if (TEST(DR_STATE_TEB_MISC, flags) && should_swap_teb_static_tls()) {
+            if (TESTANY(DR_STATE_TEB_MISC, flags) && should_swap_teb_static_tls()) {
                 if (dcontext->priv_static_tls !=
                     cur_static_tls) { /* handle two in a row */
                     dcontext->app_static_tls = cur_static_tls;
@@ -722,7 +722,7 @@ swap_peb_pointer_ex(dcontext_t *dcontext, bool to_priv, dr_state_flags_t flags)
                 }
             }
         } else {
-            if (TEST(DR_STATE_STACK_BOUNDS, flags)) {
+            if (TESTANY(DR_STATE_STACK_BOUNDS, flags)) {
                 if (SWAP_TEB_STACKLIMIT() &&
                     /* Handle two in a row, using an exact cmp b/c
                      * is_dynamo_address() is slow and needs locks (i#1832).
@@ -740,7 +740,7 @@ swap_peb_pointer_ex(dcontext_t *dcontext, bool to_priv, dr_state_flags_t flags)
                                   dcontext->app_stack_base);
                 }
             }
-            if (TEST(DR_STATE_TEB_MISC, flags) && should_swap_teb_nonstack_fields()) {
+            if (TESTANY(DR_STATE_TEB_MISC, flags) && should_swap_teb_nonstack_fields()) {
                 /* two calls in a row should be fine */
                 set_teb_field(dcontext, ERRNO_TIB_OFFSET,
                               (void *)(ptr_int_t)dcontext->app_errno);
@@ -758,7 +758,7 @@ swap_peb_pointer_ex(dcontext_t *dcontext, bool to_priv, dr_state_flags_t flags)
                                   dcontext->app_nls_cache);
                 }
             }
-            if (TEST(DR_STATE_TEB_MISC, flags) && should_swap_teb_static_tls()) {
+            if (TESTANY(DR_STATE_TEB_MISC, flags) && should_swap_teb_static_tls()) {
                 if (dcontext->app_static_tls !=
                     cur_static_tls) { /* handle two in a row */
                     /* Unlike the other fields, we control this private one so we
@@ -874,9 +874,9 @@ check_app_stack_limit(dcontext_t *dcontext)
     do {
         check_pc -= PAGE_SIZE;
         res = query_virtual_memory(check_pc, &mbi, sizeof(mbi));
-    } while (res == sizeof(mbi) && !TEST(PAGE_GUARD, mbi.Protect) &&
+    } while (res == sizeof(mbi) && !TESTANY(PAGE_GUARD, mbi.Protect) &&
              check_pc > (byte *)(ptr_uint_t)PAGE_SIZE);
-    if (res == sizeof(mbi) && TEST(PAGE_GUARD, mbi.Protect) &&
+    if (res == sizeof(mbi) && TESTANY(PAGE_GUARD, mbi.Protect) &&
         check_pc + PAGE_SIZE < start_pc) {
         LOG(THREAD, LOG_LOADER, 2,
             "updated stored TEB.StackLimit from " PFX " to " PFX "\n", start_pc,
@@ -999,7 +999,7 @@ privload_map_and_relocate(const char *filename, size_t *size DR_PARAM_OUT,
     byte *(*map_func)(file_t, size_t *, uint64, app_pc, uint, map_flags_t);
     bool (*unmap_func)(file_t, size_t);
     ASSERT(size != NULL);
-    ASSERT_OWN_RECURSIVE_LOCK(!TEST(MODLOAD_NOT_PRIVLIB, flags), &privload_lock);
+    ASSERT_OWN_RECURSIVE_LOCK(!TESTANY(MODLOAD_NOT_PRIVLIB, flags), &privload_lock);
 
     /* On win32 OS_EXECUTE is required to create a section w/ rwx
      * permissions, which is in turn required to map a view w/ rwx
@@ -1058,7 +1058,7 @@ privload_map_and_relocate(const char *filename, size_t *size DR_PARAM_OUT,
         return NULL;
     }
 #ifdef X64
-    if (TEST(MODLOAD_REACHABLE, flags)) {
+    if (TESTANY(MODLOAD_REACHABLE, flags)) {
         bool reloc = module_file_relocatable(map);
         (*unmap_func)(map, *size);
         map = NULL;
@@ -1313,7 +1313,7 @@ privload_process_one_import(privmod_t *mod, privmod_t *impmod, IMAGE_THUNK_DATA 
     const char *forwpath = NULL;
 
     ASSERT_OWN_RECURSIVE_LOCK(true, &privload_lock);
-    if (TEST(IMAGE_ORDINAL_FLAG, lookup->u1.Function)) {
+    if (TESTANY(IMAGE_ORDINAL_FLAG, lookup->u1.Function)) {
         /* XXX: for 64-bit this is a 64-bit type: should we widen through
          * get_proc_address_by_ordinal()?
          */
@@ -2752,7 +2752,7 @@ privload_bootstrap_dynamorio_imports(byte *dr_base, byte *ntdll_base)
         while (lookup->u1.Function != 0) {
             IMAGE_IMPORT_BY_NAME *name = (IMAGE_IMPORT_BY_NAME *)RVA_TO_VA(
                 dr_base, (lookup->u1.AddressOfData & ~(IMAGE_ORDINAL_FLAG)));
-            if (TEST(IMAGE_ORDINAL_FLAG, lookup->u1.Function))
+            if (TESTANY(IMAGE_ORDINAL_FLAG, lookup->u1.Function))
                 return false; /* no ordinal support */
 
             func = privload_bootstrap_get_export(ntdll_base, (const char *)name->Name);

--- a/core/win32/module.c
+++ b/core/win32/module.c
@@ -1216,8 +1216,8 @@ print_modules_ldrlist_and_ourlist(file_t f, bool dump_xml, bool conservative)
         print_file(f, "\n");
 
     /* XXX: currently updated only under aslr_action */
-    if (TEST(ASLR_DLL, DYNAMO_OPTION(aslr)) &&
-        TEST(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action)) &&
+    if (TESTANY(ASLR_DLL, DYNAMO_OPTION(aslr)) &&
+        TESTANY(ASLR_TRACK_AREAS, DYNAMO_OPTION(aslr_action)) &&
         /* XXX: xref case 10750: could print w/o lock inside a TRY  */
         !conservative) {
         print_file(f, "<print_modules_safe/>\n");
@@ -2530,7 +2530,7 @@ is_module_patch_region(dcontext_t *dcontext, app_pc start, app_pc end, bool cons
             LOG(THREAD, LOG_VMAREAS, 2,
                 "is_module_patch_region: count=%d, flags=0x%x, %s\n", mod->LoadCount,
                 mod->Flags, match_IAT ? "IAT" : "not IAT");
-            if (mod->LoadCount == 0 || TEST(LDR_LOAD_IN_PROGRESS, mod->Flags) ||
+            if (mod->LoadCount == 0 || TESTANY(LDR_LOAD_IN_PROGRESS, mod->Flags) ||
                 /* case 10180: executable itself has unknown flag 0x00004000 set; we
                  * relax to consider it the loader if the lock is held and we are
                  * before the image entry, but only when we track the image entry */
@@ -2782,7 +2782,7 @@ add_SEH_to_rct_table(dcontext_t *dcontext, app_pc module_base)
         /* If it is a chain entry, then walk the chain to get the exception
          * handler.
          */
-        while (TEST(UNW_FLAG_CHAININFO, info->Flags)) {
+        while (TESTANY(UNW_FLAG_CHAININFO, info->Flags)) {
             /* Note that while one page of the specs, and the
              * GetChainedFunctionEntry() macro, say that there is a pointer to a
              * RUNTIME_FUNCTION, another page, and all the instances I've seen, have
@@ -3842,7 +3842,7 @@ module_copy_os_data(os_module_data_t *dst, os_module_data_t *src)
 void
 os_module_area_reset(module_area_t *ma HEAPACCT(which_heap_t which))
 {
-    ASSERT(TEST(MODULE_BEING_UNLOADED, ma->flags));
+    ASSERT(TESTANY(MODULE_BEING_UNLOADED, ma->flags));
 
     /* Modules are always contiguous (xref i#160/PR 562667) */
     module_list_remove_mapping(ma, ma->start, ma->end);
@@ -3946,7 +3946,7 @@ get_module_info_pe(const app_pc module_base, uint *checksum, uint *timestamp,
                 /* Executable sections should be loadable. */
                 DODEBUG({
                     /* PR 214227: we do see INIT sections that are discardable */
-                    if (TEST(IMAGE_SCN_MEM_DISCARDABLE, sec->Characteristics)) {
+                    if (TESTANY(IMAGE_SCN_MEM_DISCARDABLE, sec->Characteristics)) {
                         SYSLOG_INTERNAL_WARNING("found code section that is discardable");
                     }
                 });
@@ -4004,7 +4004,7 @@ os_module_area_init(module_area_t *ma, app_pc base, size_t view_size, bool at_ma
     if (info.product_name != NULL)
         ma->os_data.product_name = dr_wstrdup(info.product_name HEAPACCT(which));
 
-    if (TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
+    if (TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)) &&
         dcontext != NULL && /* if during initialization */
         dcontext->aslr_context.original_section_base != ASLR_INVALID_SECTION_BASE) {
         DEBUG_DECLARE(uint pe_timestamp = timestamp;)
@@ -4670,7 +4670,7 @@ module_reloc_iterator_next(reloc_iterator_t *ri,
              */
             ASSERT_CURIOSITY(
                 skipped == 1 ||
-                TEST(ASLR_PERSISTENT_PARANOID_PREFIX, DYNAMO_OPTION(aslr_validation)));
+                TESTANY(ASLR_PERSISTENT_PARANOID_PREFIX, DYNAMO_OPTION(aslr_validation)));
 
             ri->relocs = ri->relocs + sizeof(ushort);
         } while (ri->relocs < ri->relocs_block_end); /* page block */
@@ -4765,7 +4765,7 @@ module_file_relocatable(app_pc module_base)
 
     sec = IMAGE_FIRST_SECTION(nt_hdr);
     for (i = 0; i < nt_hdr->FileHeader.NumberOfSections; i++, sec++) {
-        if (TEST(IMAGE_SCN_MEM_SHARED, sec->Characteristics)) {
+        if (TESTANY(IMAGE_SCN_MEM_SHARED, sec->Characteristics)) {
             relocatable = false;
         } else {
             /* XXX: probably best is to list all section flags that we
@@ -6342,8 +6342,8 @@ os_module_has_dynamic_base(app_pc module_base)
     IMAGE_NT_HEADERS *nt;
     ASSERT(is_readable_pe_base(module_base));
     nt = NT_HEADER(module_base);
-    return TEST(IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE,
-                nt->OptionalHeader.DllCharacteristics);
+    return TESTANY(IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE,
+                   nt->OptionalHeader.DllCharacteristics);
 }
 
 bool
@@ -6489,7 +6489,7 @@ pe_symbol_import_iterator_read_thunk(pe_symbol_import_iterator_t *iter)
         return false;
     iter->next_symbol.delay_load = false;
     iter->next_symbol.by_ordinal =
-        CAST_TO_bool(TEST(IMAGE_ORDINAL_FLAG, safe_thunk.u1.Function));
+        CAST_TO_bool(TESTANY(IMAGE_ORDINAL_FLAG, safe_thunk.u1.Function));
     if (iter->next_symbol.by_ordinal) {
         iter->next_symbol.ordinal = safe_thunk.u1.AddressOfData & (~IMAGE_ORDINAL_FLAG);
         iter->next_symbol.name = NULL;

--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -781,7 +781,7 @@ ldr_module_statically_linked(LDR_MODULE *mod)
     win8plus = (get_os_version() >= WINDOWS_VERSION_8);
 #    endif
     if (win8plus) {
-        return (mod->LoadCount == -1 || TEST(LDR_PROCESS_STATIC_IMPORT, mod->Flags) ||
+        return (mod->LoadCount == -1 || TESTANY(LDR_PROCESS_STATIC_IMPORT, mod->Flags) ||
                 mod->LoadReason == LoadReasonStaticDependency ||
                 mod->LoadReason == LoadReasonStaticForwarderDependency);
     } else

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -867,7 +867,7 @@ is_thread_exited(HANDLE hthread)
         ASSERT(false && "Not a valid thread handle.");
         return THREAD_EXIT_ERROR;
     }
-    if (!TEST(SYNCHRONIZE, nt_get_handle_access_rights(hthread))) {
+    if (!TESTANY(SYNCHRONIZE, nt_get_handle_access_rights(hthread))) {
         /* Note that our own thread handles will have SYNCHRONIZE since, like
          * THREAD_TERMINATE, that seems to be a right the thread can always get for
          * itself (prob. due to how stacks are freed). So only a potential issue with
@@ -1408,7 +1408,7 @@ get_own_context_integer_control(CONTEXT *cxt, reg_t cs, reg_t ss, priv_mcontext_
 void
 get_own_context(CONTEXT *cxt)
 {
-    if (TEST(CONTEXT_SEGMENTS, cxt->ContextFlags)) {
+    if (TESTANY(CONTEXT_SEGMENTS, cxt->ContextFlags)) {
         get_segments_defg(&cxt->SegDs, &cxt->SegEs, &cxt->SegFs, &cxt->SegGs);
     }
     /* XXX : do we want CONTEXT_DEBUG_REGISTERS or CONTEXT_FLOATING_POINT
@@ -1755,14 +1755,14 @@ tls_alloc_helper(int synch, uint *teb_offs /* OUT */, int num_slots, uint alignm
      * and mark ALL entries inbetween.  Of course we know we can't go
      * beyond index 63 in either request.
      */
-    if (TEST(TLS_FLAG_BITMAP_FILL, tls_flags)) {
+    if (TESTANY(TLS_FLAG_BITMAP_FILL, tls_flags)) {
         int first_to_fill = bitmap_find_free_sequence(
             peb->TlsBitmap->BitMapBuffer, peb->TlsBitmap->SizeOfBitMap, 1, /* single */
             false,                                                         /* bottom up */
             0, 0 /* no alignment */);
         ASSERT_NOT_TESTED();
         /* we only fill from the front - and taking all up to the top isn't nice */
-        ASSERT(!TEST(TLS_FLAG_BITMAP_TOP_DOWN, tls_flags));
+        ASSERT(!TESTANY(TLS_FLAG_BITMAP_TOP_DOWN, tls_flags));
         ASSERT_NOT_IMPLEMENTED(false);
         /* XXX: need to save first slot, so we can free the
          * filled slots on exit */
@@ -1808,14 +1808,14 @@ tls_alloc_helper(int synch, uint *teb_offs /* OUT */, int num_slots, uint alignm
      * bitmap */
     start = bitmap_find_free_sequence(peb->TlsBitmap->BitMapBuffer,
                                       peb->TlsBitmap->SizeOfBitMap, num_slots,
-                                      TEST(TLS_FLAG_BITMAP_TOP_DOWN, tls_flags),
+                                      TESTANY(TLS_FLAG_BITMAP_TOP_DOWN, tls_flags),
                                       0 /* align first element */, alignment);
 
-    if (!TEST(TLS_FLAG_CACHE_LINE_START, tls_flags)) {
+    if (!TESTANY(TLS_FLAG_CACHE_LINE_START, tls_flags)) {
         /* try either way, worthwhile only if we fit into an alignment unit */
         int end_aligned = bitmap_find_free_sequence(
             peb->TlsBitmap->BitMapBuffer, peb->TlsBitmap->SizeOfBitMap, num_slots,
-            TEST(TLS_FLAG_BITMAP_TOP_DOWN, tls_flags),
+            TESTANY(TLS_FLAG_BITMAP_TOP_DOWN, tls_flags),
             /* align the end of last
              * element, so open ended */
             num_slots, alignment);
@@ -1823,7 +1823,7 @@ tls_alloc_helper(int synch, uint *teb_offs /* OUT */, int num_slots, uint alignm
             ASSERT_NOT_TESTED();
             start = end_aligned;
         } else {
-            if (TEST(TLS_FLAG_BITMAP_TOP_DOWN, tls_flags)) {
+            if (TESTANY(TLS_FLAG_BITMAP_TOP_DOWN, tls_flags)) {
                 /* prefer latest start */
                 if (start < end_aligned) {
                     start = end_aligned;
@@ -3128,7 +3128,7 @@ get_sd_pointers(DR_PARAM_IN PISECURITY_DESCRIPTOR SecurityDescriptor,
                 DR_PARAM_OUT PACL *Sacl OPTIONAL, DR_PARAM_OUT PACL *Dacl OPTIONAL)
 {
     /* we usually deal with self-relative SIDs as returned by NtQuerySecurityObject */
-    if (TEST(SE_SELF_RELATIVE, SecurityDescriptor->Control)) {
+    if (TESTANY(SE_SELF_RELATIVE, SecurityDescriptor->Control)) {
         PISECURITY_DESCRIPTOR_RELATIVE RelSD =
             (PISECURITY_DESCRIPTOR_RELATIVE)SecurityDescriptor;
         if (Owner != NULL) {
@@ -3208,7 +3208,7 @@ set_owner_sd(PISECURITY_DESCRIPTOR SecurityDescriptor, PSID Owner)
     if (SecurityDescriptor->Revision != SECURITY_DESCRIPTOR_REVISION1) {
         return false;
     }
-    if (TEST(SE_SELF_RELATIVE, SecurityDescriptor->Control)) {
+    if (TESTANY(SE_SELF_RELATIVE, SecurityDescriptor->Control)) {
         ASSERT(false && "we only create absolute security descriptors");
         return false;
     }
@@ -3495,7 +3495,7 @@ nt_create_file(DR_PARAM_OUT HANDLE *file_handle, const wchar_t *filename,
         return res;
     }
 
-    if (TEST(FILE_DISPOSITION_SET_OWNER, create_disposition)) {
+    if (TESTANY(FILE_DISPOSITION_SET_OWNER, create_disposition)) {
         pSD = set_primary_user_owner(&sd);
         create_disposition &= ~FILE_DISPOSITION_SET_OWNER;
     }

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -1496,8 +1496,8 @@ os_terminate_common(dcontext_t *dcontext, terminate_flags_t terminate_type,
     HANDLE currentThreadOrProcess = NT_CURRENT_PROCESS;
     bool exit_process = true;
 
-    ASSERT(TEST(TERMINATE_PROCESS, terminate_type) != /* xor */
-           TEST(TERMINATE_THREAD, terminate_type));
+    ASSERT(TESTANY(TERMINATE_PROCESS, terminate_type) != /* xor */
+           TESTANY(TERMINATE_THREAD, terminate_type));
 
     /* We could be holding the bb_building_lock at this point -- if we cleanup,
      * we will get a rank order violation with all_threads_synch_lock.  if we
@@ -1520,7 +1520,7 @@ os_terminate_common(dcontext_t *dcontext, terminate_flags_t terminate_type,
              * here though caller has likely alredy gone as deep as detach
              * will since almost everyone SYSLOG's before calling this */
             detach_helper(
-                TEST(DETACH_ON_TERMINATE_NO_CLEAN, DYNAMO_OPTION(internal_detach_mask))
+                TESTANY(DETACH_ON_TERMINATE_NO_CLEAN, DYNAMO_OPTION(internal_detach_mask))
                     ? DETACH_BAD_STATE_NO_CLEANUP
                     : DETACH_BAD_STATE);
             /* skip option synch, make this as safe as possible */
@@ -1547,7 +1547,7 @@ os_terminate_common(dcontext_t *dcontext, terminate_flags_t terminate_type,
     /* CHECK: Can a process disallow PROCESS_TERMINATE or THREAD_TERMINATE
        access even to itself?
     */
-    if (TEST(TERMINATE_THREAD, terminate_type)) {
+    if (TESTANY(TERMINATE_THREAD, terminate_type)) {
         exit_process =
             (!IS_CLIENT_THREAD(dcontext) && is_last_app_thread() && !dynamo_exited);
         if (!exit_process) {
@@ -1556,7 +1556,7 @@ os_terminate_common(dcontext_t *dcontext, terminate_flags_t terminate_type,
     }
 
     STATS_INC(num_threads_killed);
-    if (TEST(TERMINATE_CLEANUP, terminate_type)) {
+    if (TESTANY(TERMINATE_CLEANUP, terminate_type)) {
         byte *arguments =
             os_terminate_static_arguments(exit_process, custom_code, exit_code);
 
@@ -1767,7 +1767,7 @@ os_thread_stack_exit(dcontext_t *dcontext)
                                     true /* own thread_initexit_lock */,
                                     false /* not image */);
         }
-        if (TEST(ASLR_HEAP_FILL, DYNAMO_OPTION(aslr))) {
+        if (TESTANY(ASLR_HEAP_FILL, DYNAMO_OPTION(aslr))) {
             size_t stack_reserved_size = ostd->stack_top - ostd->stack_base;
             /* verified above with get_allocation_size() this is not
              * only the committed portion
@@ -3072,7 +3072,7 @@ prot_is_copyonwrite(uint prot)
 bool
 prot_is_guard(uint prot)
 {
-    return TEST(PAGE_GUARD, prot);
+    return TESTANY(PAGE_GUARD, prot);
 }
 
 /* translate platform independent protection bits to native flags */
@@ -3080,22 +3080,22 @@ int
 memprot_to_osprot(uint prot)
 {
     uint os_prot = 0;
-    if (TEST(MEMPROT_EXEC, prot)) {
-        if (!TEST(MEMPROT_READ, prot)) {
-            ASSERT(!TEST(MEMPROT_WRITE, prot));
+    if (TESTANY(MEMPROT_EXEC, prot)) {
+        if (!TESTANY(MEMPROT_READ, prot)) {
+            ASSERT(!TESTANY(MEMPROT_WRITE, prot));
             os_prot = PAGE_EXECUTE;
-        } else if (TEST(MEMPROT_WRITE, prot))
+        } else if (TESTANY(MEMPROT_WRITE, prot))
             os_prot = PAGE_EXECUTE_READWRITE;
         else
             os_prot = PAGE_EXECUTE_READ;
-    } else if (TEST(MEMPROT_READ, prot)) {
-        if (TEST(MEMPROT_WRITE, prot))
+    } else if (TESTANY(MEMPROT_READ, prot)) {
+        if (TESTANY(MEMPROT_WRITE, prot))
             os_prot = PAGE_READWRITE;
         else
             os_prot = PAGE_READONLY;
     } else
         os_prot = PAGE_NOACCESS;
-    if (TEST(MEMPROT_GUARD, prot))
+    if (TESTANY(MEMPROT_GUARD, prot))
         os_prot |= PAGE_GUARD;
     return os_prot;
 }
@@ -3289,7 +3289,7 @@ should_inject_into_process(dcontext_t *dcontext, HANDLE process_handle,
         inject_setting_mask_t should_inject =
             systemwide_should_inject(process_handle, rununder_mask);
 
-        if (DYNAMO_OPTION(follow_systemwide) && TEST(INJECT_TRUE, should_inject)) {
+        if (DYNAMO_OPTION(follow_systemwide) && TESTANY(INJECT_TRUE, should_inject)) {
             LOG(THREAD, LOG_SYSCALLS | LOG_THREADS, 1,
                 "\tconfigured child should be injected\n");
             inject = true;
@@ -3306,15 +3306,15 @@ should_inject_into_process(dcontext_t *dcontext, HANDLE process_handle,
             inject = true; /* -follow_children defaults to inject */
 
             /* check if child should be excluded from running under dr */
-            if (TEST(INJECT_EXCLUDED, should_inject)) {
+            if (TESTANY(INJECT_EXCLUDED, should_inject)) {
                 LOG(THREAD, LOG_SYSCALLS | LOG_THREADS, 1,
                     "\tchild is excluded, not injecting\n");
                 inject = false;
             }
 
             /* check if we should leave injection to preinjector */
-            if (TEST(INJECT_TRUE, should_inject) && systemwide_inject_enabled() &&
-                !TEST(INJECT_EXPLICIT, should_inject)) {
+            if (TESTANY(INJECT_TRUE, should_inject) && systemwide_inject_enabled() &&
+                !TESTANY(INJECT_EXPLICIT, should_inject)) {
                 ASSERT(!DYNAMO_OPTION(follow_systemwide));
                 LOG(THREAD, LOG_SYSCALLS | LOG_THREADS, 1,
                     "\tletting preinjector inject into child\n");
@@ -3329,7 +3329,7 @@ should_inject_into_process(dcontext_t *dcontext, HANDLE process_handle,
             });
         }
         if (inject) {
-            ASSERT(!TEST(INJECT_EXCLUDED, should_inject));
+            ASSERT(!TESTANY(INJECT_EXCLUDED, should_inject));
             if (inject_settings != NULL)
                 *inject_settings = should_inject;
         }
@@ -3384,7 +3384,7 @@ inject_into_process(dcontext_t *dcontext, HANDLE process_handle, HANDLE thread_h
         /* We got the global key's library, use parent's library instead if the only
          * reason we're injecting is -follow_children (i.e. reading RUNUNDER gave us
          * !INJECT_TRUE). */
-        if (!TEST(INJECT_TRUE, should_inject)) {
+        if (!TESTANY(INJECT_TRUE, should_inject)) {
             ASSERT(DYNAMO_OPTION(follow_children));
             library = get_dynamorio_library_path();
         }
@@ -4011,7 +4011,7 @@ mem_stats_snapshot()
             r_reserve += mbi.RegionSize;
         } else if (mbi.State == MEM_COMMIT) {
             r_commit += mbi.RegionSize;
-            if (TEST(PAGE_GUARD, mbi.Protect)) {
+            if (TESTANY(PAGE_GUARD, mbi.Protect)) {
                 /* if any guard blocks inside region, assume entire region
                  * is a stack
                  */
@@ -4112,7 +4112,7 @@ process_image(app_pc base, size_t size, uint prot, bool add, bool rewalking,
              * this process first (i#817)
              */
             ASSERT_CURIOSITY(is_wow64_process(NT_CURRENT_PROCESS) ||
-                             !TEST(IMAGE_FILE_DLL, get_module_characteristics(base)));
+                             !TESTANY(IMAGE_FILE_DLL, get_module_characteristics(base)));
         }
     });
 #    else
@@ -4172,7 +4172,7 @@ process_image(app_pc base, size_t size, uint prot, bool add, bool rewalking,
         /* XXX: if some one just loads a vm, our gbop would become useless;
          * need better dgc identification for gbop; see case 8087.
          */
-        if (add && TEST(GBOP_IS_DGC, DYNAMO_OPTION(gbop)) && !gbop_vm_loaded) {
+        if (add && TESTANY(GBOP_IS_DGC, DYNAMO_OPTION(gbop)) && !gbop_vm_loaded) {
             /* !gbop_vm_loaded in the check above would prevent this memory
              * protection change from happenning for each vm load, not that any
              * process load a vm multiple times or multiple vms.
@@ -4415,8 +4415,8 @@ process_image_post_vmarea(app_pc base, size_t size, uint prot, bool add, bool re
         return;
     }
 #    ifdef RCT_IND_BRANCH
-    if (TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
-        TEST(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) {
+    if (TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_call)) ||
+        TESTANY(OPTION_ENABLED, DYNAMO_OPTION(rct_ind_jump))) {
         /* we need to know about module addition or removal
          * whether or not we'll act on it right now
          */
@@ -4854,12 +4854,12 @@ os_raw_mem_free(void *p, size_t size, uint flags, heap_error_code_t *error_code)
     ASSERT(error_code != NULL);
     ASSERT(size > 0 && ALIGNED(size, PAGE_SIZE));
 
-    if (!TEST(RAW_ALLOC_RESERVE_ONLY, flags)) {
+    if (!TESTANY(RAW_ALLOC_RESERVE_ONLY, flags)) {
         *error_code = nt_decommit_virtual_memory(p, size);
         if (!NT_SUCCESS(*error_code))
             return false;
     }
-    if (!TEST(RAW_ALLOC_COMMIT_ONLY, flags))
+    if (!TESTANY(RAW_ALLOC_COMMIT_ONLY, flags))
         *error_code = nt_free_virtual_memory(p);
     LOG(GLOBAL, LOG_HEAP, 2, "os_raw_mem_free: " SZFMT " bytes @ " PFX "\n", size, p);
     return NT_SUCCESS(*error_code);
@@ -4878,9 +4878,9 @@ os_raw_mem_alloc(void *preferred, size_t size, uint prot, uint flags,
 
     *error_code = nt_allocate_virtual_memory(
         &p, size, os_prot,
-        TEST(RAW_ALLOC_RESERVE_ONLY, flags)
+        TESTANY(RAW_ALLOC_RESERVE_ONLY, flags)
             ? MEMORY_RESERVE_ONLY
-            : (TEST(RAW_ALLOC_COMMIT_ONLY, flags) ? MEM_COMMIT : MEMORY_COMMIT));
+            : (TESTANY(RAW_ALLOC_COMMIT_ONLY, flags) ? MEM_COMMIT : MEMORY_COMMIT));
     if (!NT_SUCCESS(*error_code)) {
         LOG(GLOBAL, LOG_HEAP, 3, "os_raw_mem_alloc %d bytes failed" PFX "\n", size, p);
         return NULL;
@@ -5263,7 +5263,7 @@ dr_mcontext_to_context(CONTEXT *dst, dr_mcontext_t *src)
      * We want to keep the assert to catch invalid internal uses, so we just
      * fill it all in and then adjust the flags.
      */
-    if (TEST(DR_MC_MULTIMEDIA, src->flags))
+    if (TESTANY(DR_MC_MULTIMEDIA, src->flags))
         dst->ContextFlags = CONTEXT_DR_STATE;
     else
         dst->ContextFlags = CONTEXT_DR_STATE_NO_YMM;
@@ -5274,9 +5274,9 @@ dr_mcontext_to_context(CONTEXT *dst, dr_mcontext_t *src)
     /* XXX: CONTEXT_CONTROL includes xbp, while that's under DR_MC_INTEGER.
      * We document this difference and recommend passing both to avoid problems.
      */
-    if (!TEST(DR_MC_INTEGER, src->flags))
+    if (!TESTANY(DR_MC_INTEGER, src->flags))
         dst->ContextFlags &= ~(CONTEXT_INTEGER);
-    if (!TEST(DR_MC_CONTROL, src->flags))
+    if (!TESTANY(DR_MC_CONTROL, src->flags))
         dst->ContextFlags &= ~(CONTEXT_CONTROL);
 
     return true;
@@ -5286,11 +5286,11 @@ dr_mcontext_to_context(CONTEXT *dst, dr_mcontext_t *src)
 static dr_mcontext_flags_t
 match_mcontext_flags_to_context_flags(dr_mcontext_flags_t mc_flags, DWORD cxt_flags)
 {
-    if (TEST(DR_MC_INTEGER, mc_flags) && !TESTALL(CONTEXT_INTEGER, cxt_flags))
+    if (TESTANY(DR_MC_INTEGER, mc_flags) && !TESTALL(CONTEXT_INTEGER, cxt_flags))
         mc_flags &= ~DR_MC_INTEGER;
-    if (TEST(DR_MC_CONTROL, mc_flags) && !TESTALL(CONTEXT_CONTROL, cxt_flags))
+    if (TESTANY(DR_MC_CONTROL, mc_flags) && !TESTALL(CONTEXT_CONTROL, cxt_flags))
         mc_flags &= ~DR_MC_CONTROL;
-    if (TEST(DR_MC_MULTIMEDIA, mc_flags) &&
+    if (TESTANY(DR_MC_MULTIMEDIA, mc_flags) &&
         !TESTALL(CONTEXT_DR_STATE & ~(CONTEXT_INTEGER | CONTEXT_CONTROL), cxt_flags))
         mc_flags &= ~DR_MC_MULTIMEDIA;
     return mc_flags;
@@ -6017,7 +6017,7 @@ query_is_readable_without_exception(byte *pc, size_t size)
         if (res != sizeof(mbi)) {
             return false;
         } else {
-            if (mbi.State != MEM_COMMIT || TEST(PAGE_GUARD, mbi.Protect) ||
+            if (mbi.State != MEM_COMMIT || TESTANY(PAGE_GUARD, mbi.Protect) ||
                 !prot_is_readable(mbi.Protect))
                 return false;
         }
@@ -6181,7 +6181,7 @@ unmark_page_as_guard(byte *pc, uint prot)
      * while we wanted to remove this protection. The returned value
      * can be checked for such a case.
      */
-    return TEST(PAGE_GUARD, old_prot);
+    return TESTANY(PAGE_GUARD, old_prot);
 }
 
 /* Change page protection for pc:pc+size.
@@ -7049,8 +7049,8 @@ os_copy_file(HANDLE new_file, HANDLE original_file, uint64 new_file_offset,
 bool
 os_create_dir(const char *fname, create_directory_flags_t create_dir_flags)
 {
-    bool require_new = TEST(CREATE_DIR_REQUIRE_NEW, create_dir_flags);
-    bool force_owner = TEST(CREATE_DIR_FORCE_OWNER, create_dir_flags);
+    bool require_new = TESTANY(CREATE_DIR_REQUIRE_NEW, create_dir_flags);
+    bool force_owner = TESTANY(CREATE_DIR_FORCE_OWNER, create_dir_flags);
 
     /* case 9057 note that hard links are only between files but not directories */
     /* upcoming symlinks can be between either, for consistency should
@@ -7073,7 +7073,7 @@ os_open_directory(const char *fname, int os_open_flags)
     uint access = READ_CONTROL;
 
     /* XXX: only 0 is allowed by create_file for now */
-    if (TEST(OS_OPEN_READ, os_open_flags))
+    if (TESTANY(OS_OPEN_READ, os_open_flags))
         access |= FILE_GENERIC_READ;
 
     return os_internal_create_file(fname, true, access, sharing, FILE_OPEN);
@@ -7092,39 +7092,42 @@ os_open(const char *fname, int os_open_flags)
     /* XXX case 8865: should default be no sharing? */
     uint sharing = FILE_SHARE_READ;
 
-    if (TEST(OS_EXECUTE, os_open_flags))
+    if (TESTANY(OS_EXECUTE, os_open_flags))
         access |= FILE_GENERIC_EXECUTE;
-    if (TEST(OS_OPEN_READ, os_open_flags))
+    if (TESTANY(OS_OPEN_READ, os_open_flags))
         access |= FILE_GENERIC_READ;
 
-    if (TEST(OS_SHARE_DELETE, os_open_flags))
+    if (TESTANY(OS_SHARE_DELETE, os_open_flags))
         sharing |= FILE_SHARE_DELETE;
 
-    if (!TEST(OS_OPEN_WRITE, os_open_flags))
+    if (!TESTANY(OS_OPEN_WRITE, os_open_flags))
         return os_internal_create_file(fname, false, access, sharing, FILE_OPEN);
 
     /* We ignore OS_OPEN_WRITE_ONLY: Linux-only */
 
     /* clients are allowed to open the file however they want, xref PR 227737 */
-    ASSERT_CURIOSITY_ONCE((TEST(OS_OPEN_REQUIRE_NEW, os_open_flags) ||
+    ASSERT_CURIOSITY_ONCE((TESTANY(OS_OPEN_REQUIRE_NEW, os_open_flags) ||
                            standalone_library || CLIENTS_EXIST()) &&
                           "symlink risk PR 213492");
 
     return os_internal_create_file(
         fname, false,
         access |
-            (TEST(OS_OPEN_APPEND, os_open_flags) ?
-                                                 /* FILE_GENERIC_WRITE minus
-                                                  * FILE_WRITE_DATA, so we get auto-append
-                                                  */
+            (TESTANY(OS_OPEN_APPEND, os_open_flags)
+                 ?
+                 /* FILE_GENERIC_WRITE minus
+                  * FILE_WRITE_DATA, so we get auto-append
+                  */
                  (STANDARD_RIGHTS_WRITE | FILE_APPEND_DATA | FILE_WRITE_ATTRIBUTES |
                   FILE_WRITE_EA)
-                                                 : FILE_GENERIC_WRITE),
+                 : FILE_GENERIC_WRITE),
         sharing,
-        (TEST(OS_OPEN_REQUIRE_NEW, os_open_flags)
+        (TESTANY(OS_OPEN_REQUIRE_NEW, os_open_flags)
              ? FILE_CREATE
-             : (TEST(OS_OPEN_APPEND, os_open_flags) ? FILE_OPEN_IF : FILE_OVERWRITE_IF)) |
-            (TEST(OS_OPEN_FORCE_OWNER, os_open_flags) ? FILE_DISPOSITION_SET_OWNER : 0));
+             : (TESTANY(OS_OPEN_APPEND, os_open_flags) ? FILE_OPEN_IF
+                                                       : FILE_OVERWRITE_IF)) |
+            (TESTANY(OS_OPEN_FORCE_OWNER, os_open_flags) ? FILE_DISPOSITION_SET_OWNER
+                                                         : 0));
 }
 
 void
@@ -7521,29 +7524,29 @@ os_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc addr, uin
     LARGE_INTEGER li_offs;
     li_offs.QuadPart = offs;
 
-    if (TEST(MAP_FILE_COPY_ON_WRITE, map_flags) && TEST(MEMPROT_WRITE, prot)) {
+    if (TESTANY(MAP_FILE_COPY_ON_WRITE, map_flags) && TESTANY(MEMPROT_WRITE, prot)) {
         /* Ask for COW for both the section and the view, though we should only
          * need it for the view (except on win98, according to Richter p604)
          */
         osprot = osprot_add_writecopy(osprot);
     }
-    res = nt_create_section(&section,
-                            SECTION_ALL_ACCESS, /* XXX: maybe less privileges needed */
-                            NULL, /* full file size, even if partial view map */
-                            osprot,
-                            /* can only be SEC_IMAGE if a PE file */
-                            /* XXX: SEC_RESERVE shouldn't work w/ COW yet
-                             * it did in my test */
-                            TEST(MAP_FILE_IMAGE, map_flags) ? SEC_IMAGE : SEC_COMMIT, f,
-                            /* process private - no security needed */
-                            /* object name attributes */
-                            NULL /* unnamed */, 0, NULL, NULL);
+    res = nt_create_section(
+        &section, SECTION_ALL_ACCESS, /* XXX: maybe less privileges needed */
+        NULL,                         /* full file size, even if partial view map */
+        osprot,
+        /* can only be SEC_IMAGE if a PE file */
+        /* XXX: SEC_RESERVE shouldn't work w/ COW yet
+         * it did in my test */
+        TESTANY(MAP_FILE_IMAGE, map_flags) ? SEC_IMAGE : SEC_COMMIT, f,
+        /* process private - no security needed */
+        /* object name attributes */
+        NULL /* unnamed */, 0, NULL, NULL);
     if (!NT_SUCCESS(res)) {
         LOG(GLOBAL, LOG_NT, 2, "os_map_file: NtCreateSection error " PFX "\n", res);
         return NULL;
     }
 #    ifdef X64
-    if (TEST(MAP_FILE_REACHABLE, map_flags)) {
+    if (TESTANY(MAP_FILE_REACHABLE, map_flags)) {
         loop = true;
         vmcode_get_reachable_region(&region_start, &region_end);
         /* addr need not be NULL: we'll use it if it's in the region */
@@ -7570,7 +7573,7 @@ os_map_file(file_t f, size_t *size DR_PARAM_INOUT, uint64 offs, app_pc addr, uin
         }
         map = NULL; /* pick a new one */
     }
-    if (NT_SUCCESS(res) && TEST(MAP_FILE_REACHABLE, map_flags))
+    if (NT_SUCCESS(res) && TESTANY(MAP_FILE_REACHABLE, map_flags))
         ASSERT(map >= region_start && map + *size <= region_end);
 #    endif
     /* We do not need to keep the section handle open */
@@ -7971,7 +7974,7 @@ os_dump_core_live_dump(const char *msg, char *path DR_PARAM_OUT, size_t path_sz)
         NULL_TERMINATE_BUFFER(dump_core_buf);
         os_write(dmp_file, dump_core_buf, strlen(dump_core_buf));
 
-        if (mbi.State == MEM_COMMIT && !TEST(PAGE_GUARD, mbi.Protect) &&
+        if (mbi.State == MEM_COMMIT && !TESTANY(PAGE_GUARD, mbi.Protect) &&
             prot_is_readable(mbi.Protect)) {
             os_write(dmp_file, mbi.BaseAddress, mbi.RegionSize);
         }
@@ -9570,7 +9573,7 @@ os_check_option_compatibility(void)
     if (!os_has_aslr)
         return false;
 
-    if (TEST(OS_ASLR_DISABLE_PCACHE_ALL, DYNAMO_OPTION(os_aslr))) {
+    if (TESTANY(OS_ASLR_DISABLE_PCACHE_ALL, DYNAMO_OPTION(os_aslr))) {
         /* completely disable pcache */
 
         /* enabled by -desktop, but can be enabled independently as well */
@@ -9592,7 +9595,7 @@ os_check_option_compatibility(void)
 
     /* note dynamorio.dll is not marked as ASLR friendly so we keep
      * using our own -aslr_dr */
-    if (TEST(OS_ASLR_DISABLE_PCACHE_ALL, DYNAMO_OPTION(os_aslr))) {
+    if (TESTANY(OS_ASLR_DISABLE_PCACHE_ALL, DYNAMO_OPTION(os_aslr))) {
         /* completely disable ASLR */
         /* enabled by -client, but can be enabled independently as well */
         if (DYNAMO_OPTION(aslr) != 0) {

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2042,8 +2042,8 @@ presys_SetContextThread(dcontext_t *dcontext, reg_t *param_base)
     if (d_r_get_thread_id() == tid) {
         /* Simple case when called on own thread. */
         /* XXX i#2249 : we should handle these flags. */
-        ASSERT_NOT_IMPLEMENTED(!TEST(CONTEXT_CONTROL, cxt->ContextFlags) &&
-                               !TEST(CONTEXT_DEBUG_REGISTERS, cxt->ContextFlags));
+        ASSERT_NOT_IMPLEMENTED(!TESTANY(CONTEXT_CONTROL, cxt->ContextFlags) &&
+                               !TESTANY(CONTEXT_DEBUG_REGISTERS, cxt->ContextFlags));
         return execute_syscall;
     }
     d_r_mutex_lock(&thread_initexit_lock); /* need lock to lookup thread */
@@ -2116,7 +2116,7 @@ presys_SetContextThread(dcontext_t *dcontext, reg_t *param_base)
          * all synch_with_thread synch points should be, we check here
          */
         ASSERT(!is_couldbelinking(tr->dcontext));
-        if (TEST(THREAD_SET_CONTEXT, nt_get_handle_access_rights(thread_handle))) {
+        if (TESTANY(THREAD_SET_CONTEXT, nt_get_handle_access_rights(thread_handle))) {
             /* Case 10101: a thread waiting at check_wait_at_safe_spot can't
              * be directly setcontext-ed so we explicitly do the context
              * set request here and skip the system call.
@@ -2320,11 +2320,11 @@ presys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, int sysnum
     uint type = (uint)sys_param(dcontext, param_base, 4 + arg_shift);
     uint prot = (uint)sys_param(dcontext, param_base, 5 + arg_shift);
     app_pc base;
-    if (is_phandle_me(process_handle) && TEST(MEM_COMMIT, type) &&
+    if (is_phandle_me(process_handle) && TESTANY(MEM_COMMIT, type) &&
         /* Any overlap when asking for MEM_RESERVE (even when combined w/ MEM_COMMIT)
          * will fail anyway, so we only have to worry about overlap on plain MEM_COMMIT
          */
-        !TEST(MEM_RESERVE, type)) {
+        !TESTANY(MEM_RESERVE, type)) {
         /* i#1175: NtAllocateVirtualMemory can modify prot on existing pages */
         size_t size;
         if (d_r_safe_read(pbase, sizeof(base), &base) &&
@@ -2336,7 +2336,7 @@ presys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, int sysnum
         }
     }
 #ifdef PROGRAM_SHEPHERDING
-    if (is_phandle_me(process_handle) && TEST(MEM_COMMIT, type) &&
+    if (is_phandle_me(process_handle) && TESTANY(MEM_COMMIT, type) &&
         TESTALL(PAGE_EXECUTE_READWRITE, prot)) {
         /* executable_if_alloc policy says we only add a region to the future
          * list if it is committed rwx with no prior reservation.
@@ -2350,14 +2350,15 @@ presys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, int sysnum
          * (unless have try...except)
          */
         if (d_r_safe_read(pbase, sizeof(base), &base)) {
-            dcontext->alloc_no_reserve =
-                (base == NULL ||
-                 (TEST(MEM_RESERVE, type) && !get_memory_info(base, NULL, NULL, NULL)));
+            dcontext->alloc_no_reserve = (base == NULL ||
+                                          (TESTANY(MEM_RESERVE, type) &&
+                                           !get_memory_info(base, NULL, NULL, NULL)));
             /* XXX: can one MEM_RESERVE an address previously
              * MEM_RESERVEd - at least on XP that's not allowed */
         }
-    } else if (TEST(ASLR_STACK, DYNAMO_OPTION(aslr)) && !is_phandle_me(process_handle) &&
-               TEST(MEM_RESERVE, type) && is_newly_created_process(process_handle)) {
+    } else if (TESTANY(ASLR_STACK, DYNAMO_OPTION(aslr)) &&
+               !is_phandle_me(process_handle) && TESTANY(MEM_RESERVE, type) &&
+               is_newly_created_process(process_handle)) {
         /* pre-processing of remote NtAllocateVirtualMemory reservation */
         /* Case 9173: ignore allocations with a requested base.  These may come
          * after we've inserted our pad (is_newly_created_process() isn't
@@ -2512,7 +2513,7 @@ presys_FreeVirtualMemory(dcontext_t *dcontext, reg_t *param_base)
     if (type == MEM_RELEASE) {
         check_for_stack_free(dcontext, base, size);
     }
-    if (type == MEM_RELEASE && TEST(ASLR_HEAP_FILL, DYNAMO_OPTION(aslr))) {
+    if (type == MEM_RELEASE && TESTANY(ASLR_HEAP_FILL, DYNAMO_OPTION(aslr))) {
         /* We free our allocation before the application
          * reservation is released.  Not a critical failure if the
          * application free fails but we have freed our pad.  Also
@@ -3706,16 +3707,16 @@ postsys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool succ
         "syscall: NtAllocateVirtualMemory%s%s%s@" PFX " sz=" PIFX
         " prot=%s 0x%x => 0x%x\n",
         is_phandle_me(process_handle) ? "" : " IPC",
-        TEST(MEM_RESERVE, type) ? " reserve" : "",
-        TEST(MEM_COMMIT, type) ? " commit  " : " ", base, size, prot_string(prot), prot,
-        mc->xax);
+        TESTANY(MEM_RESERVE, type) ? " reserve" : "",
+        TESTANY(MEM_COMMIT, type) ? " commit  " : " ", base, size, prot_string(prot),
+        prot, mc->xax);
     DOLOG(1, LOG_MEMSTATS, {
         /* snapshots are heavyweight, so do rarely */
         if (size > SNAPSHOT_THRESHOLD && is_phandle_me(process_handle))
             mem_stats_snapshot();
     });
 
-    if (TEST(ASLR_HEAP_FILL, DYNAMO_OPTION(aslr)) && is_phandle_me(process_handle)) {
+    if (TESTANY(ASLR_HEAP_FILL, DYNAMO_OPTION(aslr)) && is_phandle_me(process_handle)) {
         /* We allocate our padding after the application region is
          * successfully reserved.  XXX: assuming that one cannot
          * pass MEM_RESERVE|MEM_COMMIT on an already reserved
@@ -3730,7 +3731,7 @@ postsys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool succ
          * after an allocation but that may change.)
          */
 
-        /* XXX: case 6287 we should TEST(MEM_RESERVE, type) if
+        /* XXX: case 6287 we should TESTANY(MEM_RESERVE, type) if
          * allocation has just been reserved, or if pre_syscall
          * base was NULL for a MEM_COMMIT.  Currently a pad is
          * reserved only in case immediate region has not been
@@ -3740,7 +3741,7 @@ postsys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool succ
         aslr_post_process_allocate_virtual_memory(dcontext, base, size);
     }
 
-    if (!TEST(MEM_COMMIT, type)) {
+    if (!TESTANY(MEM_COMMIT, type)) {
         /* MEM_RESERVE only: protection bits are meaningless, we do nothing
          * MEM_RESET: we do not need to flush on a reset, since whatever is there
          * cannot be changed without writing to it!
@@ -3751,11 +3752,11 @@ postsys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool succ
     }
     if (is_phandle_me(process_handle)) {
 #ifdef DGC_DIAGNOSTICS
-        LOG(THREAD, LOG_SYSCALLS | LOG_VMAREAS, TEST(MEM_COMMIT, type) ? 1U : 2U,
+        LOG(THREAD, LOG_SYSCALLS | LOG_VMAREAS, TESTANY(MEM_COMMIT, type) ? 1U : 2U,
             "syscall: NtAllocateVirtualMemory%s%s@" PFX " sz=" PIFX
             " prot=%s 0x%x => 0x%x\n",
-            TEST(MEM_RESERVE, type) ? " reserve" : "",
-            TEST(MEM_COMMIT, type) ? " commit  " : " ", base, size, prot_string(prot),
+            TESTANY(MEM_RESERVE, type) ? " reserve" : "",
+            TESTANY(MEM_COMMIT, type) ? " commit  " : " ", base, size, prot_string(prot),
             prot, mc->xax);
         DOLOG(1, LOG_VMAREAS, {
             dump_callstack(POST_SYSCALL_PC(dcontext), (app_pc)mc->xbp, THREAD,
@@ -3873,8 +3874,8 @@ postsys_QueryVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool success
                     LOG(THREAD, LOG_SYSCALLS | LOG_VMAREAS, 1,
                         "WARNING: QueryVM to DR DLL " PFX ", pretending not a dll\n",
                         base);
-                    if (TEST(HIDE_FROM_QUERY_TYPE_PROTECT,
-                             DYNAMO_OPTION(hide_from_query))) {
+                    if (TESTANY(HIDE_FROM_QUERY_TYPE_PROTECT,
+                                DYNAMO_OPTION(hide_from_query))) {
                         mbi->Type = MEM_PRIVATE; /* not image! */
                         mbi->Protect = PAGE_NOACCESS;
                     }
@@ -3883,7 +3884,8 @@ postsys_QueryVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool success
                      * XXX: app could still use a snapshot to get list
                      * of modules, but that is covered by -hide
                      */
-                    if (TEST(HIDE_FROM_QUERY_BASE_SIZE, DYNAMO_OPTION(hide_from_query))) {
+                    if (TESTANY(HIDE_FROM_QUERY_BASE_SIZE,
+                                DYNAMO_OPTION(hide_from_query))) {
                         mbi->AllocationBase = ((app_pc)mbi->AllocationBase) + PAGE_SIZE;
                         mbi->BaseAddress = ((app_pc)mbi->BaseAddress) + PAGE_SIZE;
                         /* skip over the other regions in our dll -- ok to
@@ -3895,8 +3897,8 @@ postsys_QueryVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool success
                     }
                     /* note that returning STATUS_INVALID_ADDRESS is too
                      * extreme of a solution, so this is off by default */
-                    if (TEST(HIDE_FROM_QUERY_RETURN_INVALID,
-                             DYNAMO_OPTION(hide_from_query))) {
+                    if (TESTANY(HIDE_FROM_QUERY_RETURN_INVALID,
+                                DYNAMO_OPTION(hide_from_query))) {
                         /* XXX: SET_RETURN_VAL bug 5068 had return val as 0
                          * Need to re-test this with this actual return val
                          */
@@ -4020,10 +4022,10 @@ postsys_CreateSection(dcontext_t *dcontext, reg_t *param_base, bool success)
         return;
 
     postsys_create_or_open_section(dcontext, unsafe_section_handle, file_handle,
-                                   !TEST(SEC_IMAGE, attributes));
+                                   !TESTANY(SEC_IMAGE, attributes));
 
-    if (TEST(ASLR_DLL, DYNAMO_OPTION(aslr))) {
-        if (TEST(SEC_IMAGE, attributes)) {
+    if (TESTANY(ASLR_DLL, DYNAMO_OPTION(aslr))) {
+        if (TESTANY(SEC_IMAGE, attributes)) {
             if (aslr_post_process_create_or_open_section(dcontext, true, /* create */
                                                          file_handle,
                                                          unsafe_section_handle)) {
@@ -4065,8 +4067,8 @@ postsys_OpenSection(dcontext_t *dcontext, reg_t *param_base, bool success)
      * call aslr_recreate_known_dll_file() at all?
      */
     if ((DYNAMO_OPTION(track_module_filenames) ||
-         (TEST(ASLR_DLL, DYNAMO_OPTION(aslr)) &&
-          TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)))) &&
+         (TESTANY(ASLR_DLL, DYNAMO_OPTION(aslr)) &&
+          TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache)))) &&
         obj_attr != NULL) {
         /* need to identify KnownDlls here */
         /* XXX: NtOpenSection doesn't give us section attributes,
@@ -4093,8 +4095,8 @@ postsys_OpenSection(dcontext_t *dcontext, reg_t *param_base, bool success)
                     "syscall: NtOpenSection: unable to recreate file handle\n");
             }
 
-            if (TEST(ASLR_DLL, DYNAMO_OPTION(aslr)) &&
-                TEST(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache))) {
+            if (TESTANY(ASLR_DLL, DYNAMO_OPTION(aslr)) &&
+                TESTANY(ASLR_SHARED_CONTENTS, DYNAMO_OPTION(aslr_cache))) {
                 if (aslr_post_process_create_or_open_section(dcontext, false, /* open */
                                                              /* recreated file */
                                                              new_file_handle,

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2025 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -389,7 +389,7 @@ drbbdup_ilist_has_unending_emulation(instrlist_t *bb)
     for (instr_t *inst = instrlist_first(bb); inst != NULL; inst = instr_get_next(inst)) {
         if (drmgr_is_emulation_start(inst) &&
             drmgr_get_emulated_instr_data(inst, &emul_info) &&
-            TEST(DR_EMULATE_REST_OF_BLOCK, emul_info.flags))
+            TESTANY(DR_EMULATE_REST_OF_BLOCK, emul_info.flags))
             return true;
     }
     return false;

--- a/ext/drcontainers/hashtable.c
+++ b/ext/drcontainers/hashtable.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -621,9 +621,9 @@ hashtable_persist_size(void *drcontext, hashtable_t *table, size_t entry_size,
         for (i = 0; i < HASHTABLE_SIZE(table->table_bits); i++) {
             hash_entry_t *he;
             for (he = table->table[i]; he != NULL; he = he->next) {
-                if ((!TEST(DR_HASHPERS_ONLY_IN_RANGE, flags) ||
+                if ((!TESTANY(DR_HASHPERS_ONLY_IN_RANGE, flags) ||
                      key_in_range(table, he, start, size)) &&
-                    (!TEST(DR_HASHPERS_ONLY_PERSISTED, flags) ||
+                    (!TESTANY(DR_HASHPERS_ONLY_PERSISTED, flags) ||
                      dr_fragment_persistable(drcontext, perscxt, he->key)))
                     count++;
             }
@@ -637,7 +637,7 @@ hashtable_persist_size(void *drcontext, hashtable_t *table, size_t entry_size,
      */
     table->persist_count = count;
     return sizeof(count) +
-        (TEST(DR_HASHPERS_REBASE_KEY, flags) ? sizeof(ptr_uint_t) : 0) +
+        (TESTANY(DR_HASHPERS_REBASE_KEY, flags) ? sizeof(ptr_uint_t) : 0) +
         count * (entry_size + sizeof(void *));
 }
 
@@ -649,7 +649,7 @@ hashtable_persist(void *drcontext, hashtable_t *table, size_t entry_size, file_t
     ptr_uint_t start = 0;
     size_t size = 0;
     IF_DEBUG(uint count_check = 0;)
-    if (TEST(DR_HASHPERS_REBASE_KEY, flags) && perscxt == NULL)
+    if (TESTANY(DR_HASHPERS_REBASE_KEY, flags) && perscxt == NULL)
         return false; /* invalid params */
     if (perscxt != NULL) {
         start = (ptr_uint_t)dr_persist_start(perscxt);
@@ -657,7 +657,7 @@ hashtable_persist(void *drcontext, hashtable_t *table, size_t entry_size, file_t
     }
     if (!hash_write_file(fd, &table->persist_count, sizeof(table->persist_count)))
         return false;
-    if (TEST(DR_HASHPERS_REBASE_KEY, flags)) {
+    if (TESTANY(DR_HASHPERS_REBASE_KEY, flags)) {
         if (!hash_write_file(fd, &start, sizeof(start)))
             return false;
     }
@@ -665,14 +665,14 @@ hashtable_persist(void *drcontext, hashtable_t *table, size_t entry_size, file_t
     for (i = 0; i < HASHTABLE_SIZE(table->table_bits); i++) {
         hash_entry_t *he;
         for (he = table->table[i]; he != NULL; he = he->next) {
-            if ((!TEST(DR_HASHPERS_ONLY_IN_RANGE, flags) ||
+            if ((!TESTANY(DR_HASHPERS_ONLY_IN_RANGE, flags) ||
                  key_in_range(table, he, start, size)) &&
-                (!TEST(DR_HASHPERS_ONLY_PERSISTED, flags) ||
+                (!TESTANY(DR_HASHPERS_ONLY_PERSISTED, flags) ||
                  dr_fragment_persistable(drcontext, perscxt, he->key))) {
                 IF_DEBUG(count_check++;)
                 if (!hash_write_file(fd, &he->key, sizeof(he->key)))
                     return false;
-                if (TEST(DR_HASHPERS_PAYLOAD_IS_POINTER, flags)) {
+                if (TESTANY(DR_HASHPERS_PAYLOAD_IS_POINTER, flags)) {
                     if (!hash_write_file(fd, he->payload, entry_size))
                         return false;
                 } else {
@@ -701,7 +701,7 @@ hashtable_resurrect(void *drcontext, byte **map DR_PARAM_INOUT, hashtable_t *tab
     ptr_int_t shift_amt = 0;
     uint count = *(uint *)(*map);
     *map += sizeof(count);
-    if (TEST(DR_HASHPERS_REBASE_KEY, flags)) {
+    if (TESTANY(DR_HASHPERS_REBASE_KEY, flags)) {
         if (perscxt == NULL)
             return false; /* invalid parameter */
         stored_start = *(ptr_uint_t *)(*map);
@@ -714,9 +714,9 @@ hashtable_resurrect(void *drcontext, byte **map DR_PARAM_INOUT, hashtable_t *tab
         *map += sizeof(key);
         inmap = (void *)*map;
         *map += entry_size;
-        if (TEST(DR_HASHPERS_PAYLOAD_IS_POINTER, flags)) {
+        if (TESTANY(DR_HASHPERS_PAYLOAD_IS_POINTER, flags)) {
             toadd = inmap;
-            if (TEST(DR_HASHPERS_CLONE_PAYLOAD, flags)) {
+            if (TESTANY(DR_HASHPERS_CLONE_PAYLOAD, flags)) {
                 void *inheap = hash_alloc(entry_size);
                 memcpy(inheap, inmap, entry_size);
                 toadd = inheap;
@@ -725,7 +725,7 @@ hashtable_resurrect(void *drcontext, byte **map DR_PARAM_INOUT, hashtable_t *tab
             toadd = NULL;
             memcpy(&toadd, inmap, entry_size);
         }
-        if (TEST(DR_HASHPERS_REBASE_KEY, flags)) {
+        if (TESTANY(DR_HASHPERS_REBASE_KEY, flags)) {
             key = (void *)(((ptr_int_t)key) + shift_amt);
         }
         if (process_payload != NULL) {

--- a/ext/drcovlib/drcovlib.c
+++ b/ext/drcovlib/drcovlib.c
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -149,7 +149,7 @@ bb_table_print(void *drcontext, per_thread_t *data)
            "block count exceeds 32-bit max");
     dr_fprintf(data->log, "BB Table: %u bbs\n",
                (uint)drtable_num_entries(data->bb_table));
-    if (TEST(DRCOVLIB_DUMP_AS_TEXT, options.flags)) {
+    if (TESTANY(DRCOVLIB_DUMP_AS_TEXT, options.flags)) {
         dr_fprintf(data->log, "module id, start, size:\n");
         drtable_iterate(data->bb_table, data, bb_table_entry_print);
     } else
@@ -558,7 +558,7 @@ drcovlib_init(drcovlib_options_t *ops)
         return DRCOVLIB_ERROR_INVALID_PARAMETER;
     if ((ops->flags & (~(DRCOVLIB_DUMP_AS_TEXT | DRCOVLIB_THREAD_PRIVATE))) != 0)
         return DRCOVLIB_ERROR_INVALID_PARAMETER;
-    if (TEST(DRCOVLIB_THREAD_PRIVATE, ops->flags)) {
+    if (TESTANY(DRCOVLIB_THREAD_PRIVATE, ops->flags)) {
         if (!dr_using_all_private_caches())
             return DRCOVLIB_ERROR_INVALID_SETUP;
         drcov_per_thread = true;

--- a/ext/drmf/common/utils.c
+++ b/ext/drmf/common/utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -167,7 +167,7 @@ lookup_has_fast_search(const module_data_t *mod)
 {
     drsym_debug_kind_t kind;
     drsym_error_t res = drsym_get_module_debug_kind(mod->full_path, &kind);
-    return res == DRSYM_SUCCESS && TEST(DRSYM_PDB, kind);
+    return res == DRSYM_SUCCESS && TESTANY(DRSYM_PDB, kind);
 }
 
 /* default cb used when we want first match */

--- a/ext/drmf/common/utils.h
+++ b/ext/drmf/common/utils.h
@@ -181,8 +181,7 @@ extern "C" {
 #endif
 
 #ifndef TESTANY
-#    define TEST(mask, var) (((mask) & (var)) != 0)
-#    define TESTANY TEST
+#    define TESTANY(mask, var) (((mask) & (var)) != 0)
 #    define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #    define TESTONE(mask, var) test_one_bit_set((mask) & (var))
 #endif

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2025 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -1090,7 +1090,7 @@ drmgr_bb_event_do_instrum_phases(void *drcontext, void *tag, instrlist_t *bb,
         if (pt->in_emulation_region) {
             pt->emulation_info.flags &= ~DR_EMULATE_IS_FIRST_INSTR;
             if (drmgr_is_emulation_end(inst) ||
-                (TEST(DR_EMULATE_REST_OF_BLOCK, pt->emulation_info.flags) &&
+                (TESTANY(DR_EMULATE_REST_OF_BLOCK, pt->emulation_info.flags) &&
                  drmgr_is_last_instr(drcontext, inst)))
                 pt->in_emulation_region = false;
         }
@@ -3733,7 +3733,7 @@ drmgr_orig_app_instr_for_fetch(void *drcontext)
         return NULL;
     const emulated_instr_t *emulation;
     if (drmgr_in_emulation_region(drcontext, &emulation)) {
-        if (TEST(DR_EMULATE_IS_FIRST_INSTR, emulation->flags)) {
+        if (TESTANY(DR_EMULATE_IS_FIRST_INSTR, emulation->flags)) {
             return emulation->instr;
         } // Else skip further instr fetches until outside emulation region.
     } else if (instr_is_app(pt->insertion_instr)) {
@@ -3751,11 +3751,11 @@ drmgr_orig_app_instr_for_operands(void *drcontext)
         return NULL;
     const emulated_instr_t *emulation;
     if (drmgr_in_emulation_region(drcontext, &emulation)) {
-        if (TEST(DR_EMULATE_IS_FIRST_INSTR, emulation->flags) &&
-            !TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+        if (TESTANY(DR_EMULATE_IS_FIRST_INSTR, emulation->flags) &&
+            !TESTANY(DR_EMULATE_INSTR_ONLY, emulation->flags))
             return emulation->instr;
         if (instr_is_app(pt->insertion_instr) &&
-            TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+            TESTANY(DR_EMULATE_INSTR_ONLY, emulation->flags))
             return pt->insertion_instr;
     } else if (instr_is_app(pt->insertion_instr)) {
         return pt->insertion_instr;

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -195,7 +195,7 @@ static bool
 has_pending_slot_usage_by_prior_pass(void *drcontext, per_thread_t *pt,
                                      instrlist_t *ilist, instr_t *where, uint slot)
 {
-    if (!TEST(DRREG_HANDLE_MULTI_PHASE_SLOT_RESERVATIONS, pt->bb_props))
+    if (!TESTANY(DRREG_HANDLE_MULTI_PHASE_SLOT_RESERVATIONS, pt->bb_props))
         return false;
     for (instr_t *in = where; in != NULL; in = instr_get_next(in)) {
         uint used_slot;
@@ -542,8 +542,8 @@ drreg_insert_restore_all(void *drcontext, instrlist_t *bb, instr_t *inst,
                 /* i#1954: for complex bbs we must restore before the next app instr */
                 (!pt->reg[GPR_IDX(reg)].in_use &&
                  ((pt->bb_has_internal_flow &&
-                   !TEST(DRREG_IGNORE_CONTROL_FLOW, pt->bb_props)) ||
-                  TEST(DRREG_CONTAINS_SPANNING_CONTROL_FLOW, pt->bb_props))) ||
+                   !TESTANY(DRREG_IGNORE_CONTROL_FLOW, pt->bb_props)) ||
+                  TESTANY(DRREG_CONTAINS_SPANNING_CONTROL_FLOW, pt->bb_props))) ||
                 /* If we're out of our own slots and are using a DR slot, we have to
                  * restore now b/c DR slots are not guaranteed across app instrs.
                  */
@@ -742,7 +742,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
      * like an app instr.
      */
     bool do_last_spill = drmgr_is_last_instr(drcontext, inst) &&
-        !TEST(DRREG_USER_RESTORES_AT_BB_END, pt->bb_props);
+        !TESTANY(DRREG_USER_RESTORES_AT_BB_END, pt->bb_props);
     res = drreg_insert_restore_all(drcontext, bb, inst, do_last_spill, restored_for_read);
     if (res != DRREG_SUCCESS)
         drreg_report_error(res, "failed to restore for reads");
@@ -800,8 +800,8 @@ drreg_event_clean_call_insertion(void *drcontext, instrlist_t *ilist, instr_t *w
     }
     bool restored_for_read[DR_NUM_GPR_REGS];
     drreg_status_t res;
-    if (TEST(DR_CLEANCALL_READS_APP_CONTEXT, call_flags)) {
-        if (TEST(DR_CLEANCALL_MULTIPATH, call_flags)) {
+    if (TESTANY(DR_CLEANCALL_READS_APP_CONTEXT, call_flags)) {
+        if (TESTANY(DR_CLEANCALL_MULTIPATH, call_flags)) {
             LOG(drcontext, DR_LOG_ALL, 3,
                 "%s: restoring statelessly for cleancall to read app regs\n",
                 __FUNCTION__);
@@ -816,8 +816,8 @@ drreg_event_clean_call_insertion(void *drcontext, instrlist_t *ilist, instr_t *w
         if (res != DRREG_SUCCESS)
             drreg_report_error(res, "failed to restore for clean call");
     }
-    if (TEST(DR_CLEANCALL_WRITES_APP_CONTEXT, call_flags)) {
-        if (TEST(DR_CLEANCALL_MULTIPATH, call_flags)) {
+    if (TESTANY(DR_CLEANCALL_WRITES_APP_CONTEXT, call_flags)) {
+        if (TESTANY(DR_CLEANCALL_MULTIPATH, call_flags)) {
             /* We do not support this, partly b/c it is rare and complex.
              * We would need some kind of stateless re-spill.
              */
@@ -1614,7 +1614,7 @@ drreg_spill_aflags(void *drcontext, instrlist_t *ilist, instr_t *where, per_thre
         ASSERT(pt->slot_use[xax_slot] == DR_REG_XAX, "slot should be for xax");
     }
     PRE(ilist, where, INSTR_CREATE_lahf(drcontext));
-    if (TEST(EFLAGS_READ_OF, aflags)) {
+    if (TESTANY(EFLAGS_READ_OF, aflags)) {
         PRE(ilist, where,
             INSTR_CREATE_setcc(drcontext, OP_seto, opnd_create_reg(DR_REG_AL)));
     }
@@ -1702,7 +1702,7 @@ drreg_restore_aflags(void *drcontext, instrlist_t *ilist, instr_t *where,
         ASSERT(pt->aflags.slot != MAX_SPILLS, "Aflags slot not reserved");
         restore_reg(drcontext, pt, DR_REG_XAX, pt->aflags.slot, ilist, where, release);
     }
-    if (TEST(EFLAGS_READ_OF, aflags)) {
+    if (TESTANY(EFLAGS_READ_OF, aflags)) {
         /* i#2351: DR's "add 0x7f, %al" is destructive.  Instead we use a
          * cmp so we can avoid messing up the value in al, which is
          * required for keeping the flags in xax.

--- a/ext/drstatecmp/drstatecmp.c
+++ b/ext/drstatecmp/drstatecmp.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2025 Google, Inc.   All rights reserved.
+ * Copyright (c) 2021-2026 Google, Inc.   All rights reserved.
  * **********************************************************/
 /*
  * Redistribution and use in source and binary forms, with or without
@@ -258,7 +258,7 @@ drstatecmp_analyze_phase(void *drcontext, void *tag, instrlist_t *bb, bool for_t
         if (drmgr_is_emulation_start(inst)) {
             emulated_instr_t emulated_inst;
             drmgr_get_emulated_instr_data(inst, &emulated_inst);
-            if (!TEST(DR_EMULATE_INSTR_ONLY, emulated_inst.flags)) {
+            if (!TESTANY(DR_EMULATE_INSTR_ONLY, emulated_inst.flags)) {
                 /* Emulation sequence required for re-execution and golden bb copy should
                  * be the post-app2app copy.
                  */
@@ -530,7 +530,7 @@ drstatecmp_check_machine_state(dr_mcontext_t *mc_instrumented, dr_mcontext_t *mc
     drstatecmp_check_gpr_value("r15", tag, mc_instrumented->r15, mc_expected->r15);
 #    endif
 
-    if (!TEST(DRSTATECMP_SKIP_CHECK_AFLAGS, flags)) {
+    if (!TESTANY(DRSTATECMP_SKIP_CHECK_AFLAGS, flags)) {
         drstatecmp_check_gpr_value("xflags", tag, mc_instrumented->xflags,
                                    mc_expected->xflags);
     }
@@ -574,7 +574,7 @@ drstatecmp_check_machine_state(dr_mcontext_t *mc_instrumented, dr_mcontext_t *mc
     drstatecmp_check_gpr_value("r29", tag, mc_instrumented->r29, mc_expected->r29);
 #    endif
 
-    if (!TEST(DRSTATECMP_SKIP_CHECK_LR, flags))
+    if (!TESTANY(DRSTATECMP_SKIP_CHECK_LR, flags))
         drstatecmp_check_gpr_value("lr", tag, mc_instrumented->lr, mc_expected->lr);
 
     drstatecmp_check_xflags_value("xflags", tag, mc_instrumented->xflags,

--- a/ext/drsyms/drsyms_pecoff.c
+++ b/ext/drsyms/drsyms_pecoff.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -215,7 +215,7 @@ drsym_obj_mod_init_pre(byte *map_base, size_t map_size)
      * with the current code setup.
      */
     if (is_mingw &&
-        TEST(IMAGE_FILE_LOCAL_SYMS_STRIPPED, nt->FileHeader.Characteristics) &&
+        TESTANY(IMAGE_FILE_LOCAL_SYMS_STRIPPED, nt->FileHeader.Characteristics) &&
         mod->symbol_count == 0) {
         mod->exports_only = true;
         NOTIFY(1, "%s: no pecoff symbols and likely no pdb, so using exports\n",

--- a/ext/drsyms/drsyms_unix_common.c
+++ b/ext/drsyms/drsyms_unix_common.c
@@ -213,7 +213,7 @@ load_module(const char *modpath)
             }
         }
 #endif
-        if (TEST(DRSYM_DWARF_LINE, mod->debug_kind) &&
+        if (TESTANY(DRSYM_DWARF_LINE, mod->debug_kind) &&
             drsym_obj_dwarf_init(mod->obj_info, &dbg)) {
             mod->dwarf_info = drsym_dwarf_init(dbg);
         } else {
@@ -449,7 +449,7 @@ addrsearch_symtab(dbg_module_t *mod, size_t modoffs, drsym_info_t *info DR_PARAM
     if (symbol == NULL)
         return DRSYM_ERROR;
 
-    if (TEST(DRSYM_DEMANGLE, flags) && info->name != NULL) {
+    if (TESTANY(DRSYM_DEMANGLE, flags) && info->name != NULL) {
         name_len = drsym_demangle_symbol(info->name, info->name_size, symbol, flags);
     }
     if (name_len == 0) {
@@ -647,7 +647,7 @@ drsym_unix_lookup_symbol(void *mod_in, const char *symbol, size_t *modoffs DR_PA
 
     *modoffs = 0;
 
-    if (!TEST(DRSYM_SYMBOLS, mod->debug_kind)) {
+    if (!TESTANY(DRSYM_SYMBOLS, mod->debug_kind)) {
         /* XXX i#883: we have no symbols and we're just looking at exports so we
          * should do a fast hashtable lookup instead of a linear walk.
          * DR already has the code for this, accessible via dr_get_proc_address(),
@@ -744,7 +744,7 @@ size_t
 drsym_unix_demangle_symbol(char *dst DR_PARAM_OUT, size_t dst_sz, const char *mangled,
                            uint flags)
 {
-    if (!TEST(DRSYM_DEMANGLE_FULL, flags)) {
+    if (!TESTANY(DRSYM_DEMANGLE_FULL, flags)) {
         /* The demangle.cc implementation is fast and replaces template args
          * with <> and omits parameters.  Use it if the user doesn't
          * want either of those.  Its return value always follows our

--- a/ext/drsyms/drsyms_unix_frontend.c
+++ b/ext/drsyms/drsyms_unix_frontend.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -342,7 +342,7 @@ drsym_module_has_symbols(const char *modpath)
 {
     drsym_debug_kind_t kind;
     drsym_error_t r = drsym_get_module_debug_kind(modpath, &kind);
-    if (r == DRSYM_SUCCESS && !TEST(DRSYM_SYMBOLS, kind))
+    if (r == DRSYM_SUCCESS && !TESTANY(DRSYM_SYMBOLS, kind))
         r = DRSYM_ERROR;
     return r;
 }

--- a/ext/drsyms/drsyms_windows.c
+++ b/ext/drsyms/drsyms_windows.c
@@ -923,7 +923,7 @@ drsym_search_symbols_local(const char *modpath, const char *match, uint flags,
         info.base = mod->u.load_base;
         if (!(*func)(GetCurrentProcess(), mod->u.load_base, 0, 0, match, 0, enum_cb,
                      (PVOID)&info,
-                     TEST(DRSYM_FULL_SEARCH, flags) ? SYMSEARCH_ALLITEMS : 0)) {
+                     TESTANY(DRSYM_FULL_SEARCH, flags) ? SYMSEARCH_ALLITEMS : 0)) {
             NOTIFY("SymSearch error %d\n", GetLastError());
             res = DRSYM_ERROR_SYMBOL_NOT_FOUND;
         }
@@ -943,7 +943,7 @@ demangle_symbol(char *dst DR_PARAM_OUT, size_t dst_sz, const char *mangled, uint
     DWORD undec_flags;
     size_t len;
 
-    if (TEST(DRSYM_DEMANGLE_FULL, flags)) {
+    if (TESTANY(DRSYM_DEMANGLE_FULL, flags)) {
         /* XXX: I'd like to suppress "class" from the types, but I can't find
          * an option to control it other than UNDNAME_NAME_ONLY, which
          * suppresses overloads, which we want.
@@ -1815,7 +1815,7 @@ drsym_module_has_symbols(const char *modpath)
 
         /* fall back to slower lookup */
         r = drsym_get_module_debug_kind(modpath, &kind);
-        if (r == DRSYM_SUCCESS && !TEST(DRSYM_SYMBOLS, kind))
+        if (r == DRSYM_SUCCESS && !TESTANY(DRSYM_SYMBOLS, kind))
             r = DRSYM_ERROR;
         return r;
     }

--- a/ext/drsyscall/drsyscall.c
+++ b/ext/drsyscall/drsyscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -343,7 +343,7 @@ drsys_syscall_is_known(drsys_syscall_t *syscall, bool *known DR_PARAM_OUT)
     syscall_info_t *sysinfo = (syscall_info_t *)syscall;
     if (syscall == NULL || known == NULL)
         return DRMF_ERROR_INVALID_PARAMETER;
-    *known = TEST(SYSINFO_ALL_PARAMS_KNOWN, sysinfo->flags);
+    *known = TESTANY(SYSINFO_ALL_PARAMS_KNOWN, sysinfo->flags);
     return DRMF_SUCCESS;
 }
 
@@ -678,7 +678,7 @@ get_syscall_result(syscall_info_t *sysinfo, cls_syscall_t *pt, DR_PARAM_OUT bool
         *value = mc->IF_X86_ELSE(rax, r0); /*r0 for AARCH64*/
 #else
         /* yes, reg_t is unsigned so we have no sign-extension here */
-        if (TEST(SYSINFO_RET_64BIT, sysinfo->flags)) {
+        if (TESTANY(SYSINFO_RET_64BIT, sysinfo->flags)) {
             *value = (uint64)mc->IF_ARM_ELSE(r0, eax) |
                 ((uint64)mc->IF_ARM_ELSE(r1, edx) << 32);
         } else
@@ -822,7 +822,7 @@ report_memarg_ex(sysarg_iter_info_t *ii, int ordinal, drsys_param_mode_t mode, a
     /* Support making handler code simpler by allowing them to invoke us
      * w/o conditionals on whether it's an IN param and this is post-syscall.
      */
-    if (!ii->pt->pre && !TEST(DRSYS_PARAM_OUT, mode))
+    if (!ii->pt->pre && !TESTANY(DRSYS_PARAM_OUT, mode))
         return true;
 
     arg->type = type;
@@ -854,11 +854,11 @@ drsys_param_mode_t
 mode_from_flags(uint arg_flags)
 {
     drsys_param_mode_t mode = 0;
-    if (TEST(SYSARG_WRITE, arg_flags))
+    if (TESTANY(SYSARG_WRITE, arg_flags))
         mode |= DRSYS_PARAM_OUT;
     if (TESTANY(SYSARG_READ | SYSARG_INLINED, arg_flags))
         mode |= DRSYS_PARAM_IN;
-    if (TEST(SYSARG_INLINED, arg_flags))
+    if (TESTANY(SYSARG_INLINED, arg_flags))
         mode |= DRSYS_PARAM_INLINED;
     return mode;
 }
@@ -1059,7 +1059,7 @@ handle_cstring(sysarg_iter_info_t *ii, int ordinal, uint arg_flags, const char *
     size_t maxsz = (size == 0) ? (MAX_PATH * sizeof(char)) : size;
     if (start == NULL)
         return false; /* nothing to do */
-    if (ii->arg->pre && !TEST(SYSARG_READ, arg_flags)) {
+    if (ii->arg->pre && !TESTANY(SYSARG_READ, arg_flags)) {
         if (!check_addr)
             return false;
         if (size > 0) {
@@ -1069,7 +1069,7 @@ handle_cstring(sysarg_iter_info_t *ii, int ordinal, uint arg_flags, const char *
             return true;
         }
     }
-    if (!ii->arg->pre && !TEST(SYSARG_WRITE, arg_flags))
+    if (!ii->arg->pre && !TESTANY(SYSARG_WRITE, arg_flags))
         return false; /*nothing to do */
     for (i = 0; i < maxsz; i += sizeof(char)) {
         if (safe != NULL)
@@ -1119,9 +1119,9 @@ handle_sockaddr(cls_syscall_t *pt, sysarg_iter_info_t *ii, byte *ptr, size_t soc
     /* If not enough space kernel writes space needed, so we need to adjust
      * to the passed-in size by storing it in pre-syscall.
      */
-    if (pt->first_iter && ii->arg->pre && TEST(SYSARG_WRITE, arg_flags)) {
+    if (pt->first_iter && ii->arg->pre && TESTANY(SYSARG_WRITE, arg_flags)) {
         store_extra_info(pt, EXTRA_INFO_SOCKADDR, socklen);
-    } else if (!ii->arg->pre && TEST(SYSARG_WRITE, arg_flags)) {
+    } else if (!ii->arg->pre && TESTANY(SYSARG_WRITE, arg_flags)) {
         size_t pre_len = (size_t)read_extra_info(pt, EXTRA_INFO_SOCKADDR);
         if (socklen > pre_len)
             socklen = pre_len;
@@ -1133,7 +1133,7 @@ handle_sockaddr(cls_syscall_t *pt, sysarg_iter_info_t *ii, byte *ptr, size_t soc
      * with specified capacity above) and it seems to fill in solidly
      * w/ no gaps, so on a write we do not walk the individual fields.
      */
-    if (TEST(SYSARG_WRITE, arg_flags)) {
+    if (TESTANY(SYSARG_WRITE, arg_flags)) {
         if (!report_memarg_type(ii, ordinal, arg_flags, ptr, socklen, id,
                                 DRSYS_TYPE_SOCKADDR, NULL))
             return true;
@@ -1251,7 +1251,7 @@ sysarg_get_size(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii,
 {
     ptr_uint_t size = 0;
     sysinfo_arg_t *arg = &sysinfo->arg[argnum];
-    if (arg->size == 0 && TEST(SYSARG_COMPLEX_TYPE, arg->flags) &&
+    if (arg->size == 0 && TESTANY(SYSARG_COMPLEX_TYPE, arg->flags) &&
         arg->misc == SYSARG_TYPE_CSTRING) {
         return SIZE_DYNAMIC; /* we'll figure out size later */
     } else if (arg->size == SYSARG_POST_SIZE_RETVAL) {
@@ -1329,7 +1329,7 @@ sysarg_get_size(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii,
             if (sysinfo->arg[sz_argnum].size == sizeof(uint))
                 size = (uint)size;
         }
-        if (TEST(SYSARG_LENGTH_INOUT, arg->flags)) {
+        if (TESTANY(SYSARG_LENGTH_INOUT, arg->flags)) {
             size_t *ptr;
             int sz_argnum;
             ASSERT(arg->size <= 0, "inout can't be immed");
@@ -1359,7 +1359,7 @@ sysarg_get_size(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii,
                  */
                 !safe_read((void *)ptr, sysinfo->arg[sz_argnum].size, &size))
                 size = 0;
-        } else if (TEST(SYSARG_POST_SIZE_IO_STATUS, arg->flags)) {
+        } else if (TESTANY(SYSARG_POST_SIZE_IO_STATUS, arg->flags)) {
 #ifdef WINDOWS
             IO_STATUS_BLOCK *status = (IO_STATUS_BLOCK *)pt->sysarg[-arg->size];
             ULONG_PTR sz;
@@ -1375,11 +1375,11 @@ sysarg_get_size(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii,
 #endif
         }
     }
-    if (TEST(SYSARG_SIZE_PLUS_1, arg->flags)) {
+    if (TESTANY(SYSARG_SIZE_PLUS_1, arg->flags)) {
         LOG(drcontext, SYSCALL_VERBOSE, "\t  adding 1 to original size of %d\n", size);
         size++;
     }
-    if (TEST(SYSARG_SIZE_IN_ELEMENTS, arg->flags)) {
+    if (TESTANY(SYSARG_SIZE_IN_ELEMENTS, arg->flags)) {
         ASSERT(arg->misc > 0 || -arg->misc < SYSCALL_NUM_ARG_STORE,
                "reached max syscall args stored");
         size *= ((arg->misc > 0) ? arg->misc : ((int)pt->sysarg[-arg->misc]));
@@ -1396,9 +1396,9 @@ should_ignore_arg(cls_syscall_t *pt, sysarg_iter_info_t *ii, syscall_info_t *sys
      * misc.  We skip that for now to avoid conflicting with type info for
      * inline args.
      */
-    if (TEST(SYSARG_IGNORE_IF_NEXT_NULL, sysinfo->arg[i].flags))
+    if (TESTANY(SYSARG_IGNORE_IF_NEXT_NULL, sysinfo->arg[i].flags))
         if_null_arg = i + 1;
-    else if (TEST(SYSARG_IGNORE_IF_PREV_NULL, sysinfo->arg[i].flags))
+    else if (TESTANY(SYSARG_IGNORE_IF_PREV_NULL, sysinfo->arg[i].flags))
         if_null_arg = i - 1;
     else
         return false;
@@ -1521,9 +1521,9 @@ process_post_syscall_reads_and_writes(cls_syscall_t *pt, sysarg_iter_info_t *ii)
         if (sysarg_invalid(&sysinfo->arg[i]))
             break;
         ASSERT(i < SYSCALL_NUM_ARG_STORE, "not storing enough args");
-        if (!TEST(SYSARG_WRITE, sysinfo->arg[i].flags))
+        if (!TESTANY(SYSARG_WRITE, sysinfo->arg[i].flags))
             continue;
-        ASSERT(!TEST(SYSARG_INLINED, sysinfo->arg[i].flags),
+        ASSERT(!TESTANY(SYSARG_INLINED, sysinfo->arg[i].flags),
                "inlined should not be written");
 #ifdef WINDOWS
         /* i#486, i#531, i#932: for too-small buffer, only last param written */
@@ -1570,7 +1570,7 @@ process_post_syscall_reads_and_writes(cls_syscall_t *pt, sysarg_iter_info_t *ii)
                  */
                 size = last_size;
             }
-            if (TEST(SYSARG_NO_WRITE_IF_COUNT_0, sysinfo->arg[i].flags)) {
+            if (TESTANY(SYSARG_NO_WRITE_IF_COUNT_0, sysinfo->arg[i].flags)) {
                 /* Currently used only for NtUserGetKeyboardLayoutList.
                  * If the count (passed in a param indicated by the first entry's
                  * size field) is zero, the kernel returns the capacity needed,
@@ -1628,7 +1628,7 @@ get_sysinfo(void *drcontext, cls_syscall_t *pt, int initial_num,
     sysnum->secondary = 0;
     sysinfo = syscall_lookup(*sysnum, false /*don't resolve 2ndary yet*/);
     if (sysinfo != NULL) {
-        if (TEST(SYSINFO_SECONDARY_TABLE, sysinfo->flags)) {
+        if (TESTANY(SYSINFO_SECONDARY_TABLE, sysinfo->flags)) {
             uint code;
             ASSERT(sysinfo->arg_count >= 1, "at least 1 arg for code");
             /* We're called only from pre, before pt->sysarg is set, and not
@@ -1771,7 +1771,7 @@ drsys_iterate_args_common(void *drcontext, cls_syscall_t *pt, syscall_info_t *sy
             sysinfo->arg[compacted].param == i) {
             if (SYSARG_MISC_HAS_TYPE(sysinfo->arg[compacted].flags)) {
                 arg->type = type_from_arg_info(&sysinfo->arg[compacted]);
-            } else if (!TEST(SYSARG_INLINED, sysinfo->arg[compacted].flags)) {
+            } else if (!TESTANY(SYSARG_INLINED, sysinfo->arg[compacted].flags)) {
                 /* Rather than clutter up the tables with DRSYS_TYPE_STRUCT
                  * for all the types we haven't given special enums to,
                  * we mark the truly unknown and assume everything else is
@@ -1779,7 +1779,7 @@ drsys_iterate_args_common(void *drcontext, cls_syscall_t *pt, syscall_info_t *sy
                  */
                 arg->type = DRSYS_TYPE_STRUCT;
             }
-            if (TEST(SYSARG_INLINED, sysinfo->arg[compacted].flags)) {
+            if (TESTANY(SYSARG_INLINED, sysinfo->arg[compacted].flags)) {
                 int sz = sysinfo->arg[compacted].size;
                 ASSERT(sz > 0, "inlined must have regular size in bytes");
                 arg->size = sz;
@@ -1812,7 +1812,7 @@ drsys_iterate_args_common(void *drcontext, cls_syscall_t *pt, syscall_info_t *sy
             break;
     }
 
-    if (pt == NULL || !TEST(SYSINFO_RET_TYPE_VARIES, sysinfo->flags)) {
+    if (pt == NULL || !TESTANY(SYSINFO_RET_TYPE_VARIES, sysinfo->flags)) {
         /* return value */
         arg->size = sizeof(reg_t);
         /* get exported type and size if different from reg_t */
@@ -1923,7 +1923,7 @@ drsys_event_pre_syscall(void *drcontext, int initial_num)
     /* now that we have pt->sysarg set, get sysinfo and sysnum */
     pt->sysinfo = get_sysinfo(drcontext, pt, initial_num, &pt->sysnum);
     pt->known =
-        (pt->sysinfo != NULL && TEST(SYSINFO_ALL_PARAMS_KNOWN, pt->sysinfo->flags));
+        (pt->sysinfo != NULL && TESTANY(SYSINFO_ALL_PARAMS_KNOWN, pt->sysinfo->flags));
 
     /* Save params for post-syscall access.
      * We are reading beyond the # of args of some syscalls and we can
@@ -1948,7 +1948,7 @@ drsys_event_pre_syscall(void *drcontext, int initial_num)
                     ASSERT(compacted <= MAX_ARGS_IN_ENTRY, "error in table entry");
                     if (pt->sysinfo != NULL &&
                         !sysarg_invalid(&pt->sysinfo->arg[compacted]) &&
-                        TEST(SYSARG_INLINED, pt->sysinfo->arg[compacted].flags) &&
+                        TESTANY(SYSARG_INLINED, pt->sysinfo->arg[compacted].flags) &&
                         pt->sysinfo->arg[compacted].size == 8) {
                         /* This arg takes up two slots */
                         dr_slot++;

--- a/ext/drsyscall/drsyscall_linux.c
+++ b/ext/drsyscall/drsyscall_linux.c
@@ -265,7 +265,7 @@ handle_clone(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii)
      * the kernel ignores them unless selected by appropriate flags.
      * We check the writes here to avoid races (xref PR 408540).
      */
-    if (TEST(CLONE_PARENT_SETTID, flags)) {
+    if (TESTANY(CLONE_PARENT_SETTID, flags)) {
         pid_t *ptid = SYSARG_AS_PTR(pt, 2, pid_t *);
         if (!report_sysarg(ii, 2, SYSARG_WRITE))
             return;
@@ -275,7 +275,7 @@ handle_clone(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii)
                 return;
         }
     }
-    if (TEST(CLONE_SETTLS, flags)) {
+    if (TESTANY(CLONE_SETTLS, flags)) {
 #ifdef X86_32
         /* handle differences in type name */
 #    ifdef _LINUX_LDT_H
@@ -524,7 +524,7 @@ static void
 check_msghdr(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii, byte *ptr,
              size_t len, int ordinal, uint arg_flags)
 {
-    bool sendmsg = TEST(SYSARG_READ, arg_flags); /* else, recvmsg */
+    bool sendmsg = TESTANY(SYSARG_READ, arg_flags); /* else, recvmsg */
     struct msghdr *msg = (struct msghdr *)ptr;
     byte *ptr1, *ptr2;
     size_t val_socklen;
@@ -1270,7 +1270,7 @@ static void
 check_msgbuf(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii, byte *ptr,
              size_t len, int ordinal, uint arg_flags)
 {
-    bool msgsnd = TEST(SYSARG_READ, arg_flags); /* else, msgrcv */
+    bool msgsnd = TESTANY(SYSARG_READ, arg_flags); /* else, msgrcv */
     struct msgbuf *buf = (struct msgbuf *)ptr;
     if (!ii->arg->pre) {
         if (msgsnd)
@@ -1609,7 +1609,7 @@ os_handle_pre_syscall(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii
     case SYS_mremap: {
         /* 5th arg is conditionally valid */
         int flags = (int)pt->sysarg[3];
-        if (TEST(MREMAP_FIXED, flags)) {
+        if (TESTANY(MREMAP_FIXED, flags)) {
             if (!report_sysarg(ii, 4, SYSARG_READ))
                 return;
         }
@@ -1622,7 +1622,7 @@ os_handle_pre_syscall(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii
          * that wrapper (PR 488597).
          */
         int flags = (int)pt->sysarg[1];
-        if (TEST(O_CREAT, flags)) {
+        if (TESTANY(O_CREAT, flags)) {
             if (!report_sysarg(ii, 2, SYSARG_READ))
                 return;
         }
@@ -1702,7 +1702,7 @@ os_handle_pre_syscall(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii
          */
         kernel_sigaction_t *sa = SYSARG_AS_PTR(pt, 1, kernel_sigaction_t *);
         if (sa != NULL) {
-            if (TEST(SA_RESTORER, sa->flags)) {
+            if (TESTANY(SA_RESTORER, sa->flags)) {
                 if (!report_memarg_type(ii, 1, SYSARG_READ, (app_pc)sa, sizeof(*sa), NULL,
                                         DRSYS_TYPE_STRUCT, NULL))
                     return;
@@ -1904,7 +1904,7 @@ static bool
 os_handle_syscall_arg_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info,
                              app_pc start, uint size)
 {
-    if (!TEST(SYSARG_COMPLEX_TYPE, arg_info->flags))
+    if (!TESTANY(SYSARG_COMPLEX_TYPE, arg_info->flags))
         return false;
 
     switch (arg_info->misc) {

--- a/ext/drsyscall/drsyscall_macos.c
+++ b/ext/drsyscall/drsyscall_macos.c
@@ -71,7 +71,7 @@ os_handle_pre_syscall(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii
     case SYS_open_nocancel: {
         /* 3rd arg is only required for O_CREAT */
         int flags = (int)pt->sysarg[1];
-        if (TEST(O_CREAT, flags)) {
+        if (TESTANY(O_CREAT, flags)) {
             if (!report_sysarg_type(ii, 2, SYSARG_READ, sizeof(int),
                                     DRSYS_TYPE_SIGNED_INT, NULL))
                 return;
@@ -136,7 +136,7 @@ static bool
 os_handle_syscall_arg_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info,
                              app_pc start, uint size)
 {
-    if (!TEST(SYSARG_COMPLEX_TYPE, arg_info->flags))
+    if (!TESTANY(SYSARG_COMPLEX_TYPE, arg_info->flags))
         return false;
 
     switch (arg_info->misc) {
@@ -284,13 +284,13 @@ drsys_syscall_type(drsys_syscall_t *syscall, drsys_syscall_type_t *type DR_PARAM
 bool
 os_syscall_succeeded(drsys_sysnum_t sysnum, syscall_info_t *info, cls_syscall_t *pt)
 {
-    if (TEST(SYSCALL_NUM_MARKER_MACH, sysnum.number)) {
+    if (TESTANY(SYSCALL_NUM_MARKER_MACH, sysnum.number)) {
         /* XXX i#1440: Mach syscalls vary (for some KERN_SUCCESS=0 is success,
          * for others that return mach_port_t 0 is failure (I think?).
          */
         return ((ptr_int_t)pt->mc.xax >= 0);
     } else
-        return !TEST(EFLAGS_CF, pt->mc.xflags);
+        return !TESTANY(EFLAGS_CF, pt->mc.xflags);
 }
 
 bool

--- a/ext/drsyscall/drsyscall_windows.c
+++ b/ext/drsyscall/drsyscall_windows.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -66,7 +66,7 @@ static const char *const sysnum_names[] = {
                w8x86, w8wow, w8x64, w81x86, w81wow, w81x64, w10x86, w10wow, w10x64,     \
                w11x86, w11wow, w11x64, w12x86, w12wow, w12x64, w13x86, w13wow, w13x64,  \
                w14x86, w14wow, w14x64, w15x86, w15wow, w15x64)                          \
-#    n,
+    #n,
 #include "drsyscall_numx.h"
 #undef USER32
 };
@@ -651,7 +651,7 @@ check_syscall_entry(void *drcontext, const module_data_t *info, syscall_info_t *
         return;
     if (syslist->num.secondary != 0 && win_ver.version > syslist->num.secondary)
         return;
-    if (TEST(SYSINFO_REQUIRES_PREFIX, syslist->flags))
+    if (TESTANY(SYSINFO_REQUIRES_PREFIX, syslist->flags))
         optional_prefix = NULL;
     if (info != NULL) {
         drsys_sysnum_t num_from_wrapper;
@@ -676,7 +676,7 @@ get_primary_syscall_num(void *drcontext, const module_data_t *info,
         return ok;
     if (syslist->num.secondary != 0 && win_ver.version > syslist->num.secondary)
         return ok;
-    if (TEST(SYSINFO_REQUIRES_PREFIX, syslist->flags))
+    if (TESTANY(SYSINFO_REQUIRES_PREFIX, syslist->flags))
         optional_prefix = NULL;
     /* i#388: we try our name2num table first.  We need it anyway for wrappers that
      * are not exported or when we don't have symbol info.  The table has both
@@ -738,7 +738,7 @@ add_syscall_entry(void *drcontext, const module_data_t *info, syscall_info_t *sy
      * is a pointer to secondary table. So we shouldn't
      * rewrite them here.
      */
-    if (syslist->num_out != NULL && !TEST(SYSINFO_SECONDARY_TABLE, syslist->flags))
+    if (syslist->num_out != NULL && !TESTANY(SYSINFO_SECONDARY_TABLE, syslist->flags))
         *syslist->num_out = syslist->num;
     if (add_name2num) {
         /* Add the Nt variant only if a secondary, which our numx.h table doesn't have */
@@ -974,7 +974,7 @@ drsyscall_os_init(void *drcontext)
         /* check whether syscall has additional entries */
         ok =
             add_syscall_entry(drcontext, data, &syscall_ntdll_info[i], NULL, true, false);
-        if (TEST(SYSINFO_SECONDARY_TABLE, syscall_ntdll_info[i].flags) && ok)
+        if (TESTANY(SYSINFO_SECONDARY_TABLE, syscall_ntdll_info[i].flags) && ok)
             secondary_syscall_setup(drcontext, data, &syscall_ntdll_info[i], NULL);
         DODEBUG({ check_syscall_entry(drcontext, data, &syscall_ntdll_info[i], NULL); });
     }
@@ -1000,7 +1000,7 @@ drsyscall_os_init(void *drcontext)
              */
             ok = add_syscall_entry(drcontext, NULL, &syscall_user32_info[i], "NtUser",
                                    false /*already added*/, false);
-            if (TEST(SYSINFO_SECONDARY_TABLE, syscall_user32_info[i].flags) && ok) {
+            if (TESTANY(SYSINFO_SECONDARY_TABLE, syscall_user32_info[i].flags) && ok) {
                 secondary_syscall_setup(drcontext, data, &syscall_user32_info[i],
                                         wingdi_get_secondary_syscall_num);
             }
@@ -1069,13 +1069,13 @@ drsyscall_os_module_load(void *drcontext, const module_data_t *info, bool loaded
             if (syscall_numbers_unknown) {
                 add_syscall_entry(drcontext, info, &syscall_user32_info[i], "NtUser",
                                   true, false);
-                if (TEST(SYSINFO_SECONDARY_TABLE, syscall_user32_info[i].flags)) {
+                if (TESTANY(SYSINFO_SECONDARY_TABLE, syscall_user32_info[i].flags)) {
                     secondary_syscall_setup(drcontext, info, &syscall_user32_info[i],
                                             wingdi_get_secondary_syscall_num);
                 }
             }
             DODEBUG({
-                if (!TEST(SYSINFO_IMM32_DLL, syscall_user32_info[i].flags)) {
+                if (!TESTANY(SYSINFO_IMM32_DLL, syscall_user32_info[i].flags)) {
                     check_syscall_entry(drcontext, info, &syscall_user32_info[i],
                                         "NtUser");
                 }
@@ -1087,7 +1087,7 @@ drsyscall_os_module_load(void *drcontext, const module_data_t *info, bool loaded
          stri_eq(modname, "win32u.dll"))) {
         DODEBUG({
             for (i = 0; i < num_user32_syscalls(); i++) {
-                if (TEST(SYSINFO_IMM32_DLL, syscall_user32_info[i].flags)) {
+                if (TESTANY(SYSINFO_IMM32_DLL, syscall_user32_info[i].flags)) {
                     check_syscall_entry(drcontext, info, &syscall_user32_info[i],
                                         "NtUser");
                 }
@@ -1180,7 +1180,7 @@ os_syscall_ret_small_write_last(syscall_info_t *info, ptr_int_t res)
     /* i#486, i#932: syscalls that return the capacity needed in an OUT
      * param will still write to it when returning STATUS_BUFFER_TOO_SMALL
      */
-    if (!TEST(SYSINFO_RET_SMALL_WRITE_LAST, info->flags))
+    if (!TESTANY(SYSINFO_RET_SMALL_WRITE_LAST, info->flags))
         return false;
     if (info->return_type == DRSYS_TYPE_NTSTATUS) {
         return (res == STATUS_BUFFER_TOO_SMALL ||
@@ -1235,7 +1235,7 @@ os_syscall_succeeded(drsys_sysnum_t sysnum, syscall_info_t *info, cls_syscall_t 
     if (info != NULL) {
         if (os_syscall_ret_small_write_last(info, res))
             return true;
-        if (TEST(SYSINFO_RET_ZERO_FAIL, info->flags) ||
+        if (TESTANY(SYSINFO_RET_ZERO_FAIL, info->flags) ||
             info->return_type == SYSARG_TYPE_BOOL32 ||
             info->return_type == SYSARG_TYPE_BOOL8 ||
             info->return_type == DRSYS_TYPE_HANDLE ||
@@ -1245,7 +1245,7 @@ os_syscall_succeeded(drsys_sysnum_t sysnum, syscall_info_t *info, cls_syscall_t 
          * also NT_CURRENT_PROCESS, so we rely on any syscalls that return
          * INVALID_HANDLE_VALUE for failure to use SYSINFO_RET_MINUS1_FAIL.
          */
-        if (TEST(SYSINFO_RET_MINUS1_FAIL, info->flags))
+        if (TESTANY(SYSINFO_RET_MINUS1_FAIL, info->flags))
             return (res != -1);
         if (info->return_type != DRSYS_TYPE_NTSTATUS) {
             /* We don't really know, so safest to assume it succeeded */
@@ -1296,8 +1296,8 @@ handle_port_message_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info
 {
     /* variable-length */
     PORT_MESSAGE pm;
-    if (TEST(SYSARG_WRITE, arg_info->flags) && ii->arg->pre &&
-        !TEST(SYSARG_READ, arg_info->flags)) {
+    if (TESTANY(SYSARG_WRITE, arg_info->flags) && ii->arg->pre &&
+        !TESTANY(SYSARG_READ, arg_info->flags)) {
         /* Struct is passed in uninit w/ max-len buffer after it.
          * XXX i#415: There is some ambiguity over the max, hence we choose
          * the lower estimation to avoid false positives.
@@ -1431,7 +1431,7 @@ handle_context_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info, app
             return true;
     }
 #else /* 32-bit X86 */
-    ASSERT(TEST(CONTEXT_i486, context_flags),
+    ASSERT(TESTANY(CONTEXT_i486, context_flags),
            "ContextFlags doesn't have CONTEXT_i486 bit set");
 
     /* CONTEXT structure on x86 consists of the following sections:
@@ -1547,7 +1547,7 @@ handle_security_descriptor_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *a
     const SECURITY_DESCRIPTOR *s = (SECURITY_DESCRIPTOR *)start;
     SECURITY_DESCRIPTOR_CONTROL flags;
     ASSERT(s != NULL, "descriptor must not be NULL"); /* caller should check */
-    ASSERT(!TEST(SYSARG_WRITE, arg_info->flags), "Should only be called for reads");
+    ASSERT(!TESTANY(SYSARG_WRITE, arg_info->flags), "Should only be called for reads");
     if (!ii->arg->pre) {
         /* Handling pre- is enough for reads */
         return true;
@@ -1561,11 +1561,11 @@ handle_security_descriptor_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *a
 
     ASSERT(sizeof(flags) == sizeof(s->Control), "");
     if (safe_read((void *)&s->Control, sizeof(flags), &flags)) {
-        if (TEST(SE_SACL_PRESENT, flags)) {
+        if (TESTANY(SE_SACL_PRESENT, flags)) {
             if (!report_memarg(ii, arg_info, (app_pc)&s->Sacl, sizeof(s->Sacl), NULL))
                 return true;
         }
-        if (TEST(SE_DACL_PRESENT, flags)) {
+        if (TESTANY(SE_DACL_PRESENT, flags)) {
             if (!report_memarg(ii, arg_info, (app_pc)&s->Dacl, sizeof(s->Dacl), NULL))
                 return true;
         }
@@ -1587,7 +1587,7 @@ handle_unicode_string_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_in
 
     /* we assume OUT fields just have their Buffer as OUT */
     if (ii->arg->pre) {
-        if (TEST(SYSARG_READ, arg_info->flags)) {
+        if (TESTANY(SYSARG_READ, arg_info->flags)) {
             if (!report_memarg(ii, arg_info, (byte *)&arg->Length, sizeof(arg->Length),
                                "UNICODE_STRING.Length"))
                 return true;
@@ -1609,7 +1609,7 @@ handle_unicode_string_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_in
             "UNICODE_STRING Buffer=" PFX " Length=%d MaximumLength=%d\n",
             (byte *)us.Buffer, us.Length, us.MaximumLength);
         if (ii->arg->pre) {
-            if (TEST(SYSARG_READ, arg_info->flags)) {
+            if (TESTANY(SYSARG_READ, arg_info->flags)) {
                 /* For IN params, the buffer size is passed as us.Length */
                 ASSERT(!ignore_len, "Length must be defined for IN params");
                 /* XXX i#519: Length doesn't include NULL, but NULL seems
@@ -1718,7 +1718,7 @@ handle_cwstring(sysarg_iter_info_t *ii, const char *id, byte *start,
     size_t maxsz = (size == 0) ? (MAX_PATH * sizeof(wchar_t)) : size;
     if (start == NULL)
         return false; /* nothing to do */
-    if (ii->arg->pre && !TEST(SYSARG_READ, arg_flags)) {
+    if (ii->arg->pre && !TESTANY(SYSARG_READ, arg_flags)) {
         if (!check_addr)
             return false;
         if (size > 0) {
@@ -1729,7 +1729,7 @@ handle_cwstring(sysarg_iter_info_t *ii, const char *id, byte *start,
             return true;
         }
     }
-    if (!ii->arg->pre && !TEST(SYSARG_WRITE, arg_flags))
+    if (!ii->arg->pre && !TESTANY(SYSARG_WRITE, arg_flags))
         return false; /*nothing to do */
     for (i = 0; i < maxsz; i += sizeof(wchar_t)) {
         if (safe != NULL)
@@ -1876,7 +1876,7 @@ handle_alpc_message_attributes_access(sysarg_iter_info_t *ii,
                 sizeof(arg->ValidAttributes), "ALPC_MESSAGE_ATTRIBUTES ValidAttributes",
                 DRSYS_TYPE_ALPC_MESSAGE_ATTRIBUTES, NULL))
             return true;
-        if (TEST(ALPC_MESSAGE_SECURITY_ATTRIBUTE, attributes)) {
+        if (TESTANY(ALPC_MESSAGE_SECURITY_ATTRIBUTE, attributes)) {
             /* Kernel does not write SecurityQos field. */
             if (!report_memarg_type(ii, arg_info->param, SYSARG_WRITE, start + delta,
                                     sizeof(((ALPC_SECURITY_ATTRIBUTES *)0)->Flags),
@@ -1892,7 +1892,7 @@ handle_alpc_message_attributes_access(sysarg_iter_info_t *ii,
                 return true;
             delta = sizeof(ALPC_SECURITY_ATTRIBUTES);
         }
-        if (TEST(ALPC_MESSAGE_VIEW_ATTRIBUTE, attributes)) {
+        if (TESTANY(ALPC_MESSAGE_VIEW_ATTRIBUTE, attributes)) {
             /* XXX: The kernel performs checks for each attribute, however it is checked
              * against AllocatedAttributes masked w/ ALPC_MESSAGE_SECURITY_ATTRIBUTE thus
              * making the additional checks unnecessary. Kernel does not write
@@ -1912,7 +1912,7 @@ handle_alpc_message_attributes_access(sysarg_iter_info_t *ii,
                 return true;
             delta += sizeof(ALPC_DATA_VIEW);
         }
-        if (TEST(ALPC_MESSAGE_CONTEXT_ATTRIBUTE, attributes)) {
+        if (TESTANY(ALPC_MESSAGE_CONTEXT_ATTRIBUTE, attributes)) {
             if (!report_memarg_type(ii, arg_info->param, SYSARG_WRITE, start + delta,
                                     sizeof(ALPC_CONTEXT_ATTRIBUTES),
                                     "exposed ALPC_CONTEXT_ATTRIBUTES", DRSYS_TYPE_STRUCT,
@@ -1920,7 +1920,7 @@ handle_alpc_message_attributes_access(sysarg_iter_info_t *ii,
                 return true;
             delta += sizeof(ALPC_CONTEXT_ATTRIBUTES);
         }
-        if (TEST(ALPC_MESSAGE_HANDLE_ATTRIBUTE, attributes)) {
+        if (TESTANY(ALPC_MESSAGE_HANDLE_ATTRIBUTE, attributes)) {
             if (!report_memarg_type(ii, arg_info->param, SYSARG_WRITE, start + delta,
                                     sizeof(ALPC_HANDLE_ATTRIBUTES),
                                     "exposed ALPC_MESSAGE_HANDLE_ATTRIBUTES",
@@ -1959,7 +1959,7 @@ static bool
 os_handle_syscall_arg_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info,
                              app_pc start, uint size)
 {
-    if (!TEST(SYSARG_COMPLEX_TYPE, arg_info->flags))
+    if (!TESTANY(SYSARG_COMPLEX_TYPE, arg_info->flags))
         return false;
 
     switch (arg_info->misc) {
@@ -2882,12 +2882,12 @@ handle_AFD_ioctl(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii)
             AFD_TDI_HANDLE_DATA *info = (AFD_TDI_HANDLE_DATA *)pt->sysarg[8];
             uint flags;
             if (safe_read(inbuf, sizeof(flags), &flags) && outsz == sizeof(*info)) {
-                if (TEST(AFD_ADDRESS_HANDLE, flags)) {
+                if (TESTANY(AFD_ADDRESS_HANDLE, flags)) {
                     MARK_WRITE(ii, (byte *)&info->TdiAddressHandle,
                                sizeof(info->TdiAddressHandle),
                                "AFD_TDI_HANDLE_DATA.TdiAddressHandle");
                 }
-                if (TEST(AFD_CONNECTION_HANDLE, flags)) {
+                if (TESTANY(AFD_CONNECTION_HANDLE, flags)) {
                     MARK_WRITE(ii, (byte *)&info->TdiConnectionHandle,
                                sizeof(info->TdiConnectionHandle),
                                "AFD_TDI_HANDLE_DATA.TdiConnectionHandle");

--- a/ext/drsyscall/drsyscall_wingdi.c
+++ b/ext/drsyscall/drsyscall_wingdi.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -80,7 +80,7 @@ static hashtable_t usercall_table;
 static const char *const usercall_names[] = {
 #define USERCALL(type, name, w2k, xp, w2003, vistaSP01, vistaSP2, w7, w8, w81, w10, w11, \
                  w12, w13, w14, w15)                                                     \
-#    type "." #    name,
+    #type "." #name,
 #include "drsyscall_usercallx.h"
 #undef USERCALL
 };
@@ -89,7 +89,7 @@ static const char *const usercall_names[] = {
 static const char *const usercall_primary[] = {
 #define USERCALL(type, name, w2k, xp, w2003, vistaSP01, vistaSP2, w7, w8, w81, w10, w11, \
                  w12, w13, w14, w15)                                                     \
-#    type,
+    #type,
 #include "drsyscall_usercallx.h"
 #undef USERCALL
 };
@@ -401,12 +401,12 @@ handle_large_string_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info
                                   "LARGE_STRING capacity", DRSYS_TYPE_LARGE_STRING, NULL,
                                   DRSYS_TYPE_INVALID))
                 return true;
-            if (TEST(SYSARG_READ, arg_info->flags)) {
+            if (TESTANY(SYSARG_READ, arg_info->flags)) {
                 if (!report_memarg(ii, arg_info, (byte *)ls.Buffer, ls.Length,
                                    "LARGE_STRING content"))
                     return true;
             }
-        } else if (TEST(SYSARG_WRITE, arg_info->flags)) {
+        } else if (TESTANY(SYSARG_WRITE, arg_info->flags)) {
             if (!report_memarg(ii, arg_info, (byte *)ls.Buffer, ls.Length,
                                "LARGE_STRING content"))
                 return true;
@@ -467,7 +467,7 @@ handle_wndclassexw_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info,
      * alternatively keep the check here and treat this is a user32.dll bug and
      * suppress it.
      */
-    bool use_cbSize = TEST(SYSARG_READ, arg_info->flags);
+    bool use_cbSize = TESTANY(SYSARG_READ, arg_info->flags);
     if (ii->arg->pre && use_cbSize) {
         if (!report_memarg_type(ii, arg_info->param, SYSARG_READ, start,
                                 sizeof(safe.cbSize), "WNDCLASSEX.cbSize",
@@ -479,8 +479,8 @@ handle_wndclassexw_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info,
                            use_cbSize ? safe.cbSize : sizeof(WNDCLASSEX), "WNDCLASSEX"))
             return true;
         /* For WRITE there is no capacity here so nothing to check (i#505) */
-        if ((ii->arg->pre && TEST(SYSARG_READ, arg_info->flags)) ||
-            (!ii->arg->pre && TEST(SYSARG_WRITE, arg_info->flags))) {
+        if ((ii->arg->pre && TESTANY(SYSARG_READ, arg_info->flags)) ||
+            (!ii->arg->pre && TESTANY(SYSARG_WRITE, arg_info->flags))) {
             /* lpszMenuName can be from MAKEINTRESOURCE, and
              * lpszClassName can be an atom
              */
@@ -515,7 +515,7 @@ handle_clsmenuname_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_info,
     CLSMENUNAME safe;
     if (!report_memarg(ii, arg_info, start, size, "CLSMENUNAME"))
         return true;
-    if (ii->arg->pre && !TEST(SYSARG_READ, arg_info->flags)) {
+    if (ii->arg->pre && !TESTANY(SYSARG_READ, arg_info->flags)) {
         /* looks like even the UNICODE_STRING is not set up: contains garbage,
          * so presumably kernel creates it and doesn't just write to Buffer
          */
@@ -577,13 +577,13 @@ handle_menuiteminfow_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_inf
                                   NULL, DRSYS_TYPE_INVALID))
                 return true;
         }
-        if (TEST(MIIM_BITMAP, safe.fMask) &&
+        if (TESTANY(MIIM_BITMAP, safe.fMask) &&
             safe.cbSize > offsetof(MENUITEMINFOW, hbmpItem)) {
             if (!report_memarg(ii, arg_info, (byte *)&real->hbmpItem,
                                sizeof(real->hbmpItem), "MENUITEMINFOW.hbmpItem"))
                 return true;
         }
-        if (TEST(MIIM_CHECKMARKS, safe.fMask)) {
+        if (TESTANY(MIIM_CHECKMARKS, safe.fMask)) {
             if (safe.cbSize > offsetof(MENUITEMINFOW, hbmpChecked)) {
                 if (!report_memarg(ii, arg_info, (byte *)&real->hbmpChecked,
                                    sizeof(real->hbmpChecked),
@@ -597,43 +597,43 @@ handle_menuiteminfow_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_inf
                     return true;
             }
         }
-        if (TEST(MIIM_DATA, safe.fMask) &&
+        if (TESTANY(MIIM_DATA, safe.fMask) &&
             safe.cbSize > offsetof(MENUITEMINFOW, dwItemData)) {
             if (!report_memarg(ii, arg_info, (byte *)&real->dwItemData,
                                sizeof(real->dwItemData), "MENUITEMINFOW.dwItemData"))
                 return true;
         }
-        if (TEST(MIIM_FTYPE, safe.fMask) &&
+        if (TESTANY(MIIM_FTYPE, safe.fMask) &&
             safe.cbSize > offsetof(MENUITEMINFOW, fType)) {
             if (!report_memarg(ii, arg_info, (byte *)&real->fType, sizeof(real->fType),
                                "MENUITEMINFOW.fType"))
                 return true;
         }
-        if (TEST(MIIM_ID, safe.fMask) && safe.cbSize > offsetof(MENUITEMINFOW, wID)) {
+        if (TESTANY(MIIM_ID, safe.fMask) && safe.cbSize > offsetof(MENUITEMINFOW, wID)) {
             if (!report_memarg(ii, arg_info, (byte *)&real->wID, sizeof(real->wID),
                                "MENUITEMINFOW.wID"))
                 return true;
         }
-        if (TEST(MIIM_STATE, safe.fMask) &&
+        if (TESTANY(MIIM_STATE, safe.fMask) &&
             safe.cbSize > offsetof(MENUITEMINFOW, fState)) {
             if (!report_memarg(ii, arg_info, (byte *)&real->fState, sizeof(real->fState),
                                "MENUITEMINFOW.fState"))
                 return true;
         }
-        if (TEST(MIIM_STRING, safe.fMask) &&
+        if (TESTANY(MIIM_STRING, safe.fMask) &&
             safe.cbSize > offsetof(MENUITEMINFOW, dwTypeData)) {
             if (!report_memarg(ii, arg_info, (byte *)&real->dwTypeData,
                                sizeof(real->dwTypeData), "MENUITEMINFOW.dwTypeData"))
                 return true;
             check_dwTypeData = true;
         }
-        if (TEST(MIIM_SUBMENU, safe.fMask) &&
+        if (TESTANY(MIIM_SUBMENU, safe.fMask) &&
             safe.cbSize > offsetof(MENUITEMINFOW, hSubMenu)) {
             if (!report_memarg(ii, arg_info, (byte *)&real->hSubMenu,
                                sizeof(real->hSubMenu), "MENUITEMINFOW.hSubMenu"))
                 return true;
         }
-        if (TEST(MIIM_TYPE, safe.fMask) &&
+        if (TESTANY(MIIM_TYPE, safe.fMask) &&
             !TESTANY(MIIM_BITMAP | MIIM_FTYPE | MIIM_STRING, safe.fMask)) {
             if (safe.cbSize > offsetof(MENUITEMINFOW, fType)) {
                 if (!report_memarg(ii, arg_info, (byte *)&real->fType,
@@ -651,7 +651,7 @@ handle_menuiteminfow_access(sysarg_iter_info_t *ii, const sysinfo_arg_t *arg_inf
             /* i#1463: when retrieving, kernel sets safe.cch so we don't have
              * to walk the string.  When setting, cch is ignored.
              */
-            if (TEST(SYSARG_WRITE, arg_info->flags)) {
+            if (TESTANY(SYSARG_WRITE, arg_info->flags)) {
                 if (safe.cbSize > offsetof(MENUITEMINFOW, cch)) {
                     if (ii->arg->pre) {
                         /* User must set cch to capacity of dwTypeData */
@@ -743,7 +743,7 @@ handle_logfont(sysarg_iter_info_t *ii, byte *start, size_t size, int ordinal,
                uint arg_flags, LOGFONTW *safe)
 {
     LOGFONTW *font = (LOGFONTW *)start;
-    if (ii->arg->pre && TEST(SYSARG_WRITE, arg_flags)) {
+    if (ii->arg->pre && TESTANY(SYSARG_WRITE, arg_flags)) {
         if (!report_memarg_type(ii, ordinal, arg_flags, start, size, "LOGFONTW",
                                 DRSYS_TYPE_LOGFONTW, NULL))
             return;
@@ -798,11 +798,11 @@ handle_nonclientmetrics(sysarg_iter_info_t *ii, byte *start, size_t size_specifi
      */
     LOG(ii->arg->drcontext, 2,
         "NONCLIENTMETRICSW %s: sizeof(NONCLIENTMETRICSW)=%x, cbSize=%x, uiParam=%x\n",
-        TEST(SYSARG_WRITE, arg_flags) ? "write" : "read", sizeof(NONCLIENTMETRICSW),
+        TESTANY(SYSARG_WRITE, arg_flags) ? "write" : "read", sizeof(NONCLIENTMETRICSW),
         ptr_safe->cbSize, size_specified);
     /* win7 seems to set cbSize properly, always */
     if (win_ver.version >= DR_WINDOWS_VERSION_7 ||
-        (!ii->arg->pre && TEST(SYSARG_WRITE, arg_flags)))
+        (!ii->arg->pre && TESTANY(SYSARG_WRITE, arg_flags)))
         size = ptr_safe->cbSize;
     else {
         /* MAX to handle future additions.  I don't think older versions
@@ -811,7 +811,7 @@ handle_nonclientmetrics(sysarg_iter_info_t *ii, byte *start, size_t size_specifi
         size = MAX(sizeof(NONCLIENTMETRICSW), size_specified);
     }
 
-    if (ii->arg->pre && TEST(SYSARG_WRITE, arg_flags)) {
+    if (ii->arg->pre && TESTANY(SYSARG_WRITE, arg_flags)) {
         if (!report_memarg_type(ii, ordinal, arg_flags, start, size, "NONCLIENTMETRICSW",
                                 DRSYS_TYPE_NONCLIENTMETRICSW, NULL))
             return;
@@ -921,7 +921,7 @@ handle_iconmetrics(sysarg_iter_info_t *ii, byte *start, int ordinal, uint arg_fl
     }
     size = ptr_safe->cbSize;
 
-    if (ii->arg->pre && TEST(SYSARG_WRITE, arg_flags)) {
+    if (ii->arg->pre && TESTANY(SYSARG_WRITE, arg_flags)) {
         if (!report_memarg_type(ii, ordinal, arg_flags, start, size, "ICONMETRICSW",
                                 DRSYS_TYPE_ICONMETRICSW, NULL))
             return;
@@ -2157,7 +2157,7 @@ handle_UserTrackMouseEvent(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_
         uint flags;
         safe = (TRACKMOUSEEVENT *)buf;
         /* XXX: for non-TME_QUERY are the other fields read? */
-        flags = TEST(TME_QUERY, safe->dwFlags) ? SYSARG_WRITE : SYSARG_READ;
+        flags = TESTANY(TME_QUERY, safe->dwFlags) ? SYSARG_WRITE : SYSARG_READ;
         if ((flags == SYSARG_WRITE || ii->arg->pre) &&
             safe->cbSize > BUFFER_SIZE_BYTES(buf)) {
             report_sysarg_type(ii, 0, SYSARG_READ, safe->cbSize - BUFFER_SIZE_BYTES(buf),
@@ -2427,20 +2427,22 @@ handle_UserSetScrollInfo(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t 
                             "SCROLLINFO cbSize+fMask", DRSYS_TYPE_STRUCT, "SCROLLINFO"))
         return;
     if (safe_read((byte *)si, sizeof(safe), &safe)) {
-        if (TEST(SIF_RANGE, safe.fMask) && safe.cbSize >= offsetof(SCROLLINFO, nPage)) {
+        if (TESTANY(SIF_RANGE, safe.fMask) &&
+            safe.cbSize >= offsetof(SCROLLINFO, nPage)) {
             if (!report_memarg_type(ii, 0, SYSARG_READ, (byte *)&si->nMin,
                                     sizeof(si->nMin) + sizeof(si->nMax),
                                     "SCROLLINFO nMin+nMax", DRSYS_TYPE_STRUCT,
                                     "SCROLLINFO"))
                 return;
         }
-        if (TEST(SIF_PAGE, safe.fMask) && safe.cbSize >= offsetof(SCROLLINFO, nPos)) {
+        if (TESTANY(SIF_PAGE, safe.fMask) && safe.cbSize >= offsetof(SCROLLINFO, nPos)) {
             if (!report_memarg_type(ii, 0, SYSARG_READ, (byte *)&si->nPage,
                                     sizeof(si->nPage), "SCROLLINFO.nPage",
                                     DRSYS_TYPE_STRUCT, "SCROLLINFO"))
                 return;
         }
-        if (TEST(SIF_POS, safe.fMask) && safe.cbSize >= offsetof(SCROLLINFO, nTrackPos)) {
+        if (TESTANY(SIF_POS, safe.fMask) &&
+            safe.cbSize >= offsetof(SCROLLINFO, nTrackPos)) {
             if (!report_memarg_type(ii, 0, SYSARG_READ, (byte *)&si->nPos,
                                     sizeof(si->nPos), "SCROLLINFO.nPos",
                                     DRSYS_TYPE_STRUCT, "SCROLLINFO"))
@@ -2677,7 +2679,7 @@ wingdi_shadow_process_syscall(void *drcontext, cls_syscall_t *pt, sysarg_iter_in
         UINT fuOptions = (UINT)pt->sysarg[3];
         int cwc = (int)pt->sysarg[6];
         INT *pdx = (INT *)pt->sysarg[7];
-        if (ii->arg->pre && TEST(ETO_PDY, fuOptions)) {
+        if (ii->arg->pre && TESTANY(ETO_PDY, fuOptions)) {
             /* pdx contains pairs of INTs.  regular entry already checked
              * size of singletons of INTs so here we check the extra size.
              */

--- a/ext/drutil/drutil.c
+++ b/ext/drutil/drutil.c
@@ -417,7 +417,7 @@ drutil_insert_get_mem_addr_risc(void *drcontext, instrlist_t *bb, instr_t *where
         int disp = opnd_get_disp(memref);
         reg_id_t stolen = dr_get_stolen_reg();
 #    ifdef AARCHXX
-        bool negated = TEST(DR_OPND_NEGATED, opnd_get_flags(memref));
+        bool negated = TESTANY(DR_OPND_NEGATED, opnd_get_flags(memref));
         /* On ARM, disp is never negative; on AArch64, we do not use DR_OPND_NEGATED. */
         ASSERT(IF_ARM_ELSE(disp >= 0, !negated), "DR_OPND_NEGATED internal error");
         if (disp < 0) {

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -569,7 +569,8 @@ drwrap_get_mcontext_internal(drwrap_context_t *wrapcxt, dr_mcontext_flags_t flag
             else
                 wrapcxt->mc->pc = wrapcxt->retaddr;
         } else {
-            ASSERT(TEST(DR_MC_MULTIMEDIA, flags) && !TEST(DR_MC_MULTIMEDIA, old_flags) &&
+            ASSERT(TESTANY(DR_MC_MULTIMEDIA, flags) &&
+                       !TESTANY(DR_MC_MULTIMEDIA, old_flags) &&
                        TESTALL(DR_MC_INTEGER | DR_MC_CONTROL, old_flags),
                    "logic error");
             /* the pre-ymm is smaller than ymm so we make a temp copy and then
@@ -581,14 +582,14 @@ drwrap_get_mcontext_internal(drwrap_context_t *wrapcxt, dr_mcontext_flags_t flag
             dr_get_mcontext(wrapcxt->drcontext, wrapcxt->mc);
             memcpy(wrapcxt->mc, &tmp, offsetof(dr_mcontext_t, pc) + sizeof(tmp.pc));
         }
-        if (TEST(DRWRAP_FAST_CLEANCALLS, global_flags)) {
+        if (TESTANY(DRWRAP_FAST_CLEANCALLS, global_flags)) {
             /* N.B: it's fine to have garbage in the xmm slots we didn't save
              * (which is all but the x64 param ones) since we only redirect
              * to start of callee where they're scratch or to retaddr on a
              * skip where client should have retrieved param xmm (should happen
              * automatically on get) and then filled in any xmm retvals.
              */
-            if (TEST(DR_MC_CONTROL, flags)) {
+            if (TESTANY(DR_MC_CONTROL, flags)) {
                 /* we need a sane eflags for redirect, but we also need to preserve
                  * trap flag or other flags so instead of zeroing we copy cur flags
                  * (xref i#806).
@@ -607,7 +608,7 @@ drwrap_get_mcontext_internal(drwrap_context_t *wrapcxt, dr_mcontext_flags_t flag
                     : "=m"(val));
                 wrapcxt->mc->xflags = val;
 #    endif
-                ASSERT(!TEST(EFLAGS_DF, wrapcxt->mc->xflags), "DF not cleared");
+                ASSERT(!TESTANY(EFLAGS_DF, wrapcxt->mc->xflags), "DF not cleared");
 #endif
             }
         }
@@ -630,7 +631,7 @@ dr_mcontext_t *
 drwrap_get_mcontext(void *wrapcxt_opaque)
 {
     return drwrap_get_mcontext_ex(wrapcxt_opaque,
-                                  TEST(DRWRAP_FAST_CLEANCALLS, global_flags)
+                                  TESTANY(DRWRAP_FAST_CLEANCALLS, global_flags)
                                       ? (DR_MC_INTEGER | DR_MC_CONTROL)
                                       : DR_MC_ALL);
 }
@@ -748,7 +749,7 @@ drwrap_get_arg(void *wrapcxt_opaque, int arg)
         return NULL; /* can only get args in pre */
     if (addr == NULL)
         return NULL;
-    else if (TEST(DRWRAP_SAFE_READ_ARGS, global_flags)) {
+    else if (TESTANY(DRWRAP_SAFE_READ_ARGS, global_flags)) {
         void *value;
         if (!fast_safe_read(addr, sizeof(value), &value))
             return NULL;
@@ -772,7 +773,7 @@ drwrap_set_arg(void *wrapcxt_opaque, int arg, void *val)
         in_memory = !(addr >= (reg_t *)wrapcxt->mc && addr < (reg_t *)(wrapcxt->mc + 1));
         if (!in_memory)
             wrapcxt->mc_modified = true;
-        if (in_memory && TEST(DRWRAP_SAFE_READ_ARGS, global_flags)) {
+        if (in_memory && TESTANY(DRWRAP_SAFE_READ_ARGS, global_flags)) {
             if (!dr_safe_write((void *)addr, sizeof(val), val, NULL))
                 return false;
         } else
@@ -968,7 +969,7 @@ drwrap_init(void)
     drmgr_init();
     if (!drmgr_register_bb_app2app_event(drwrap_event_bb_app2app, &pri_replace))
         return false;
-    if (!TEST(DRWRAP_INVERT_CONTROL, global_flags)) {
+    if (!TESTANY(DRWRAP_INVERT_CONTROL, global_flags)) {
         if (!drmgr_register_bb_instrumentation_event(NULL, drwrap_event_bb_insert,
                                                      &pri_insert))
             return false;
@@ -1031,7 +1032,7 @@ drwrap_exit(void)
     if (count != 0)
         return;
 
-    if (!TEST(DRWRAP_INVERT_CONTROL, global_flags)) {
+    if (!TESTANY(DRWRAP_INVERT_CONTROL, global_flags)) {
         if (!drmgr_unregister_bb_insertion_event(drwrap_event_bb_insert))
             ASSERT(false, "failed to unregister in drwrap_exit");
     }
@@ -1139,8 +1140,8 @@ drwrap_set_global_flags(drwrap_global_flags_t flags)
     dr_recurlock_lock(wrap_lock);
     if (dr_atomic_load32(&drwrap_init_count) > 0 &&
         /* After drwrap_init() was called, control inversion cannot be changed. */
-        TEST(DRWRAP_INVERT_CONTROL, flags) &&
-        !TEST(DRWRAP_INVERT_CONTROL, global_flags)) {
+        TESTANY(DRWRAP_INVERT_CONTROL, flags) &&
+        !TESTANY(DRWRAP_INVERT_CONTROL, global_flags)) {
         dr_recurlock_unlock(wrap_lock);
         return false;
     }
@@ -1162,7 +1163,7 @@ dr_emit_flags_t
 drwrap_invoke_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                      instr_t *where, bool for_trace, bool translating, void *user_data)
 {
-    ASSERT(TEST(DRWRAP_INVERT_CONTROL, global_flags),
+    ASSERT(TESTANY(DRWRAP_INVERT_CONTROL, global_flags),
            "must set DRWRAP_INVERT_CONTROL to call drwrap_invoke_insert");
     return drwrap_event_bb_insert_where(drcontext, tag, bb, inst, where, for_trace,
                                         translating, user_data, /*cleanup_only=*/false);
@@ -1174,7 +1175,7 @@ drwrap_invoke_insert_cleanup_only(void *drcontext, void *tag, instrlist_t *bb,
                                   instr_t *inst, instr_t *where, bool for_trace,
                                   bool translating, void *user_data)
 {
-    ASSERT(TEST(DRWRAP_INVERT_CONTROL, global_flags),
+    ASSERT(TESTANY(DRWRAP_INVERT_CONTROL, global_flags),
            "must set DRWRAP_INVERT_CONTROL to call drwrap_invoke_insert_cleanup_only");
     return drwrap_event_bb_insert_where(drcontext, tag, bb, inst, where, for_trace,
                                         translating, user_data, /*cleanup_only=*/true);
@@ -1317,7 +1318,7 @@ DR_EXPORT
 bool
 drwrap_replace(app_pc original, app_pc replacement, bool override)
 {
-    if (TEST(DRWRAP_INVERT_CONTROL, global_flags)) {
+    if (TESTANY(DRWRAP_INVERT_CONTROL, global_flags)) {
         /* Not supported in this mode since drbbdup does not support a separate
          * app2app per case.
          */
@@ -1331,7 +1332,7 @@ bool
 drwrap_replace_native(app_pc original, app_pc replacement, bool at_entry,
                       uint stack_adjust, void *user_data, bool override)
 {
-    if (TEST(DRWRAP_INVERT_CONTROL, global_flags)) {
+    if (TESTANY(DRWRAP_INVERT_CONTROL, global_flags)) {
         /* Not supported in this mode since drbbdup does not support a separate
          * app2app per case.
          */
@@ -1794,7 +1795,7 @@ static app_pc
 get_retaddr_from_stack(reg_t xsp)
 {
     app_pc retaddr = NULL;
-    if (TEST(DRWRAP_SAFE_READ_RETADDR, global_flags)) {
+    if (TESTANY(DRWRAP_SAFE_READ_RETADDR, global_flags)) {
         if (!fast_safe_read((void *)xsp, sizeof(retaddr), &retaddr))
             return NULL;
     } else
@@ -1806,7 +1807,7 @@ static bool
 set_retaddr_on_stack(reg_t xsp, app_pc value)
 {
     bool res = true;
-    if (TEST(DRWRAP_SAFE_READ_RETADDR, global_flags)) {
+    if (TESTANY(DRWRAP_SAFE_READ_RETADDR, global_flags)) {
         DR_TRY_EXCEPT(
             dr_get_current_drcontext(), { *(app_pc *)xsp = value; }, { /* EXCEPT */
                                                                        res = false;
@@ -1904,7 +1905,7 @@ wrap_table_lookup_normalized_pc(app_pc pc)
 {
     wrap_entry_t *wrap = hashtable_lookup(&wrap_table, (void *)pc);
 #ifdef ARM
-    if (wrap == NULL && !TEST(0x1, (ptr_uint_t)pc)) {
+    if (wrap == NULL && !TESTANY(0x1, (ptr_uint_t)pc)) {
         wrap = hashtable_lookup(&wrap_table,
                                 (void *)dr_app_pc_as_jump_target(DR_ISA_ARM_THUMB, pc));
     }
@@ -1912,14 +1913,14 @@ wrap_table_lookup_normalized_pc(app_pc pc)
     return wrap;
 }
 
-/* assumes that if TEST(DRWRAP_NO_FRILLS, global_flags) then
+/* assumes that if TESTANY(DRWRAP_NO_FRILLS, global_flags) then
  * wrap_lock is held
  */
 static inline void
 drwrap_ensure_postcall(void *drcontext, per_thread_t *pt, wrap_entry_t *wrap,
                        drwrap_context_t *wrapcxt, app_pc decorated_pc)
 {
-    if (TEST(DRWRAP_NO_DYNAMIC_RETADDRS, wrap->flags)) {
+    if (TESTANY(DRWRAP_NO_DYNAMIC_RETADDRS, wrap->flags)) {
         /* i#0470: On a large multithreaded app, using shared memory here and especially
          * a lock (even an rwlock where the read path is always taken) causes noticeable
          * overhead.  The postcall_cache is often not enough.  Maybe a per-thread cache
@@ -1932,7 +1933,7 @@ drwrap_ensure_postcall(void *drcontext, per_thread_t *pt, wrap_entry_t *wrap,
     }
     app_pc retaddr = dr_app_pc_as_load_target(DR_ISA_ARM_THUMB, wrapcxt->retaddr);
     app_pc plain_pc = dr_app_pc_as_load_target(DR_ISA_ARM_THUMB, decorated_pc);
-    if (TEST(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
+    if (TESTANY(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
         NOTIFY(2, "DRWRAP_REPLACE_RETADDR: saving real retaddr as [%d] " PFX "\n",
                pt->wrap_level, retaddr);
         pt->retaddr[pt->wrap_level] = wrapcxt->retaddr; /* Original, not load tgt. */
@@ -1968,11 +1969,11 @@ drwrap_ensure_postcall(void *drcontext, per_thread_t *pt, wrap_entry_t *wrap,
          * release all locks.
          */
         dr_rwlock_write_unlock(post_call_rwlock);
-        if (!TEST(DRWRAP_NO_FRILLS, global_flags))
+        if (!TESTANY(DRWRAP_NO_FRILLS, global_flags))
             dr_recurlock_unlock(wrap_lock);
         drwrap_mark_retaddr_for_instru(drcontext, pt, decorated_pc, wrapcxt, enabled);
         /* if we come back, re-lookup */
-        if (!TEST(DRWRAP_NO_FRILLS, global_flags))
+        if (!TESTANY(DRWRAP_NO_FRILLS, global_flags))
             dr_recurlock_lock(wrap_lock);
         wrap = wrap_table_lookup_normalized_pc(plain_pc);
     } else
@@ -2009,7 +2010,7 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(IF_RISCV64_ELSE(reg_t ra, reg
     ASSERT(arg1 != NULL, "drwrap_in_callee: arg1 is NULL!");
     ASSERT(pt != NULL, "drwrap_in_callee: pt is NULL!");
 
-    if (TEST(DRWRAP_NO_FRILLS, global_flags)) {
+    if (TESTANY(DRWRAP_NO_FRILLS, global_flags)) {
         wrap = (wrap_entry_t *)arg1;
         pc = wrap->func;
     } else
@@ -2019,7 +2020,7 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(IF_RISCV64_ELSE(reg_t ra, reg
 
     app_pc retaddr =
         IF_X86_ELSE(get_retaddr_from_stack(xsp), (app_pc)IF_AARCHXX_ELSE(lr, ra));
-    if (wrap != NULL && TEST(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
+    if (wrap != NULL && TESTANY(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
         /* In case of a tailcall, the return address has already been replaced by
          * the sentinel in the stack, we need to retrieve the return address from the
          * outer level.
@@ -2035,7 +2036,7 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(IF_RISCV64_ELSE(reg_t ra, reg
 
     drwrap_in_callee_check_unwind(drcontext, pt, &mc);
 
-    if (!TEST(DRWRAP_NO_FRILLS, global_flags)) {
+    if (!TESTANY(DRWRAP_NO_FRILLS, global_flags)) {
         dr_recurlock_lock(wrap_lock);
         wrap = hashtable_lookup(&wrap_table, (void *)pc);
         ASSERT(wrap != NULL, "failed to find wrap info");
@@ -2049,7 +2050,7 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(IF_RISCV64_ELSE(reg_t ra, reg
     ASSERT(pt->wrap_level >= 0, "wrapping level corrupted");
     ASSERT(pt->wrap_level < MAX_WRAP_NESTING, "max wrapped nesting reached");
     if (pt->wrap_level >= MAX_WRAP_NESTING) {
-        if (!TEST(DRWRAP_NO_FRILLS, global_flags))
+        if (!TESTANY(DRWRAP_NO_FRILLS, global_flags))
             dr_recurlock_unlock(wrap_lock);
         wrapcxt.where_am_i = DRWRAP_WHERE_OUTSIDE_CALLBACK;
         return; /* we'll have to skip stuff */
@@ -2070,7 +2071,7 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(IF_RISCV64_ELSE(reg_t ra, reg
     }
 
     pt->last_wrap_func[pt->wrap_level] = decorated_pc;
-    if (TEST(DRWRAP_NO_FRILLS, global_flags))
+    if (TESTANY(DRWRAP_NO_FRILLS, global_flags))
         pt->last_wrap_entry[pt->wrap_level] = wrap;
     pt->app_esp[pt->wrap_level] = mc.xsp;
 #ifdef DEBUG
@@ -2083,7 +2084,7 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(IF_RISCV64_ELSE(reg_t ra, reg
     }
 #endif
 
-    if (TEST(DRWRAP_NO_FRILLS, global_flags)) {
+    if (TESTANY(DRWRAP_NO_FRILLS, global_flags)) {
         if (!wrap->enabled) {
             dr_recurlock_lock(wrap_lock);
             disabled_count++;
@@ -2140,7 +2141,7 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(IF_RISCV64_ELSE(reg_t ra, reg
         /* we won't decrement in post so decrement now.  we needed to increment
          * to set up for pt->skip, etc.
          */
-        if (!TEST(DRWRAP_NO_FRILLS, global_flags))
+        if (!TESTANY(DRWRAP_NO_FRILLS, global_flags))
             drwrap_free_user_data(drcontext, pt, pt->wrap_level);
         pt->wrap_level--;
     }
@@ -2188,7 +2189,7 @@ drwrap_after_callee_func(void *drcontext, per_thread_t *pt, dr_mcontext_t *mc, i
         return; /* skip the post-func cbs */
     }
 
-    if (TEST(DRWRAP_NO_FRILLS, global_flags)) {
+    if (TESTANY(DRWRAP_NO_FRILLS, global_flags)) {
         wrap = pt->last_wrap_entry[level];
     } else {
         dr_recurlock_lock(wrap_lock);
@@ -2201,20 +2202,20 @@ drwrap_after_callee_func(void *drcontext, per_thread_t *pt, dr_mcontext_t *mc, i
         /* handle drwrap_unwrap being called in post_cb */
         next = wrap->next;
         if (!wrap->enabled) {
-            if (TEST(DRWRAP_NO_FRILLS, global_flags))
+            if (TESTANY(DRWRAP_NO_FRILLS, global_flags))
                 dr_recurlock_lock(wrap_lock);
             disabled_count++;
-            if (TEST(DRWRAP_NO_FRILLS, global_flags))
+            if (TESTANY(DRWRAP_NO_FRILLS, global_flags))
                 dr_recurlock_unlock(wrap_lock);
             continue;
         }
-        if (TEST(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
+        if (TESTANY(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
             NOTIFY(2, "DRWRAP_REPLACE_RETADDR: setting real retaddr as [%d] " PFX "\n",
                    level, pt->retaddr[level]);
             dr_write_saved_reg(drcontext, SPILL_SLOT_REDIRECT_NATIVE_TGT,
                                (reg_t)pt->retaddr[level]);
         }
-        if (TEST(DRWRAP_NO_FRILLS, global_flags)) {
+        if (TESTANY(DRWRAP_NO_FRILLS, global_flags)) {
             user_data = pt->user_data_nofrills[level];
         } else {
             /* we may have to skip some entries */
@@ -2228,7 +2229,7 @@ drwrap_after_callee_func(void *drcontext, per_thread_t *pt, dr_mcontext_t *mc, i
         }
         if (pt->cleanup_only) {
             /* Skip post handlers. */
-        } else if (!TEST(DRWRAP_NO_FRILLS, global_flags) &&
+        } else if (!TESTANY(DRWRAP_NO_FRILLS, global_flags) &&
                    idx == pt->user_data_count[level]) {
             /* we didn't find it, it must be new, so had no pre => skip post
              * (even if only has post, to be consistent w/ timing)
@@ -2239,14 +2240,14 @@ drwrap_after_callee_func(void *drcontext, per_thread_t *pt, dr_mcontext_t *mc, i
                 wrapcxt.callconv = wrap->callconv;
                 (*wrap->post_cb)(&wrapcxt, user_data);
             } else if (!only_requested_unwind ||
-                       TEST(DRWRAP_UNWIND_ON_EXCEPTION, wrap->flags)) {
+                       TESTANY(DRWRAP_UNWIND_ON_EXCEPTION, wrap->flags)) {
                 /* don't double-call those that we presumably already called
                  * that had the flag set.  there might have been a longjmp and no
                  * exception (e.g., any longjmp on linux): but that's too bad:
                  * current impl doesn't handle that.
                  */
                 if (only_requested_unwind ||
-                    !TEST(DRWRAP_UNWIND_ON_EXCEPTION, wrap->flags)) {
+                    !TESTANY(DRWRAP_UNWIND_ON_EXCEPTION, wrap->flags)) {
                     (*wrap->post_cb)(NULL, user_data);
                 }
             } else
@@ -2263,7 +2264,7 @@ drwrap_after_callee_func(void *drcontext, per_thread_t *pt, dr_mcontext_t *mc, i
          */
         uint i;
         drvector_init(&toflush, 10, false /*no synch: wrapcxt-local*/, NULL);
-        if (TEST(DRWRAP_NO_FRILLS, global_flags))
+        if (TESTANY(DRWRAP_NO_FRILLS, global_flags))
             dr_recurlock_lock(wrap_lock);
         for (i = 0; i < HASHTABLE_SIZE(wrap_table.table_bits); i++) {
             hash_entry_t *he, *next_he;
@@ -2297,10 +2298,10 @@ drwrap_after_callee_func(void *drcontext, per_thread_t *pt, dr_mcontext_t *mc, i
         }
         do_flush = true;
         disabled_count = 0;
-        if (TEST(DRWRAP_NO_FRILLS, global_flags))
+        if (TESTANY(DRWRAP_NO_FRILLS, global_flags))
             dr_recurlock_unlock(wrap_lock);
     }
-    if (!TEST(DRWRAP_NO_FRILLS, global_flags))
+    if (!TESTANY(DRWRAP_NO_FRILLS, global_flags))
         dr_recurlock_unlock(wrap_lock);
     if (wrapcxt.mc_modified && !unwind)
         dr_set_mcontext(drcontext, wrapcxt.mc);
@@ -2316,7 +2317,7 @@ drwrap_after_callee_func(void *drcontext, per_thread_t *pt, dr_mcontext_t *mc, i
     }
 
     if (unwound_all) {
-        if (!TEST(DRWRAP_NO_FRILLS, global_flags))
+        if (!TESTANY(DRWRAP_NO_FRILLS, global_flags))
             drwrap_free_user_data(drcontext, pt, level);
 
         if (level == pt->wrap_level) {
@@ -2453,7 +2454,8 @@ drwrap_event_bb_insert_where(void *drcontext, void *tag, instrlist_t *bb, instr_
         dr_recurlock_lock(wrap_lock);
         wrap = hashtable_lookup(&wrap_table, (void *)pc);
         if (wrap != NULL) {
-            void *arg1 = TEST(DRWRAP_NO_FRILLS, global_flags) ? (void *)wrap : (void *)pc;
+            void *arg1 =
+                TESTANY(DRWRAP_NO_FRILLS, global_flags) ? (void *)wrap : (void *)pc;
             /* i#690: do not bother saving registers that should be scratch at
              * function entry, if requested by user.
              * I considered building a custom context switch but that would require
@@ -2461,7 +2463,7 @@ drwrap_event_bb_insert_where(void *drcontext, void *tag, instrlist_t *bb, instr_
              * stack alignment code; plus, skipping preservation was already
              * mostly in place for clean call auto opt.
              */
-            dr_cleancall_save_t flags = TEST(DRWRAP_FAST_CLEANCALLS, global_flags)
+            dr_cleancall_save_t flags = TESTANY(DRWRAP_FAST_CLEANCALLS, global_flags)
                 ? (DR_CLEANCALL_NOSAVE_FLAGS | DR_CLEANCALL_NOSAVE_XMM_NONPARAM)
                 : 0;
             flags |= DR_CLEANCALL_READS_APP_CONTEXT | DR_CLEANCALL_WRITES_APP_CONTEXT;
@@ -2502,7 +2504,7 @@ drwrap_event_bb_insert_where(void *drcontext, void *tag, instrlist_t *bb, instr_
         dr_recurlock_lock(wrap_lock);
         wrap = hashtable_lookup(&wrap_table, (void *)target);
         bool add_post = wrap != NULL && wrap->post_cb != NULL &&
-            !TEST(DRWRAP_REPLACE_RETADDR, wrap->flags);
+            !TESTANY(DRWRAP_REPLACE_RETADDR, wrap->flags);
         dr_recurlock_unlock(wrap_lock);
         if (add_post) {
             /* Add the pc-as-load-target (so *not* "pc"). */
@@ -2520,7 +2522,7 @@ static dr_emit_flags_t
 drwrap_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                        bool for_trace, bool translating, void *user_data)
 {
-    ASSERT(!TEST(DRWRAP_INVERT_CONTROL, global_flags),
+    ASSERT(!TESTANY(DRWRAP_INVERT_CONTROL, global_flags),
            "should not get here if DRWRAP_INVERT_CONTROL is set");
     return drwrap_event_bb_insert_where(drcontext, tag, bb, inst, inst, for_trace,
                                         translating, user_data, /*cleanup_only=*/false);
@@ -2631,7 +2633,7 @@ drwrap_wrap_ex(app_pc func,
     /* allow one side to be NULL (i#562) */
     if (func == NULL || (pre_func_cb == NULL && post_func_cb == NULL))
         return false;
-    if (TEST(DRWRAP_REPLACE_RETADDR, flags) && post_func_cb == NULL) {
+    if (TESTANY(DRWRAP_REPLACE_RETADDR, flags) && post_func_cb == NULL) {
         /* Nonsensical combination so we fail. */
         return false;
     }
@@ -2660,7 +2662,7 @@ drwrap_wrap_ex(app_pc func,
         for (e = wrap_cur; e != NULL; e = e->next) {
             if (e->pre_cb == pre_func_cb && e->post_cb == post_func_cb) {
                 /* no-frills requires 1st entry to be the live one */
-                if (!TEST(DRWRAP_NO_FRILLS, global_flags) || e == wrap_cur) {
+                if (!TESTANY(DRWRAP_NO_FRILLS, global_flags) || e == wrap_cur) {
                     /* matches existing request: re-enable if necessary */
                     e->enabled = true;
                     /* be sure to update all fields (xref drmem i#816) */
@@ -2670,14 +2672,14 @@ drwrap_wrap_ex(app_pc func,
                     dr_recurlock_unlock(wrap_lock);
                     return true;
                 } /* else continue */
-            } else if (TEST(DRWRAP_NO_FRILLS, global_flags) && e->enabled) {
+            } else if (TESTANY(DRWRAP_NO_FRILLS, global_flags) && e->enabled) {
                 /* more than one wrap of same address is not allowed */
                 dr_global_free(wrap_new, sizeof(*wrap_new));
                 dr_recurlock_unlock(wrap_lock);
                 return false;
             }
         }
-        if (TEST(DRWRAP_NO_FRILLS, global_flags)) {
+        if (TESTANY(DRWRAP_NO_FRILLS, global_flags)) {
             /* free whole chain of disabled entries */
             wrap_entry_free(wrap_cur);
             wrap_cur = NULL;
@@ -2844,7 +2846,7 @@ drwrap_in_callee_check_unwind(void *drcontext, per_thread_t *pt, dr_mcontext_t *
          */
         while (pt->wrap_level >= 0) {
             app_pc ret;
-            if (TEST(DRWRAP_SAFE_READ_RETADDR, global_flags)) {
+            if (TESTANY(DRWRAP_SAFE_READ_RETADDR, global_flags)) {
                 if (!fast_safe_read((void *)pt->app_esp[pt->wrap_level], sizeof(ret),
                                     &ret))
                     ret = NULL;

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -433,7 +433,7 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
     bool save_regs = true;
     reg_id_t reg1, reg2;
 #endif
-    bool is_64 = TEST(DRX_COUNTER_64BIT, flags);
+    bool is_64 = TESTANY(DRX_COUNTER_64BIT, flags);
     /* Requires drx_init(), where it didn't when first added. */
     if (drx_init_count == 0) {
         ASSERT(false, "drx_insert_counter_update requires drx_init");
@@ -457,7 +457,7 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
     }
 
     /* check whether we can add lock */
-    if (TEST(DRX_COUNTER_LOCK, flags)) {
+    if (TESTANY(DRX_COUNTER_LOCK, flags)) {
 #if defined(AARCHXX) || defined(RISCV64)
         /* TODO i#1551,i#1569,i#3544: implement for AArchXX/RISCV64. */
         ASSERT(false, "DRX_COUNTER_LOCK not implemented for AArchXX/RISCV64");
@@ -493,7 +493,7 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
         drcontext,
         OPND_CREATE_ABSMEM(addr, IF_X64_ELSE((is_64 ? OPSZ_8 : OPSZ_4), OPSZ_4)),
         OPND_CREATE_INT_32OR8(value));
-    if (TEST(DRX_COUNTER_LOCK, flags))
+    if (TESTANY(DRX_COUNTER_LOCK, flags))
         instr = LOCK(instr);
     /* On x86, for DRX_COUNTER_REL_ACQ, we don't need to do anything as the
      * ISA provides release-acquire semantics for regular stores and loads.
@@ -554,7 +554,7 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
      */
     instrlist_insert_mov_immed_ptrsz(drcontext, (ptr_int_t)addr, opnd_create_reg(reg1),
                                      ilist, where, NULL, NULL);
-    if (TEST(DRX_COUNTER_REL_ACQ, flags)) {
+    if (TESTANY(DRX_COUNTER_REL_ACQ, flags)) {
 #    ifdef AARCH64
         MINSERT(ilist, where,
                 INSTR_CREATE_ldar(drcontext, opnd_create_reg(reg2),
@@ -963,8 +963,8 @@ soft_kills_pre_SetInformationJobObject(void *drcontext, cls_soft_t *cls)
     if (class == JobObjectExtendedLimitInformation && sz >= sizeof(info) &&
         dr_safe_read((byte *)dr_syscall_get_param(drcontext, 2), sizeof(info), &info,
                      NULL)) {
-        if (TEST(JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-                 info.BasicLimitInformation.LimitFlags)) {
+        if (TESTANY(JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                    info.BasicLimitInformation.LimitFlags)) {
             /* Remove the kill-on-close flag from the syscall arg.
              * We restore in post-syscall in case app uses the memory
              * for something else.  There is of course a race where another
@@ -1037,7 +1037,7 @@ soft_kills_pre_DuplicateObject(void *drcontext, cls_soft_t *cls)
         /* We have to save jinfo b/c dup_src will be gone */
         cls->dup_jinfo = (job_info_t *)hashtable_lookup(&job_table, (void *)cls->dup_src);
         if (cls->dup_jinfo != NULL) {
-            if (TEST(DUPLICATE_CLOSE_SOURCE, cls->dup_options)) {
+            if (TESTANY(DUPLICATE_CLOSE_SOURCE, cls->dup_options)) {
                 /* "This occurs regardless of any error status returned"
                  * according to MSDN DuplicateHandle, and Nebbett.
                  * Thus, we act on this here, which avoids any handle value

--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -495,7 +495,7 @@ event_pre_syscall(void *drcontext, int sysnum)
                dr_get_thread_id(drcontext), flags, new_spec, old_spec);
         data->app_set_timer_param = new_spec;
         data->app_read_timer_param = old_spec;
-        if (TEST(TIMER_ABSTIME, flags)) {
+        if (TESTANY(TIMER_ABSTIME, flags)) {
             /* TODO i#7504: Handle TIMER_ABSTIME and SYS_timer_getoverrun. */
             NOTIFY(0, "Absolute time is not supported\n");
             data->app_read_timer_param = NULL; /* Don't scale in post. */
@@ -524,7 +524,7 @@ event_pre_syscall(void *drcontext, int sysnum)
                dr_get_thread_id(drcontext), flags, new_spec, old_spec);
         data->app_set_timer_param = new_spec;
         data->app_read_timer_param = old_spec;
-        if (TEST(TIMER_ABSTIME, flags)) {
+        if (TESTANY(TIMER_ABSTIME, flags)) {
             /* TODO i#7504: Handle TIMER_ABSTIME and SYS_timer_getoverrun. */
             NOTIFY(0, "Absolute time is not supported\n");
             data->app_read_timer_param = NULL; /* Don't scale in post. */
@@ -611,7 +611,7 @@ event_pre_syscall(void *drcontext, int sysnum)
         data->app_set_timer_param = spec;
         data->app_read_timer_param = remain;
         data->was_zero = false;
-        if (TEST(TIMER_ABSTIME, flags)) {
+        if (TESTANY(TIMER_ABSTIME, flags)) {
             /* TODO i#7504: Handle TIMER_ABSTIME and SYS_timer_getoverrun. */
             NOTIFY(0, "Absolute time is not supported\n");
             data->app_read_timer_param = NULL; /* Don't scale in post. */
@@ -643,7 +643,7 @@ event_pre_syscall(void *drcontext, int sysnum)
         data->app_set_timer_param = spec;
         data->app_read_timer_param = remain;
         data->was_zero = false;
-        if (TEST(TIMER_ABSTIME, flags)) {
+        if (TESTANY(TIMER_ABSTIME, flags)) {
             /* TODO i#7504: Handle TIMER_ABSTIME and SYS_timer_getoverrun. */
             NOTIFY(0, "Absolute time is not supported\n");
             data->app_read_timer_param = NULL; /* Don't scale in post. */

--- a/ext/drx/scatter_gather_aarch64.c
+++ b/ext/drx/scatter_gather_aarch64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2023 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.   All rights reserved.
  * Copyright (c) 2023-2024 Arm Limited.   All rights reserved.
  * **********************************************************/
 
@@ -1652,7 +1652,7 @@ loop_var_is_first_element(const scatter_gather_info_t *sg_info,
 
     /* loop_var should be 1-bit mask indicating the current element */
     DR_ASSERT(loop_var != 0);
-    DR_ASSERT(TEST(loop_var, governing_predicate));
+    DR_ASSERT(TESTANY(loop_var, governing_predicate));
 
     /* If any of the governing_predicate bits lower than the loop_var bit are set, then
      * this is not the first active element.

--- a/ext/ext_utils.h
+++ b/ext/ext_utils.h
@@ -48,7 +48,5 @@
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 /* check if any bit in mask is set in var */
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
-/* check if a single bit is set in var */
-#define TEST TESTANY
 
 #endif /* EXT_UTILS_H */

--- a/libutil/config.c
+++ b/libutil/config.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -924,7 +924,7 @@ is_parent_of_qualified_config_group(ConfigGroup *config)
     if (run_under == NULL)
         return FALSE;
 
-    return TEST(RUNUNDER_COMMANDLINE_DISPATCH, _wtoi(run_under));
+    return TESTANY(RUNUNDER_COMMANDLINE_DISPATCH, _wtoi(run_under));
 }
 
 ConfigGroup *
@@ -1168,7 +1168,7 @@ set_autoinjection_ex(BOOL inject, DWORD flags, const WCHAR *blocklist,
     if (NULL != current_list)
         wcsncpy(current_list, curlist, maxchars);
 
-    if (using_system32 && TEST(APPINIT_SYS32_CLEAR_OTHERS, flags)) {
+    if (using_system32 && TESTANY(APPINIT_SYS32_CLEAR_OTHERS, flags)) {
         /* if we're using system32, and the clear flag is set, clear it */
         curlist[0] = L'\0';
     }
@@ -1254,36 +1254,36 @@ set_autoinjection_ex(BOOL inject, DWORD flags, const WCHAR *blocklist,
         } else {
             /* force overwrite if someone cared enough to set one of these */
             force_overwrite =
-                TEST((APPINIT_FORCE_TO_FRONT | APPINIT_FORCE_TO_BACK), flags);
+                TESTANY((APPINIT_FORCE_TO_FRONT | APPINIT_FORCE_TO_BACK), flags);
         }
         /* always overwrite if asked to */
-        force_overwrite = force_overwrite | TEST(APPINIT_OVERWRITE, flags);
+        force_overwrite = force_overwrite | TESTANY(APPINIT_OVERWRITE, flags);
 
-        /* add !TEST(APPINIT_FORCE_TO_BACK, flags) so that we favor adding
+        /* add !TESTANY(APPINIT_FORCE_TO_BACK, flags) so that we favor adding
          *  to the front if neither are set. */
         list = add_to_file_list(list, preinject_name, TRUE,
-                                TEST(APPINIT_FORCE_TO_FRONT, flags) ||
-                                    !TEST(APPINIT_FORCE_TO_BACK, flags),
+                                TESTANY(APPINIT_FORCE_TO_FRONT, flags) ||
+                                    !TESTANY(APPINIT_FORCE_TO_BACK, flags),
                                 force_overwrite, APPINIT_SEPARATOR_CHAR);
     } else {
         remove_from_file_list(list, preinject_name, APPINIT_SEPARATOR_CHAR);
     }
 
-    if (TEST(APPINIT_USE_ALLOWLIST, flags)) {
+    if (TESTANY(APPINIT_USE_ALLOWLIST, flags)) {
         if (NULL == allowlist)
             res = ERROR_INVALID_PARAMETER;
         else
-            list_ok_ =
-                allowlist_filter(list, allowlist, TEST(APPINIT_CHECK_LISTS_ONLY, flags),
-                                 APPINIT_SEPARATOR_CHAR);
-    } else if (TEST(APPINIT_USE_BLOCKLIST, flags)) {
+            list_ok_ = allowlist_filter(list, allowlist,
+                                        TESTANY(APPINIT_CHECK_LISTS_ONLY, flags),
+                                        APPINIT_SEPARATOR_CHAR);
+    } else if (TESTANY(APPINIT_USE_BLOCKLIST, flags)) {
         /* else if since allowlist subsumes blocklist */
         if (NULL == blocklist)
             res = ERROR_INVALID_PARAMETER;
         else
-            list_ok_ =
-                blocklist_filter(list, blocklist, TEST(APPINIT_CHECK_LISTS_ONLY, flags),
-                                 APPINIT_SEPARATOR_CHAR);
+            list_ok_ = blocklist_filter(list, blocklist,
+                                        TESTANY(APPINIT_CHECK_LISTS_ONLY, flags),
+                                        APPINIT_SEPARATOR_CHAR);
     }
 
     if (list_error != NULL && !list_ok_)
@@ -1292,14 +1292,14 @@ set_autoinjection_ex(BOOL inject, DWORD flags, const WCHAR *blocklist,
     if (res == ERROR_INVALID_PARAMETER)
         return res;
 
-    if (!list_ok_ && TEST(APPINIT_BAIL_ON_LIST_VIOLATION, flags))
+    if (!list_ok_ && TESTANY(APPINIT_BAIL_ON_LIST_VIOLATION, flags))
         remove_from_file_list(list, preinject_name, APPINIT_SEPARATOR_CHAR);
 
     /* now, system32 flag checks */
     if (using_system32) {
 
         /* not yet supported */
-        if (TEST(APPINIT_SYS32_USE_LENGTH_WORKAROUND, flags))
+        if (TESTANY(APPINIT_SYS32_USE_LENGTH_WORKAROUND, flags))
             return ERROR_INVALID_PARAMETER;
 
         if (wcslen(list) > APPINIT_SYSTEM32_LENGTH_LIMIT) {
@@ -1307,11 +1307,11 @@ set_autoinjection_ex(BOOL inject, DWORD flags, const WCHAR *blocklist,
             if (list_error != NULL)
                 *list_error = ERROR_LENGTH_VIOLATION;
 
-            if (TEST(APPINIT_SYS32_FAIL_ON_LENGTH_ERROR, flags)) {
+            if (TESTANY(APPINIT_SYS32_FAIL_ON_LENGTH_ERROR, flags)) {
                 remove_from_file_list(list, preinject_name, APPINIT_SEPARATOR_CHAR);
             } else {
                 /* truncate, if the flags specify it. */
-                if (TEST(APPINIT_SYS32_TRUNCATE, flags)) {
+                if (TESTANY(APPINIT_SYS32_TRUNCATE, flags)) {
                     list[APPINIT_SYSTEM32_LENGTH_LIMIT] = L'\0';
                 }
             }

--- a/libutil/detach.c
+++ b/libutil/detach.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -484,12 +484,12 @@ create_remote_thread(HANDLE hProc, PTHREAD_START_ROUTINE pfnThreadRtn, void *arg
     HANDLE hThread = NULL;
     if (remote_stack != NULL)
         *remote_stack = NULL;
-    if (TEST(CREATE_REMOTE_THREAD_USE_NT, flags)) {
+    if (TESTANY(CREATE_REMOTE_THREAD_USE_NT, flags)) {
         /* XXX - should we allow the caller to specify the stack sizes?
          * we already just use defaults if we're using CreateRemoteThread */
         hThread = nt_create_thread(hProc, pfnThreadRtn, arg, arg_buf, arg_buf_size,
                                    STACK_RESERVE, STACK_COMMIT, false, NULL,
-                                   TEST(CREATE_REMOTE_THREAD_TARGET_API, flags),
+                                   TESTANY(CREATE_REMOTE_THREAD_TARGET_API, flags),
                                    false /* !64-bit */, remote_stack);
     } else {
         DO_ASSERT(false && "not tested (not currently used)");
@@ -609,7 +609,7 @@ nudge_dr(process_id_t pid, BOOL allow_upgraded_perms, DWORD timeout_ms,
          * As such we are left with two options: free the app stack here (nudgee free) or
          * have the nudge thread creator free the app stack (nudger free). We use
          * nudge flags to specify which we are using. */
-        if (TEST(NUDGE_NUDGER_FREE_STACK, nudge_arg->flags) && remote_stack != NULL) {
+        if (TESTANY(NUDGE_NUDGER_FREE_STACK, nudge_arg->flags) && remote_stack != NULL) {
             VirtualFreeEx(hProcess, remote_stack, 0, MEM_RELEASE);
         }
     }

--- a/libutil/dr_frontend_unix.c
+++ b/libutil/dr_frontend_unix.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -101,7 +101,7 @@ drfront_access(const char *fname, drfront_access_mode_t mode, DR_PARAM_OUT bool 
          * and +x access to any file with at least one +x bit set.  This is
          * usually true but not always.
          */
-        if (TEST(DRFRONT_EXEC, mode)) {
+        if (TESTANY(DRFRONT_EXEC, mode)) {
             *ret = TESTANY((DRFRONT_EXEC << 6) | (DRFRONT_EXEC << 3) | DRFRONT_EXEC,
                            st.st_mode);
         } else
@@ -114,7 +114,7 @@ drfront_access(const char *fname, drfront_access_mode_t mode, DR_PARAM_OUT bool 
         *ret = TESTALL(mode, st.st_mode);
     }
 
-    if (*ret && S_ISDIR(st.st_mode) && TEST(DRFRONT_WRITE, mode)) {
+    if (*ret && S_ISDIR(st.st_mode) && TESTANY(DRFRONT_WRITE, mode)) {
         /* We use an actual write try, to avoid failing on a read-only filesystem
          * (DrMi#1857).
          */

--- a/libutil/dr_frontend_win.c
+++ b/libutil/dr_frontend_win.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -99,9 +99,9 @@ drfront_access(const char *fname, drfront_access_mode_t mode, DR_PARAM_OUT bool 
     }
 
     /* Translate drfront_access_mode_t to msdn _waccess mode */
-    if (TEST(mode, DRFRONT_WRITE))
+    if (TESTANY(mode, DRFRONT_WRITE))
         msdn_mode |= 02;
-    if (TEST(mode, DRFRONT_READ))
+    if (TESTANY(mode, DRFRONT_READ))
         msdn_mode |= 04;
 
     r = _waccess(wfname, msdn_mode);
@@ -111,10 +111,10 @@ drfront_access(const char *fname, drfront_access_mode_t mode, DR_PARAM_OUT bool 
         if (GetLastError() == EACCES)
             return DRFRONT_SUCCESS;
         return DRFRONT_ERROR;
-    } else if (TEST(DRFRONT_WRITE, mode)) {
+    } else if (TESTANY(DRFRONT_WRITE, mode)) {
         DWORD file_attrs = GetFileAttributes(wfname);
         if (file_attrs != INVALID_FILE_ATTRIBUTES &&
-            TEST(file_attrs, FILE_ATTRIBUTE_DIRECTORY)) {
+            TESTANY(file_attrs, FILE_ATTRIBUTE_DIRECTORY)) {
             /* We use an actual write try, to avoid failing on a read-only filesystem
              * (DrMi#1857).
              */
@@ -680,7 +680,7 @@ drfront_dir_exists(const char *path, DR_PARAM_OUT bool *is_dir)
         *is_dir = false;
         return DRFRONT_ERROR_INVALID_PATH;
     } else {
-        if (TEST(file_attrs, FILE_ATTRIBUTE_DIRECTORY))
+        if (TESTANY(file_attrs, FILE_ATTRIBUTE_DIRECTORY))
             *is_dir = true;
         else
             *is_dir = false;

--- a/libutil/processes.c
+++ b/libutil/processes.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -285,11 +285,11 @@ under_dynamorio_ex(process_id_t ProcessID, DWORD *build_num)
         }
         /* NOTE - profile build can be combined with DEBUG or RELEASE so we check it
          * first.  Perhaps we should just get rid of the notion of profile builds. */
-        if (TEST(DR_MARKER_PROFILE_BUILD, marker.flags))
+        if (TESTANY(DR_MARKER_PROFILE_BUILD, marker.flags))
             return DLL_PROFILE;
-        if (TEST(DR_MARKER_RELEASE_BUILD, marker.flags))
+        if (TESTANY(DR_MARKER_RELEASE_BUILD, marker.flags))
             return DLL_RELEASE;
-        if (TEST(DR_MARKER_DEBUG_BUILD, marker.flags))
+        if (TESTANY(DR_MARKER_DEBUG_BUILD, marker.flags))
             return DLL_DEBUG;
     }
     /* should never get here */

--- a/libutil/utils.c
+++ b/libutil/utils.c
@@ -1981,8 +1981,8 @@ run_canary_test_ex(FILE *file, /* INOUT */ CANARY_INFO *info, const WCHAR *scrat
 
 #        define DO_RUN(run_flag, core_ops, canary_options, inject, run_name, test_type) \
             do {                                                                        \
-                if (TEST(run_flag, info->run_flags)) {                                  \
-                    WCHAR *canary_ops = TEST(run_flag, info->fault_run)                 \
+                if (TESTANY(run_flag, info->run_flags)) {                               \
+                    WCHAR *canary_ops = TESTANY(run_flag, info->fault_run)              \
                         ? info->canary_fault_args                                       \
                         : canary_options;                                               \
                     for (i = 0; i < num_canary_processes; i++) {                        \

--- a/suite/tests/api/detach_state_shared.c
+++ b/suite/tests/api/detach_state_shared.c
@@ -339,7 +339,7 @@ check_gpr_vals(ptr_uint_t *xsp, uint gpr_check_mask)
 #        endif
 #        define CHECK_GPR(name, num, reference_value)                       \
             do {                                                            \
-                if (TEST(1 << (num), gpr_check_mask))                       \
+                if (TESTANY(1 << (num), gpr_check_mask))                    \
                     check_gpr_value(name, *(xsp + (num)), reference_value); \
             } while (0)
     CHECK_GPR("r15", 15, MAKE_HEX_C(R15_BASE()));
@@ -363,7 +363,7 @@ check_gpr_vals(ptr_uint_t *xsp, uint gpr_check_mask)
      * AARCH64
      */
 
-    if (TEST(1, gpr_check_mask)) {
+    if (TESTANY(1, gpr_check_mask)) {
         /* Unfortunately, since it's RISC, we have to use x0 in the asm loop.
          * Its value could be either 0x1 or &sideline_exit.
          */
@@ -371,7 +371,7 @@ check_gpr_vals(ptr_uint_t *xsp, uint gpr_check_mask)
     }
 #        define CHECK_GPR(name, num, reference_value)                       \
             do {                                                            \
-                if (TEST(1 << (num), gpr_check_mask))                       \
+                if (TESTANY(1 << (num), gpr_check_mask))                    \
                     check_gpr_value(name, *(xsp + (num)), reference_value); \
             } while (0)
     CHECK_GPR("x1", 1, MAKE_HEX_C(X1_BASE()));

--- a/suite/tests/api/ir_aarch64_v80.c
+++ b/suite/tests/api/ir_aarch64_v80.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2025-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2024 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -210,23 +210,23 @@ TEST_INSTR(mrs)
             );
             switch (systemreg[i]) {
             case DR_REG_NZCV:
-                EXPECT_TRUE(TEST(EFLAGS_READ_NZCV,
-                                 instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
-                EXPECT_FALSE(TEST(EFLAGS_WRITE_NZCV,
-                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                    instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_FALSE(TESTANY(EFLAGS_WRITE_NZCV,
+                                     instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
                 break;
             case DR_REG_RNDR:
             case DR_REG_RNDRRS:
-                EXPECT_FALSE(TEST(EFLAGS_READ_NZCV,
-                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
-                EXPECT_TRUE(TEST(EFLAGS_WRITE_NZCV,
-                                 instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_FALSE(TESTANY(EFLAGS_READ_NZCV,
+                                     instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                    instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
                 break;
             default:
-                EXPECT_FALSE(TEST(EFLAGS_READ_NZCV,
-                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
-                EXPECT_FALSE(TEST(EFLAGS_WRITE_NZCV,
-                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_FALSE(TESTANY(EFLAGS_READ_NZCV,
+                                     instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_FALSE(TESTANY(EFLAGS_WRITE_NZCV,
+                                     instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
             }
         });
 }
@@ -293,16 +293,16 @@ TEST_INSTR(msr)
             );
             switch (systemreg[i]) {
             case DR_REG_NZCV:
-                EXPECT_FALSE(TEST(EFLAGS_READ_NZCV,
-                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
-                EXPECT_TRUE(TEST(EFLAGS_WRITE_NZCV,
-                                 instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_FALSE(TESTANY(EFLAGS_READ_NZCV,
+                                     instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                    instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
                 break;
             default:
-                EXPECT_FALSE(TEST(EFLAGS_READ_NZCV,
-                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
-                EXPECT_FALSE(TEST(EFLAGS_WRITE_NZCV,
-                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_FALSE(TESTANY(EFLAGS_READ_NZCV,
+                                     instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_FALSE(TESTANY(EFLAGS_WRITE_NZCV,
+                                     instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
             }
         });
 
@@ -322,10 +322,10 @@ TEST_INSTR(msr)
                                "msr    %spsel $0x02", "msr    %ssbs $0x03",
                                "msr    %dit $0x04", "msr    %tco $0x05",
                                "msr    %daifset $0x06", "msr    %daifclr $0x07");
-            EXPECT_FALSE(TEST(EFLAGS_READ_NZCV,
-                              instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
-            EXPECT_FALSE(TEST(EFLAGS_WRITE_NZCV,
-                              instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+            EXPECT_FALSE(TESTANY(EFLAGS_READ_NZCV,
+                                 instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+            EXPECT_FALSE(TESTANY(EFLAGS_WRITE_NZCV,
+                                 instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
         });
 }
 
@@ -501,10 +501,10 @@ TEST_INSTR(ccmp)
                                "ccmp   %w24 $0x18 $0x0c gt", "ccmp   %w26 $0x1a $0x0d le",
                                "ccmp   %w28 $0x1c $0x0e al",
                                "ccmp   %w30 $0x1e $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing CCMP <Xn>, #<imm>, #<nzcv>, <cond> */
@@ -523,10 +523,10 @@ TEST_INSTR(ccmp)
                                "ccmp   %x24 $0x18 $0x0c gt", "ccmp   %x26 $0x1a $0x0d le",
                                "ccmp   %x28 $0x1c $0x0e al",
                                "ccmp   %x30 $0x1e $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing CCMP <Wn>, <Wm>, #<nzcv>, <cond> */
@@ -544,10 +544,10 @@ TEST_INSTR(ccmp)
                                "ccmp   %w20 %w21 $0x0a ge", "ccmp   %w22 %w23 $0x0b lt",
                                "ccmp   %w24 %w25 $0x0c gt", "ccmp   %w26 %w27 $0x0d le",
                                "ccmp   %w28 %w29 $0x0e al", "ccmp   %w30 %wzr $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing CCMP <Xn>, <Xm>, #<nzcv>, <cond> */
@@ -565,10 +565,10 @@ TEST_INSTR(ccmp)
                                "ccmp   %x20 %x21 $0x0a ge", "ccmp   %x22 %x23 $0x0b lt",
                                "ccmp   %x24 %x25 $0x0c gt", "ccmp   %x26 %x27 $0x0d le",
                                "ccmp   %x28 %x29 $0x0e al", "ccmp   %x30 %xzr $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 }
 
@@ -590,10 +590,10 @@ TEST_INSTR(ccmn)
                                "ccmn   %w24 $0x18 $0x0c gt", "ccmn   %w26 $0x1a $0x0d le",
                                "ccmn   %w28 $0x1c $0x0e al",
                                "ccmn   %w30 $0x1e $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing CCMN <Xn>, #<imm>, #<nzcv>, <cond> */
@@ -612,10 +612,10 @@ TEST_INSTR(ccmn)
                                "ccmn   %x24 $0x18 $0x0c gt", "ccmn   %x26 $0x1a $0x0d le",
                                "ccmn   %x28 $0x1c $0x0e al",
                                "ccmn   %x30 $0x1e $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing CCMN <Wn>, <Wm>, #<nzcv>, <cond> */
@@ -633,10 +633,10 @@ TEST_INSTR(ccmn)
                                "ccmn   %w20 %w21 $0x0a ge", "ccmn   %w22 %w23 $0x0b lt",
                                "ccmn   %w24 %w25 $0x0c gt", "ccmn   %w26 %w27 $0x0d le",
                                "ccmn   %w28 %w29 $0x0e al", "ccmn   %w30 %wzr $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing CCMN <Xn>, <Xm>, #<nzcv>, <cond> */
@@ -654,10 +654,10 @@ TEST_INSTR(ccmn)
                                "ccmn   %x20 %x21 $0x0a ge", "ccmn   %x22 %x23 $0x0b lt",
                                "ccmn   %x24 %x25 $0x0c gt", "ccmn   %x26 %x27 $0x0d le",
                                "ccmn   %x28 %x29 $0x0e al", "ccmn   %x30 %xzr $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 }
 

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2022-2024 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -2477,10 +2477,10 @@ TEST_INSTR(fccmp)
                                "fccmp  %d20 %d21 $0x0a ge", "fccmp  %d22 %d23 $0x0b lt",
                                "fccmp  %d24 %d25 $0x0c gt", "fccmp  %d26 %d27 $0x0d le",
                                "fccmp  %d28 %d29 $0x0e al", "fccmp  %d30 %d31 $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing FCCMP   <Hn>, <Hm>, #<imm>, <cond> */
@@ -2498,10 +2498,10 @@ TEST_INSTR(fccmp)
                                "fccmp  %h20 %h21 $0x0a ge", "fccmp  %h22 %h23 $0x0b lt",
                                "fccmp  %h24 %h25 $0x0c gt", "fccmp  %h26 %h27 $0x0d le",
                                "fccmp  %h28 %h29 $0x0e al", "fccmp  %h30 %h31 $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing FCCMP   <Sn>, <Sm>, #<imm>, <cond> */
@@ -2519,10 +2519,10 @@ TEST_INSTR(fccmp)
                                "fccmp  %s20 %s21 $0x0a ge", "fccmp  %s22 %s23 $0x0b lt",
                                "fccmp  %s24 %s25 $0x0c gt", "fccmp  %s26 %s27 $0x0d le",
                                "fccmp  %s28 %s29 $0x0e al", "fccmp  %s30 %s31 $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 }
 
@@ -2543,10 +2543,10 @@ TEST_INSTR(fccmpe)
                                "fccmpe %d20 %d21 $0x0a ge", "fccmpe %d22 %d23 $0x0b lt",
                                "fccmpe %d24 %d25 $0x0c gt", "fccmpe %d26 %d27 $0x0d le",
                                "fccmpe %d28 %d29 $0x0e al", "fccmpe %d30 %d31 $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing FCCMPE  <Hn>, <Hm>, #<imm>, <cond> */
@@ -2564,10 +2564,10 @@ TEST_INSTR(fccmpe)
                                "fccmpe %h20 %h21 $0x0a ge", "fccmpe %h22 %h23 $0x0b lt",
                                "fccmpe %h24 %h25 $0x0c gt", "fccmpe %h26 %h27 $0x0d le",
                                "fccmpe %h28 %h29 $0x0e al", "fccmpe %h30 %h31 $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing FCCMPE  <Sn>, <Sm>, #<imm>, <cond> */
@@ -2585,10 +2585,10 @@ TEST_INSTR(fccmpe)
                                "fccmpe %s20 %s21 $0x0a ge", "fccmpe %s22 %s23 $0x0b lt",
                                "fccmpe %s24 %s25 $0x0c gt", "fccmpe %s26 %s27 $0x0d le",
                                "fccmpe %s28 %s29 $0x0e al", "fccmpe %s30 %s31 $0x0f nv");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_TRUE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 }
 
@@ -2785,10 +2785,10 @@ TEST_INSTR(fcsel)
                 "fcsel  %d21 %d11 ge -> %d20", "fcsel  %d23 %d9 lt -> %d22",
                 "fcsel  %d25 %d7 gt -> %d24", "fcsel  %d27 %d5 le -> %d26",
                 "fcsel  %d29 %d3 al -> %d28", "fcsel  %d31 %d1 nv -> %d30");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_FALSE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_FALSE(TESTANY(EFLAGS_WRITE_NZCV,
+                                 instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing FCSEL   <Sd>, <Sn>, <Sm>, <cond> */
@@ -2806,10 +2806,10 @@ TEST_INSTR(fcsel)
                 "fcsel  %s21 %s11 ge -> %s20", "fcsel  %s23 %s9 lt -> %s22",
                 "fcsel  %s25 %s7 gt -> %s24", "fcsel  %s27 %s5 le -> %s26",
                 "fcsel  %s29 %s3 al -> %s28", "fcsel  %s31 %s1 nv -> %s30");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_FALSE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_FALSE(TESTANY(EFLAGS_WRITE_NZCV,
+                                 instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 
     /* Testing FCSEL   <Hd>, <Hn>, <Hm>, <cond> */
@@ -2827,10 +2827,10 @@ TEST_INSTR(fcsel)
                 "fcsel  %h21 %h11 ge -> %h20", "fcsel  %h23 %h9 lt -> %h22",
                 "fcsel  %h25 %h7 gt -> %h24", "fcsel  %h27 %h5 le -> %h26",
                 "fcsel  %h29 %h3 al -> %h28", "fcsel  %h31 %h1 nv -> %h30");
-            EXPECT_TRUE(
-                TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
-            EXPECT_FALSE(
-                TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                                instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
+            EXPECT_FALSE(TESTANY(EFLAGS_WRITE_NZCV,
+                                 instr_get_arith_flags(instr, DR_QUERY_DEFAULT)));
         });
 }
 

--- a/suite/tests/api/ir_aarch64_v85.c
+++ b/suite/tests/api/ir_aarch64_v85.c
@@ -768,10 +768,10 @@ TEST_INSTR(axflag)
     /* Testing AXFLAG */
     TEST_LOOP_EXPECT(axflag, 1, INSTR_CREATE_axflag(dc), {
         EXPECT_DISASSEMBLY("axflag");
-        EXPECT_TRUE(
-            TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
-        EXPECT_TRUE(
-            TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+        EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                            instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+        EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                            instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
     });
 }
 
@@ -780,10 +780,10 @@ TEST_INSTR(xaflag)
     /* Testing XAFLAG */
     TEST_LOOP_EXPECT(xaflag, 1, INSTR_CREATE_xaflag(dc), {
         EXPECT_DISASSEMBLY("xaflag");
-        EXPECT_TRUE(
-            TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
-        EXPECT_TRUE(
-            TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+        EXPECT_TRUE(TESTANY(EFLAGS_READ_NZCV,
+                            instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+        EXPECT_TRUE(TESTANY(EFLAGS_WRITE_NZCV,
+                            instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
     });
 }
 

--- a/suite/tests/api/ir_arm.c
+++ b/suite/tests/api/ir_arm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -182,12 +182,12 @@ test_flags(void *dc)
     instr_t *inst;
     inst = INSTR_CREATE_lsls(dc, opnd_create_reg(DR_REG_R0), opnd_create_reg(DR_REG_R1),
                              OPND_CREATE_INT(4));
-    ASSERT(!TEST(EFLAGS_WRITE_V, instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)));
+    ASSERT(!TESTANY(EFLAGS_WRITE_V, instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)));
     instr_destroy(dc, inst);
 
     inst = INSTR_CREATE_movs(dc, opnd_create_reg(DR_REG_R0), OPND_CREATE_INT(4));
-    ASSERT(TEST(EFLAGS_READ_C, instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)));
-    ASSERT(!TEST(EFLAGS_WRITE_V, instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)));
+    ASSERT(TESTANY(EFLAGS_READ_C, instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)));
+    ASSERT(!TESTANY(EFLAGS_WRITE_V, instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)));
     ASSERT(TESTALL(EFLAGS_WRITE_N | EFLAGS_WRITE_Z | EFLAGS_WRITE_C,
                    instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)));
     instr_destroy(dc, inst);

--- a/suite/tests/api/ir_x86_all_opc.h
+++ b/suite/tests/api/ir_x86_all_opc.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -81,11 +81,11 @@ orig = instrlist_first(ilist);
 #endif
 #define OPCODE(name, opc, icnm, flags, ...)                                              \
     do {                                                                                 \
-        if (!TEST(IF_X64_ELSE(X86_ONLY, X64_ONLY), flags) && len_##name != 0) {          \
+        if (!TESTANY(IF_X64_ELSE(X86_ONLY, X64_ONLY), flags) && len_##name != 0) {       \
             instr_reset(dc, instr);                                                      \
             next_pc = decode(dc, pc, instr);                                             \
             ASSERT(next_pc != NULL);                                                     \
-            if (TEST(VERIFY_EVEX, flags))                                                \
+            if (TESTANY(VERIFY_EVEX, flags))                                             \
                 ASSERT(*pc == FIRST_EVEX_BYTE);                                          \
             ASSERT((next_pc - pc) == decode_sizeof(dc, pc, NULL _IF_X64(NULL)));         \
             ASSERT((next_pc - pc) == len_##name);                                        \
@@ -93,10 +93,12 @@ orig = instrlist_first(ilist);
             /* ensure operands all came out the same (xref i#1232) */                    \
             ASSERT(instr_same(orig, instr) ||                                            \
                    instr_num_srcs(orig) > 0 && opnd_is_instr(instr_get_target(orig)));   \
-            ASSERT(BOOLS_MATCH(TEST(DR_INSTR_CATEGORY_LOAD, instr_get_category(instr)),  \
-                               instr_reads_memory(instr)));                              \
-            ASSERT(BOOLS_MATCH(TEST(DR_INSTR_CATEGORY_STORE, instr_get_category(instr)), \
-                               instr_writes_memory(instr)));                             \
+            ASSERT(                                                                      \
+                BOOLS_MATCH(TESTANY(DR_INSTR_CATEGORY_LOAD, instr_get_category(instr)),  \
+                            instr_reads_memory(instr)));                                 \
+            ASSERT(                                                                      \
+                BOOLS_MATCH(TESTANY(DR_INSTR_CATEGORY_STORE, instr_get_category(instr)), \
+                            instr_writes_memory(instr)));                                \
             EXTRA_IN_DEBUG(dc, pc, instr); /* Clobbers "instr". */                       \
             pc = next_pc;                                                                \
             orig = instr_get_next(orig);                                                 \

--- a/suite/tests/client-interface/alloc.dll.c
+++ b/suite/tests/client-interface/alloc.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -66,7 +66,7 @@ write_array(char *array)
 static uint
 get_os_mem_prot(uint prot)
 {
-    if (add_exec && TEST(DR_MEMPROT_READ, prot))
+    if (add_exec && TESTANY(DR_MEMPROT_READ, prot))
         return (prot | DR_MEMPROT_EXEC);
     return prot;
 }
@@ -742,7 +742,7 @@ dr_init(client_id_t id)
     int res = personality(0xffffffff);
     if (res == -1)
         fprintf(stderr, "Error: fail to get personality\n");
-    else if (TEST(READ_IMPLIES_EXEC, res))
+    else if (TESTANY(READ_IMPLIES_EXEC, res))
         add_exec = true;
 #endif
 

--- a/suite/tests/client-interface/drbbdup-emul-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-emul-test.dll.c
@@ -177,8 +177,8 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
              * XXX: We could try to pass a flag: but drbbdup won't let
              * us pass from app2app; we'd need TLS or a global.
              */
-            CHECK(!TEST(DR_EMULATE_REST_OF_BLOCK, emul_info->flags) ||
-                      TEST(DR_EMULATE_INSTR_ONLY, emul_info->flags),
+            CHECK(!TESTANY(DR_EMULATE_REST_OF_BLOCK, emul_info->flags) ||
+                      TESTANY(DR_EMULATE_INSTR_ONLY, emul_info->flags),
                   "DR_EMULATE_REST_OF_BLOCK leaked through!");
         }
     }

--- a/suite/tests/client-interface/drsyms-test.dll.cpp
+++ b/suite/tests/client-interface/drsyms-test.dll.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -338,7 +338,7 @@ lookup_exe_syms(void)
     ASSERT(r == DRSYM_ERROR_INVALID_PARAMETER);
 
 #ifdef WINDOWS
-    if (TEST(DRSYM_PDB, debug_kind)) { /* else NYI */
+    if (TESTANY(DRSYM_PDB, debug_kind)) { /* else NYI */
         lookup_overloads(exe_path);
         lookup_templates(exe_path);
         /* Test drsym_get_type_by_name function */
@@ -736,7 +736,7 @@ enum_sym_ex_cb(drsym_info_t *out, drsym_error_t status, void *data)
                || syms_found->flags_expected == DRSYM_LEAVE_MANGLED ||
                (out->flags == (syms_found->flags_expected & ~DRSYM_DEMANGLE_FULL))));
 
-    if (TEST(DRSYM_PDB, out->debug_kind)) { /* else types NYI */
+    if (TESTANY(DRSYM_PDB, out->debug_kind)) { /* else types NYI */
         static char buf[4096];
         drsym_type_t *type;
         drsym_error_t r = drsym_get_type(syms_found->dll_path, out->start_offs, 1, buf,
@@ -820,7 +820,7 @@ enum_syms_with_flags(const char *dll_path, const char **syms_expected, uint flag
     }
 
 #ifdef WINDOWS
-    if (TEST(DRSYM_PDB, debug_kind)) {
+    if (TESTANY(DRSYM_PDB, debug_kind)) {
         /* drsym_search_symbols should find the same symbols with the short
          * mangling, regardless of the flags used by the previous enumerations.
          */
@@ -864,17 +864,18 @@ check_enumerate_dll_syms(const char *dll_path)
     ASSERT(r == DRSYM_SUCCESS);
 
     dr_fprintf(STDERR, "enumerating with DRSYM_LEAVE_MANGLED\n");
-    enum_syms_with_flags(
-        dll_path, TEST(DRSYM_PDB, debug_kind) ? dll_syms_mangled_pdb : dll_syms_mangled,
-        DRSYM_LEAVE_MANGLED);
+    enum_syms_with_flags(dll_path,
+                         TESTANY(DRSYM_PDB, debug_kind) ? dll_syms_mangled_pdb
+                                                        : dll_syms_mangled,
+                         DRSYM_LEAVE_MANGLED);
     dr_fprintf(STDERR, "enumerating with DRSYM_DEMANGLE\n");
     enum_syms_with_flags(
-        dll_path, TEST(DRSYM_PDB, debug_kind) ? dll_syms_short_pdb : dll_syms_short,
+        dll_path, TESTANY(DRSYM_PDB, debug_kind) ? dll_syms_short_pdb : dll_syms_short,
         DRSYM_DEMANGLE);
     dr_fprintf(STDERR, "enumerating with DRSYM_DEMANGLE_FULL\n");
-    enum_syms_with_flags(dll_path,
-                         TEST(DRSYM_PDB, debug_kind) ? dll_syms_full_pdb : dll_syms_full,
-                         (DRSYM_DEMANGLE | DRSYM_DEMANGLE_FULL));
+    enum_syms_with_flags(
+        dll_path, TESTANY(DRSYM_PDB, debug_kind) ? dll_syms_full_pdb : dll_syms_full,
+        (DRSYM_DEMANGLE | DRSYM_DEMANGLE_FULL));
 }
 
 #ifdef UNIX

--- a/suite/tests/client-interface/drsyscall-test.dll.c
+++ b/suite/tests/client-interface/drsyscall-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -34,7 +34,7 @@
 #    include <sys/socket.h>
 #endif
 
-#define TEST(mask, var) (((mask) & (var)) != 0)
+#define TESTANY(mask, var) (((mask) & (var)) != 0)
 
 #undef ASSERT /* we don't want msgbox */
 #define ASSERT(cond, msg)                                                               \
@@ -125,13 +125,13 @@ drsys_iter_arg_cb(drsys_arg_t *arg, void *user_data)
     ASSERT(arg->mc != NULL, "mc check");
     ASSERT(arg->drcontext == dr_get_current_drcontext(), "dc check");
 
-    if (arg->reg == DR_REG_NULL && !TEST(DRSYS_PARAM_RETVAL, arg->mode)) {
+    if (arg->reg == DR_REG_NULL && !TESTANY(DRSYS_PARAM_RETVAL, arg->mode)) {
         ASSERT((byte *)arg->start_addr >= (byte *)arg->mc->xsp &&
                    (byte *)arg->start_addr < (byte *)arg->mc->xsp + dr_page_size(),
                "mem args should be on stack");
     }
 
-    if (TEST(DRSYS_PARAM_RETVAL, arg->mode)) {
+    if (TESTANY(DRSYS_PARAM_RETVAL, arg->mode)) {
         ASSERT(arg->pre ||
                    arg->value == dr_syscall_get_result(dr_get_current_drcontext()),
                "return val wrong");

--- a/suite/tests/client-interface/drutil-test.dll.c
+++ b/suite/tests/client-interface/drutil-test.dll.c
@@ -154,7 +154,7 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
             CHECK(drmgr_get_emulated_instr_data(instr, &emulated_instr),
                   "drmgr_get_emulated_instr_data() failed");
             CHECK(instr_is_stringop_loop(emulated_instr.instr), "orig not string loop");
-            CHECK(TEST(DR_EMULATE_REST_OF_BLOCK, emulated_instr.flags),
+            CHECK(TESTANY(DR_EMULATE_REST_OF_BLOCK, emulated_instr.flags),
                   "entire block not emulated");
             in_emulation = true;
             ++num_app_instrs;

--- a/suite/tests/client-interface/emulation_api_simple.dll.c
+++ b/suite/tests/client-interface/emulation_api_simple.dll.c
@@ -426,10 +426,10 @@ event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
     /* Use the recommended emulation instrumentation code pattern: */
     const emulated_instr_t *emulation;
     if (drmgr_in_emulation_region(drcontext, &emulation)) {
-        if (TEST(DR_EMULATE_IS_FIRST_INSTR, emulation->flags)) {
+        if (TESTANY(DR_EMULATE_IS_FIRST_INSTR, emulation->flags)) {
             DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == emulation->instr);
             record_instr_fetch_orig(emulation->instr);
-            if (!TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
+            if (!TESTANY(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
                 DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) ==
                           emulation->instr);
                 record_data_addresses_orig(emulation->instr);
@@ -438,11 +438,11 @@ event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
             /* Else skip further instr fetches until outside emulation region. */
             DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == NULL);
         }
-        if (instr_is_app(inst) && TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
+        if (instr_is_app(inst) && TESTANY(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
             DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) == inst);
             record_data_addresses_derived(inst);
-        } else if (!TEST(DR_EMULATE_IS_FIRST_INSTR, emulation->flags) ||
-                   TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
+        } else if (!TESTANY(DR_EMULATE_IS_FIRST_INSTR, emulation->flags) ||
+                   TESTANY(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
             DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) == NULL);
         }
     } else if (instr_is_app(inst)) {

--- a/suite/tests/client-interface/file_io.c
+++ b/suite/tests/client-interface/file_io.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -155,7 +155,7 @@ main(int argc, const char *argv[])
 #        endif
     }
     /* Mark one FD as close-on-exec. */
-    assert(!TEST(FD_CLOEXEC, fcntl(rlimit.rlim_max - 1, F_GETFD)));
+    assert(!TESTANY(FD_CLOEXEC, fcntl(rlimit.rlim_max - 1, F_GETFD)));
 #        ifdef CLOSE_RANGE_CLOEXEC
     /* CLOSE_RANGE_CLOEXEC is available only on kernel version >= 5.11 */
     if (syscall(__NR_close_range, rlimit.rlim_max - 1, rlimit.rlim_max - 1,
@@ -166,7 +166,7 @@ main(int argc, const char *argv[])
     assert(fcntl(rlimit.rlim_max - 1, F_SETFD,
                  fcntl(rlimit.rlim_max - 1, F_GETFD) | FD_CLOEXEC) == 0);
 #        endif
-    if (!TEST(FD_CLOEXEC, fcntl(rlimit.rlim_max - 1, F_GETFD)))
+    if (!TESTANY(FD_CLOEXEC, fcntl(rlimit.rlim_max - 1, F_GETFD)))
         print("close_range failed to set the close-on-exec flag\n");
     /* close_range should close the open FDs, and not return any error for
      * any unopen or DR-private FDs.

--- a/suite/tests/client-interface/file_io.dll.c
+++ b/suite/tests/client-interface/file_io.dll.c
@@ -50,8 +50,6 @@
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 /* check if any bit in mask is set in var */
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
-/* check if a single bit is set in var */
-#define TEST TESTANY
 
 static void
 test_dr_rename_delete(void);
@@ -215,17 +213,19 @@ dr_init(client_id_t id)
 
     if (!dr_query_memory((byte *)dummy_func, &base_pc, &size, &prot))
         dr_fprintf(STDERR, "ERROR : can't find dummy_func mem region\n");
-    dr_fprintf(STDERR, "dummy_func is %s%s%s\n", TEST(DR_MEMPROT_READ, prot) ? "r" : "",
-               TEST(DR_MEMPROT_WRITE, prot) ? "w" : "",
-               TEST(DR_MEMPROT_EXEC, prot) ? "x" : "");
+    dr_fprintf(STDERR, "dummy_func is %s%s%s\n",
+               TESTANY(DR_MEMPROT_READ, prot) ? "r" : "",
+               TESTANY(DR_MEMPROT_WRITE, prot) ? "w" : "",
+               TESTANY(DR_MEMPROT_EXEC, prot) ? "x" : "");
     if (base_pc > (byte *)dummy_func || base_pc + size < (byte *)dummy_func)
         dr_fprintf(STDERR, "dummy_func region mismatch");
 
     memset(writable_buf, 0, sizeof(writable_buf)); /* strip off write copy */
     if (!dr_query_memory(writable_buf + 100, &base_pc, &size, &prot))
         dr_fprintf(STDERR, "ERROR : can't find dummy_func mem region\n");
-    dr_fprintf(STDERR, "writable_buf is %s%s%s\n", TEST(DR_MEMPROT_READ, prot) ? "r" : "",
-               TEST(DR_MEMPROT_WRITE, prot) ? "w" : "",
+    dr_fprintf(STDERR, "writable_buf is %s%s%s\n",
+               TESTANY(DR_MEMPROT_READ, prot) ? "r" : "",
+               TESTANY(DR_MEMPROT_WRITE, prot) ? "w" : "",
 #ifdef UNIX
                /* Linux sometimes (probably depends on version and hardware NX
                 * support) lists all readable regions as also exectuable in the
@@ -233,7 +233,7 @@ dr_init(client_id_t id)
                 * matching the template file easier. */
                ""
 #else
-               TEST(DR_MEMPROT_EXEC, prot) ? "x" : ""
+               TESTANY(DR_MEMPROT_EXEC, prot) ? "x" : ""
 #endif
     );
     if (base_pc > writable_buf || base_pc + size < writable_buf)
@@ -244,8 +244,9 @@ dr_init(client_id_t id)
 
     if (!dr_query_memory(read_only_buf + 100, &base_pc, &size, &prot))
         dr_fprintf(STDERR, "ERROR : can't find dummy_func mem region\n");
-    dr_fprintf(STDERR, "read_only_buf is %s%s\n", TEST(DR_MEMPROT_READ, prot) ? "r" : "",
-               TEST(DR_MEMPROT_WRITE, prot) ? "w" : "");
+    dr_fprintf(STDERR, "read_only_buf is %s%s\n",
+               TESTANY(DR_MEMPROT_READ, prot) ? "r" : "",
+               TESTANY(DR_MEMPROT_WRITE, prot) ? "w" : "");
     if (base_pc > read_only_buf || base_pc + size < read_only_buf)
         dr_fprintf(STDERR, "read_only_buf region mismatch");
     if (base_pc + size < read_only_buf + sizeof(read_only_buf))

--- a/suite/tests/client-interface/nudge_ex.dll.c
+++ b/suite/tests/client-interface/nudge_ex.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -169,7 +169,7 @@ event_post_syscall(void *drcontext, int sysnum)
 #ifdef UNIX
     if (sysnum == SYS_FORK_VALUE
 #    ifdef LINUX
-        || (sysnum == SYS_clone && !TEST(CLONE_VM, data->saved_param))
+        || (sysnum == SYS_clone && !TESTANY(CLONE_VM, data->saved_param))
 #    endif
     ) {
         child_pid = dr_syscall_get_result(drcontext);

--- a/suite/tests/client-interface/strace-test.dll.c
+++ b/suite/tests/client-interface/strace-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -37,7 +37,7 @@
 #    define IF_WINDOWS_ELSE(x, y) y
 #endif
 
-#define TEST(mask, var) (((mask) & (var)) != 0)
+#define TESTANY(mask, var) (((mask) & (var)) != 0)
 
 #undef ASSERT /* we don't want msgbox */
 #define ASSERT(cond, msg)                                                               \
@@ -104,7 +104,7 @@ drsys_iter_arg_cb(drsys_arg_t *arg, void *user_data)
     ASSERT(arg->mc != NULL, "mc check");
     ASSERT(arg->drcontext == dr_get_current_drcontext(), "dc check");
 
-    if (arg->reg == DR_REG_NULL && !TEST(DRSYS_PARAM_RETVAL, arg->mode)) {
+    if (arg->reg == DR_REG_NULL && !TESTANY(DRSYS_PARAM_RETVAL, arg->mode)) {
         ASSERT((byte *)arg->start_addr >= (byte *)arg->mc->xsp &&
                    (byte *)arg->start_addr < (byte *)arg->mc->xsp + dr_page_size(),
                "mem args should be on stack");
@@ -119,7 +119,7 @@ drsys_iter_arg_cb(drsys_arg_t *arg, void *user_data)
                    arg->value64, arg->size);
     }
 
-    if (TEST(DRSYS_PARAM_RETVAL, arg->mode)) {
+    if (TESTANY(DRSYS_PARAM_RETVAL, arg->mode)) {
         ASSERT(arg->pre ||
                    arg->value == dr_syscall_get_result(dr_get_current_drcontext()),
                "return val wrong");

--- a/suite/tests/client_tools.h
+++ b/suite/tests/client_tools.h
@@ -85,8 +85,6 @@
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 /* check if any bit in mask is set in var */
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
-/* check if a single bit is set in var */
-#define TEST TESTANY
 
 #ifdef WINDOWS
 #    define IF_WINDOWS_ELSE(x, y) x

--- a/suite/tests/common/fake_ctr_dic.c
+++ b/suite/tests/common/fake_ctr_dic.c
@@ -42,7 +42,7 @@ main(int argc, const char *argv[])
     const int CTR_EL0_DIC_BIT = 29;
     unsigned long ctr;
     asm volatile("mrs %[ctr], ctr_el0" : [ctr] "=r"(ctr));
-    if (TEST(ctr, 1U << CTR_EL0_DIC_BIT)) {
+    if (TESTANY(ctr, 1U << CTR_EL0_DIC_BIT)) {
         print("CTR_EL0 = %lx\n", ctr);
         return 1;
     } else {

--- a/suite/tests/common/nzcv.c
+++ b/suite/tests/common/nzcv.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -57,7 +57,7 @@ test_flag(uint nzcv, uint pos, bool set)
 #    if VERBOSE
     print("NZCV where %c should be %d: " PFX "\n", flag, set, nzcv);
 #    endif
-    bool value = TEST(nzcv, 1U << pos);
+    bool value = TESTANY(nzcv, 1U << pos);
 
     for (i = 0; i < NUM_FLAGS; i++) {
         if (nzcv_pos[i] == pos)

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -143,25 +143,25 @@ int
 get_os_prot_word(int prot)
 {
 #    ifdef UNIX
-    return ((TEST(ALLOW_READ, prot) ? PROT_READ : 0) |
-            (TEST(ALLOW_WRITE, prot) ? PROT_WRITE : 0) |
-            (TEST(ALLOW_EXEC, prot) ? PROT_EXEC : 0));
+    return ((TESTANY(ALLOW_READ, prot) ? PROT_READ : 0) |
+            (TESTANY(ALLOW_WRITE, prot) ? PROT_WRITE : 0) |
+            (TESTANY(ALLOW_EXEC, prot) ? PROT_EXEC : 0));
 #    else
-    if (TEST(ALLOW_WRITE, prot)) {
-        if (TEST(ALLOW_EXEC, prot)) {
+    if (TESTANY(ALLOW_WRITE, prot)) {
+        if (TESTANY(ALLOW_EXEC, prot)) {
             return PAGE_EXECUTE_READWRITE;
         } else {
             return PAGE_READWRITE;
         }
     } else {
-        if (TEST(ALLOW_READ, prot)) {
-            if (TEST(ALLOW_EXEC, prot)) {
+        if (TESTANY(ALLOW_READ, prot)) {
+            if (TESTANY(ALLOW_EXEC, prot)) {
                 return PAGE_EXECUTE_READ;
             } else {
                 return PAGE_READONLY;
             }
         } else {
-            if (TEST(ALLOW_EXEC, prot)) {
+            if (TESTANY(ALLOW_EXEC, prot)) {
                 return PAGE_EXECUTE;
             } else {
                 return PAGE_NOACCESS;
@@ -177,7 +177,7 @@ allocate_mem(size_t size, int prot)
 #    ifdef UNIX
     int flags = MAP_PRIVATE | MAP_ANON;
 #        if defined(MACOS) && defined(AARCH64)
-    if (TEST(ALLOW_EXEC, prot)) {
+    if (TESTANY(ALLOW_EXEC, prot)) {
         flags |= MAP_JIT;
         pthread_jit_write_protect_np(0);
     }
@@ -213,7 +213,7 @@ protect_mem(void *start, size_t len, int prot)
     int page_len = (len + ((ptr_int_t)start - (ptr_int_t)page_start) + PAGE_SIZE - 1) &
         ~(PAGE_SIZE - 1);
 #        if defined(MACOS) && defined(AARCH64)
-    if (TEST(ALLOW_EXEC, prot) && !TEST(ALLOW_WRITE, prot)) {
+    if (TESTANY(ALLOW_EXEC, prot) && !TESTANY(ALLOW_WRITE, prot)) {
         pthread_jit_write_protect_np(1);
         return;
     }

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -166,8 +166,6 @@ extern "C" {
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 /* check if any bit in mask is set in var */
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
-/* check if a single bit is set in var */
-#define TEST TESTANY
 
 #ifdef USE_DYNAMO
 /* to avoid non-api tests depending on dr_api headers we rely on test

--- a/tools/ldmp.c
+++ b/tools/ldmp.c
@@ -62,8 +62,6 @@ static int verbose = 1;
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 /* check if any bit in mask is set in var */
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
-/* check if a single bit is set in var */
-#define TEST TESTANY
 
 #define BUFFER_SIZE_BYTES(buf) sizeof(buf)
 #define BUFFER_SIZE_ELEMENTS(buf) (BUFFER_SIZE_BYTES(buf) / sizeof(buf[0]))
@@ -543,7 +541,7 @@ print_descriptor(DESCRIPTOR_TABLE_ENTRY *entry)
 
     /* The definition for LDT_ENTRY combines the S and type fields
      * into a five bit field. */
-    if (TEST(0x10, descr->HighWord.Bits.Type)) {
+    if (TESTANY(0x10, descr->HighWord.Bits.Type)) {
         PRINT("%s ", types[descr->HighWord.Bits.Type & 0xf]);
     } else {
         PRINT("System               ");
@@ -855,7 +853,7 @@ copy_memory(FILE *file, bool just_mapped, HANDLE hProc)
                      * is guard! (why?), post rc1 should check
                      * MEM_COMMIT && !guard && is_readable */
                     assert(mbi.State == MEM_COMMIT);
-                    if (!TEST(PAGE_GUARD, mbi.Protect)) {
+                    if (!TESTANY(PAGE_GUARD, mbi.Protect)) {
                         res = fseek(file, mbi.RegionSize, SEEK_CUR);
                         assert(res == 0);
                     } else {
@@ -958,7 +956,8 @@ copy_memory(FILE *file, bool just_mapped, HANDLE hProc)
                 } else {
                     uint old_prot;
                     assert(mbi.State = MEM_COMMIT);
-                    if (!TEST(PAGE_GUARD, mbi.Protect) && prot_is_readable(mbi.Protect)) {
+                    if (!TESTANY(PAGE_GUARD, mbi.Protect) &&
+                        prot_is_readable(mbi.Protect)) {
                         uint i;
                         /* copy over memory */
                         res = VirtualProtectEx(hProc, TARGET_ADDR, mbi.RegionSize,


### PR DESCRIPTION
In preparation of moving the TEST* defines into
dr_project_wide_headers.h, we replace all uses of TEST with the equivalent TESTANY.  Although we avoid exposing
dr_project_wide_headers.h in DR_API headers, it is exposed in drmemtrace's headers where TEST causes collisions with third-party code such as googletest.

Issue: #8001