### PR TITLE
i#8038: Remove XXX comments as they are no longer planned

### DIFF
--- a/core/ir/instr_create_shared_api.h
+++ b/core/ir/instr_create_shared_api.h
@@ -59,8 +59,6 @@
 
 /* Inlined rather than using limits_wrapper.h: this file is exported as
  * dr_ir_macros.h and limits_wrapper.h is not part of the exported headers.
- * XXX i#8038: Consider using CMake configure_file (@ONLY) to substitute
- * system headers at configure time to keep public headers clean.
  */
 #ifdef LINUX_KERNEL
 #    include <linux/kernel.h>

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -57,8 +57,6 @@
 #endif
 /* Inlined rather than using stdarg_wrapper.h: this file is exported as
  * dr_defines.h and stdarg_wrapper.h is not part of the exported headers.
- * XXX i#8038: Consider using CMake configure_file (@ONLY) to substitute
- * system headers at configure time to keep public headers clean.
  */
 #ifdef LINUX_KERNEL
 #    include <linux/stdarg.h>


### PR DESCRIPTION
Per offline discussion, we think it's better to have one set of public headers for both user space release and kernel release. Therefore, it's acceptable to have `#ifdef`s in the public headers for conditionally including system header, and the optimization in #8038 is no longer plan. This PR removes the XXX comments referring #8038.

Issue: #8038