### PR TITLE
i#5427: Make -raw_compress lz4 usable from statically linked clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Copyright (c) 2010-2026 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2018 Arm Limited          All rights reserved.
+# Copyright (c) 2026 Meta Platforms, Inc. All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -1992,6 +1993,30 @@ if (UNIX AND X64)
     message(STATUS "Found liblz4: ${liblz4}")
     if (APPLE)
       mac_add_inc_and_lib(lz4.h liblz4.a)
+    endif ()
+    # lz4 >= 1.9.4 supports custom allocators, but some builds do not export the
+    # required API.  Check that it links before using it for static clients (i#5427).
+    include(CheckCSourceCompiles)
+    set(_lz4_save_required_libraries ${CMAKE_REQUIRED_LIBRARIES})
+    set(CMAKE_REQUIRED_LIBRARIES ${liblz4})
+    check_c_source_compiles("
+#define LZ4F_STATIC_LINKING_ONLY
+#include <lz4frame.h>
+int main(void) {
+  LZ4F_cctx *cctx = LZ4F_createCompressionContext_advanced(LZ4F_defaultCMem,
+                                                           LZ4F_VERSION);
+  LZ4F_freeCompressionContext(cctx);
+  return 0;
+}
+" HAVE_LZ4_CUSTOM_MEM)
+    set(CMAKE_REQUIRED_LIBRARIES ${_lz4_save_required_libraries})
+    unset(_lz4_save_required_libraries)
+    if (HAVE_LZ4_CUSTOM_MEM)
+      message(STATUS "liblz4 supports LZ4F_CustomMem: lz4 is safe for static clients")
+    else ()
+      message(STATUS "liblz4 lacks a usable LZ4F_CustomMem: "
+        "-raw_compress lz4 stays unsafe for static clients (needs lz4 >= 1.9.4 "
+        "built with -DLZ4F_PUBLISH_STATIC_FUNCTIONS, or a static liblz4)")
     endif ()
   endif ()
   find_library(libxxhash xxhash)

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -1,5 +1,6 @@
 /* ******************************************************************************
  * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
+ * Copyright (c) 2026 Meta Platforms, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -290,6 +291,10 @@ Further non-compatibility-affecting changes include:
  - Added -filter_kernel and -filter_kernel_except_syscalls to the drmemtrace
    analyzer that invokes #dynamorio::drmemtrace::kernel_filter_t to remove kernel
    content from a trace.
+ - Changed the default for the drmemtrace -raw_compress option in statically linked
+   clients from "none" to "lz4", when built against an lz4 with LZ4F_CustomMem support
+   (lz4 >= 1.9.4).  lz4's allocations are routed through DR's private heap in that
+   configuration.  Where that support is unavailable the static default remains "none".
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -1,5 +1,6 @@
 # **********************************************************
 # Copyright (c) 2015-2026 Google, Inc.    All rights reserved.
+# Copyright (c) 2026 Meta Platforms, Inc. All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -141,6 +142,11 @@ endif()
 if (liblz4)
   add_definitions(-DHAS_LZ4)
   set(lz4_reader reader/lz4_file_reader.cpp)
+  if (HAVE_LZ4_CUSTOM_MEM)
+    # Lets the tracer route lz4's allocations through DR's private heap, making
+    # -raw_compress lz4 safe for statically linked clients.
+    add_definitions(-DHAS_LZ4_CUSTOM_MEM)
+  endif ()
 endif ()
 
 if (BUILD_DRMEMTRACE_WITH_DR_SYSCALL)

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1,5 +1,6 @@
 /* **********************************************************
  * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
+ * Copyright (c) 2026 Meta Platforms, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -441,8 +442,11 @@ droption_t<bytesize_t> op_exit_after_tracing(
 
 droption_t<std::string> op_raw_compress(
     DROPTION_SCOPE_CLIENT, "raw_compress",
-#if defined(HAS_LZ4) && !defined(DRMEMTRACE_STATIC)
-    // lz4 performs best but has no allocator parameterization so cannot be static.
+#if defined(HAS_LZ4) && (!defined(DRMEMTRACE_STATIC) || defined(HAS_LZ4_CUSTOM_MEM))
+    // lz4 performs best i#5427.  A statically linked client additionally needs
+    // HAS_LZ4_CUSTOM_MEM (lz4 >= 1.9.4), which is what lets the tracer point lz4's
+    // allocator at DR's private heap; older lz4 has no allocator parameterization
+    // and so cannot be used statically at all.
     "lz4",
 #elif defined(HAS_SNAPPY) && !defined(DRMEMTRACE_STATIC)
     // snappy_nocrc also has no allocator parameterization so cannot be static.

--- a/clients/drcachesim/tests/burst_static.cpp
+++ b/clients/drcachesim/tests/burst_static.cpp
@@ -79,7 +79,7 @@ test_main(int argc, const char *argv[])
     static int iter_start = outer_iters / 3;
     static int iter_stop = iter_start + 4;
 
-    const bool use_lz4 = argc > 1 && strcmp(argv[1], "--lz4") == 0;
+    const bool use_lz4 = argc > 1 && strcmp(argv[1], "-lz4") == 0;
     const char *dynamorio_options;
     if (use_lz4) {
         /* This app is shared with the non-lz4 test, so we pass a distinct subdir

--- a/clients/drcachesim/tests/burst_static.cpp
+++ b/clients/drcachesim/tests/burst_static.cpp
@@ -80,12 +80,19 @@ test_main(int argc, const char *argv[])
     static int iter_stop = iter_start + 4;
 
     const bool use_lz4 = argc > 1 && strcmp(argv[1], "--lz4") == 0;
-    const char *dynamorio_options =
-        use_lz4 ? "-stderr_mask 0xc -rstats_to_stderr "
-                  "-client_lib ';;-offline -raw_compress lz4 "
-                  "-subdir_prefix drmemtrace.tool.drcacheoff.burst_static-lz4'"
-                : "-stderr_mask 0xc -rstats_to_stderr "
-                  "-client_lib ';;-offline -raw_compress none'";
+    const char *dynamorio_options;
+    if (use_lz4) {
+        /* This app is shared with the non-lz4 test, so we pass a distinct subdir
+         * prefix to keep the two tests' output directories apart.
+         */
+        dynamorio_options = "-stderr_mask 0xc -rstats_to_stderr "
+                            "-client_lib ';;-offline -raw_compress lz4 "
+                            "-subdir_prefix "
+                            "drmemtrace.tool.drcacheoff.burst_static-lz4'";
+    } else {
+        dynamorio_options = "-stderr_mask 0xc -rstats_to_stderr "
+                            "-client_lib ';;-offline -raw_compress none'";
+    }
     /* We also test -rstats_to_stderr. */
     if (!my_setenv("DYNAMORIO_OPTIONS", dynamorio_options))
         std::cerr << "failed to set env var!\n";

--- a/clients/drcachesim/tests/burst_static.cpp
+++ b/clients/drcachesim/tests/burst_static.cpp
@@ -1,5 +1,6 @@
 /* **********************************************************
  * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2026 Meta Platforms, Inc. All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,6 +45,7 @@
 #include <iostream>
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -77,10 +79,15 @@ test_main(int argc, const char *argv[])
     static int iter_start = outer_iters / 3;
     static int iter_stop = iter_start + 4;
 
-    /* We also test -rstats_to_stderr */
-    if (!my_setenv("DYNAMORIO_OPTIONS",
-                   "-stderr_mask 0xc -rstats_to_stderr "
-                   "-client_lib ';;-offline'"))
+    const bool use_lz4 = argc > 1 && strcmp(argv[1], "--lz4") == 0;
+    const char *dynamorio_options =
+        use_lz4 ? "-stderr_mask 0xc -rstats_to_stderr "
+                  "-client_lib ';;-offline -raw_compress lz4 "
+                  "-subdir_prefix drmemtrace.tool.drcacheoff.burst_static-lz4'"
+                : "-stderr_mask 0xc -rstats_to_stderr "
+                  "-client_lib ';;-offline -raw_compress none'";
+    /* We also test -rstats_to_stderr. */
+    if (!my_setenv("DYNAMORIO_OPTIONS", dynamorio_options))
         std::cerr << "failed to set env var!\n";
 
     /* We use an outer loop to test re-attaching (i#2157). */

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1,5 +1,6 @@
 /* ******************************************************************************
  * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
+ * Copyright (c) 2026 Meta Platforms, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * ******************************************************************************/
 
@@ -66,6 +67,12 @@
 #    include <zlib.h>
 #endif
 #ifdef HAS_LZ4
+#    ifdef HAS_LZ4_CUSTOM_MEM
+/* LZ4F_CustomMem and LZ4F_createCompressionContext_advanced() are declared under
+ * this guard, which must be defined before including the header.
+ */
+#        define LZ4F_STATIC_LINKING_ONLY
+#    endif
 #    include <lz4frame.h>
 #endif
 
@@ -266,30 +273,82 @@ snappy_enabled()
 }
 #endif
 
-#ifdef HAS_ZLIB
+#if defined(HAS_ZLIB) || defined(HAS_LZ4_CUSTOM_MEM)
+/* A compression library whose allocator we can parameterize gets pointed at DR's
+ * private heap.  That is what makes it usable from a statically linked client,
+ * where calling the application's malloc is not safe.  dr_custom_free() needs the
+ * original size back, so we stash it in a header word ahead of the returned
+ * pointer.
+ */
 static void *
-redirect_malloc(void *drcontext, uint items, uint per_size)
+alloc_from_dr_heap(size_t size)
 {
-    void *mem;
-    size_t size = items * per_size; /* XXX: ignoring overflow */
     size += sizeof(size_t);
-    mem = dr_custom_alloc(nullptr, static_cast<dr_alloc_flags_t>(0), size,
-                          DR_MEMPROT_READ | DR_MEMPROT_WRITE, nullptr);
-    if (mem == NULL)
-        return Z_NULL;
-    *((size_t *)mem) = size;
-    return (byte *)mem + sizeof(size_t);
+    void *mem = dr_custom_alloc(nullptr, static_cast<dr_alloc_flags_t>(0), size,
+                                DR_MEMPROT_READ | DR_MEMPROT_WRITE, nullptr);
+    if (mem == nullptr)
+        return nullptr;
+    *reinterpret_cast<size_t *>(mem) = size;
+    return reinterpret_cast<byte *>(mem) + sizeof(size_t);
 }
 
 static void
-redirect_free(void *drcontext, void *ptr)
+free_to_dr_heap(void *ptr)
 {
-    if (ptr != NULL) {
-        byte *mem = (byte *)ptr;
-        mem -= sizeof(size_t);
-        dr_custom_free(nullptr, static_cast<dr_alloc_flags_t>(0), mem, *((size_t *)mem));
-    }
+    if (ptr == nullptr)
+        return;
+    byte *mem = reinterpret_cast<byte *>(ptr) - sizeof(size_t);
+    dr_custom_free(nullptr, static_cast<dr_alloc_flags_t>(0), mem,
+                   *reinterpret_cast<size_t *>(mem));
 }
+#endif
+
+#ifdef HAS_ZLIB
+static void *
+zlib_redirect_malloc(void *drcontext, uint items, uint per_size)
+{
+    void *mem = alloc_from_dr_heap(items * per_size); /* XXX: ignoring overflow */
+    return mem == nullptr ? Z_NULL : mem;
+}
+
+static void
+zlib_redirect_free(void *drcontext, void *ptr)
+{
+    free_to_dr_heap(ptr);
+}
+#endif
+
+#ifdef HAS_LZ4_CUSTOM_MEM
+/* lz4's allocator hooks take a single byte count, unlike zlib's (items, size)
+ * pair, so they cannot reuse zlib_redirect_malloc()/zlib_redirect_free() directly.
+ */
+static void *
+lz4_redirect_malloc(void *opaque, size_t size)
+{
+    return alloc_from_dr_heap(size);
+}
+
+static void *
+lz4_redirect_calloc(void *opaque, size_t size)
+{
+    void *mem = alloc_from_dr_heap(size);
+    if (mem != nullptr)
+        memset(mem, 0, size);
+    return mem;
+}
+
+static void
+lz4_redirect_free(void *opaque, void *ptr)
+{
+    free_to_dr_heap(ptr);
+}
+
+/* Setting this at context creation is sufficient: lz4 stores it on the context
+ * and every subsequent internal allocation (the LZ4_stream_t and the frame's
+ * tmpBuff) goes through it.
+ */
+static const LZ4F_CustomMem lz4_custom_mem = { lz4_redirect_malloc, lz4_redirect_calloc,
+                                               lz4_redirect_free, nullptr };
 #endif
 
 int
@@ -460,15 +519,15 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
 #ifdef HAS_ZLIB
         if (op_offline.get_value() && op_raw_compress.get_value() == "zlib") {
             memset(&data->zstream, 0, sizeof(data->zstream));
-            data->zstream.zalloc = redirect_malloc;
-            data->zstream.zfree = redirect_free;
+            data->zstream.zalloc = zlib_redirect_malloc;
+            data->zstream.zfree = zlib_redirect_free;
             data->zstream.opaque = drcontext;
             int res = deflateInit(&data->zstream, Z_BEST_SPEED);
             DR_ASSERT(res == Z_OK);
         } else if (op_offline.get_value() && op_raw_compress.get_value() == "gzip") {
             memset(&data->zstream, 0, sizeof(data->zstream));
-            data->zstream.zalloc = redirect_malloc;
-            data->zstream.zfree = redirect_free;
+            data->zstream.zalloc = zlib_redirect_malloc;
+            data->zstream.zfree = zlib_redirect_free;
             data->zstream.opaque = drcontext;
             const int ZLIB_WINDOW_SIZE = 15;
             const int ZLIB_REQUEST_GZIP = 16; /* Added to size to trigger gz headers. */
@@ -482,8 +541,18 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
 #endif
 #ifdef HAS_LZ4
         if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
+#    ifdef HAS_LZ4_CUSTOM_MEM
+            /* Unlike the legacy entry point, this returns the context itself
+             * (NULL on failure) rather than an error code.
+             */
+            data->lzcxt =
+                LZ4F_createCompressionContext_advanced(lz4_custom_mem, LZ4F_VERSION);
+            DR_ASSERT(data->lzcxt != nullptr);
+            size_t res;
+#    else
             size_t res = LZ4F_createCompressionContext(&data->lzcxt, LZ4F_VERSION);
             DR_ASSERT(!LZ4F_isError(res));
+#    endif
             // Write out the header.
             res = LZ4F_compressBegin(data->lzcxt, data->buf_lz4, data->buf_lz4_size,
                                      &lz4_ops);
@@ -1535,12 +1604,18 @@ init_io()
 #    endif
     }
 #endif
-#ifdef HAS_LZ4
+#if defined(HAS_LZ4) && !defined(HAS_LZ4_CUSTOM_MEM)
     if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
-        /* Similarly to libsnappy, lz4 doesn't parameterize its allocator. */
+        /* Similarly to libsnappy, this liblz4 gives us no way to parameterize its
+         * allocator: either it predates LZ4F_CustomMem (lz4 < 1.9.4) or it does not
+         * export LZ4F_createCompressionContext_advanced().  See the link test in the
+         * top-level CMakeLists.txt.
+         */
         dr_allow_unsafe_static_behavior();
 #    ifdef DRMEMTRACE_STATIC
-        NOTIFY(0, "-raw_compress lz4 is unsafe with statically linked clients\n");
+        NOTIFY(0,
+               "-raw_compress lz4 is unsafe with statically linked clients: "
+               "this build's liblz4 lacks LZ4F_CustomMem support\n");
 #    endif
     }
 #endif

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -348,7 +348,8 @@ lz4_redirect_free(void *opaque, void *ptr)
  * tmpBuff) goes through it.
  */
 static const LZ4F_CustomMem lz4_custom_mem = { lz4_redirect_malloc, lz4_redirect_calloc,
-                                               lz4_redirect_free, nullptr };
+                                               lz4_redirect_free,
+                                               /*opaqueState=*/nullptr };
 #endif
 
 int

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4944,7 +4944,7 @@ if (BUILD_CLIENTS)
       if (HAVE_LZ4_CUSTOM_MEM)
         set(tool.drcacheoff.burst_static-lz4_nodr ON)
         torunonly_drcacheoff(burst_static-lz4 tool.drcacheoff.burst_static
-          "" "" "--lz4")
+          "" "" "-lz4")
         set(tool.drcacheoff.burst_static-lz4_expectbase "offline-burst_static")
       endif ()
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Copyright (c) 2010-2026 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2016-2023 ARM Limited.    All rights reserved.
+# Copyright (c) 2026 Meta Platforms, Inc. All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -4477,6 +4478,10 @@ if (BUILD_CLIENTS)
     # lz4 is on by default so we test no compression here.
     torunonly_drcacheoff(raw-none ${ci_shared_app} "-raw_compress none" "" "")
     set(tool.drcacheoff.raw-none_expectbase "offline-simple")
+    if (liblz4)
+      torunonly_drcacheoff(raw-lz4 ${ci_shared_app} "-raw_compress lz4" "" "")
+      set(tool.drcacheoff.raw-lz4_expectbase "offline-simple")
+    endif ()
 
     # Test that malloc & co. are not invoked.
     # We disable the lz4 default as both lz4 and snappy call
@@ -4485,6 +4490,15 @@ if (BUILD_CLIENTS)
     torunonly_drcacheoff(check-malloc ${ci_shared_app}
       "-raw_compress none -record_function 'main|2'" "" "")
     set(tool.drcacheoff.check-malloc_expectbase "offline-simple")
+
+    if (HAVE_LZ4_CUSTOM_MEM)
+      # With lz4 >= 1.9.4 we parameterize lz4's allocator onto DR's heap instead of
+      # calling dr_allow_unsafe_static_behavior(), so the malloc check above stays
+      # armed and can cover the lz4 path too.
+      torunonly_drcacheoff(check-malloc-lz4 ${ci_shared_app}
+        "-raw_compress lz4 -record_function 'main|2'" "" "")
+      set(tool.drcacheoff.check-malloc-lz4_expectbase "offline-simple")
+    endif ()
 
     # Test reading a trace in sharded snappy-compressed files.
     if (libsnappy)
@@ -4927,6 +4941,12 @@ if (BUILD_CLIENTS)
     if (NOT ARM AND NOT APPLE AND NOT DISABLE_FOR_BUG_2949 AND NOT RISCV64)
       set(tool.drcacheoff.burst_static_nodr ON)
       torunonly_drcacheoff(burst_static tool.drcacheoff.burst_static "" "" "")
+      if (HAVE_LZ4_CUSTOM_MEM)
+        set(tool.drcacheoff.burst_static-lz4_nodr ON)
+        torunonly_drcacheoff(burst_static-lz4 tool.drcacheoff.burst_static
+          "" "" "--lz4")
+        set(tool.drcacheoff.burst_static-lz4_expectbase "offline-burst_static")
+      endif ()
 
       set(tool.drcacheoff.burst_replace_nodr ON)
       torunonly_drcacheoff(burst_replace tool.drcacheoff.burst_replace "" "" "")
@@ -5559,6 +5579,8 @@ if (BUILD_CLIENTS)
       # the check that complains about malloc use in the client is disabled by invoking
       # dr_allow_unsafe_static_behavior. We want to perform this check on the kernel
       # tracing flow.
+      # (With lz4 >= 1.9.4 that is no longer true for lz4. See HAS_LZ4_CUSTOM_MEM.
+      # But we keep 'none' here to hold the kernel flow's coverage fixed.)
       torunonly_drcacheoff_kernel(simple ${ci_shared_app} "-raw_compress none" ""
                                   "@-tool@basic_counts")
       torunonly_drcacheoff_kernel(opcode-mix ${ci_shared_app} "-raw_compress none" ""


### PR DESCRIPTION
Since v1.9.4, lz4 supports supplying a custom allocator, allowing it to be safely used with statically linked drmemtrace. This PR adds support for lz4 to static drmemtrace when linked against lz4 v1.9.4+ and when the library actually exports the `LZ4F_createCompressionContext_advanced()` symbol. 

If these conditions are met, a CMake link test sets `HAS_LZ4_CUSTOM_MEM`, which makes lz4 the default for `-raw_compress` in static clients, matching the existing non-static default. If custom allocator support is not available, behavior is unchanged. 

Three new tests:
- raw-lz4: raw lz4 files are written and read back through raw2trace.
- check-malloc-lz4: runs the existing malloc check over the lz4 path, which is possible now that the path no longer disables that check.
- burst_static-lz4: a statically linked client writes lz4 raw files and the output matches uncompressed burst_static.

Issue: #5427