### PR TITLE
i#8043: Remove w suffix from Intel style

### DIFF
--- a/core/ir/x86/disassemble.c
+++ b/core/ir/x86/disassemble.c
@@ -337,9 +337,7 @@ instr_opcode_name_suffix(instr_t *instr)
         case OP_pushf:
         case OP_popf: {
             uint sz = instr_memory_reference_size(instr);
-            if (sz == 1)
-                return "b";
-            else if (sz == 2)
+            if (sz == 2)
                 return att ? "w" : "";
             else if (sz == 4)
                 return "d"; /* Some tools use "l" for att. */

--- a/core/ir/x86/disassemble.c
+++ b/core/ir/x86/disassemble.c
@@ -302,11 +302,10 @@ suppress_memory_size_annotations(instr_t *instr)
 static const char *
 instr_opcode_name_suffix(instr_t *instr)
 {
-    if (TESTANY(DR_DISASM_INTEL | DR_DISASM_ATT, DYNAMO_OPTION(disasm_mask))) {
-        /* add "b" or "d" suffix */
+    bool att = TESTANY(DR_DISASM_ATT, DYNAMO_OPTION(disasm_mask));
+    bool intel = TESTANY(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask));
+    if (att || intel) {
         switch (instr_get_opcode(instr)) {
-        case OP_pushf:
-        case OP_popf:
         case OP_xlat:
         case OP_ins:
         case OP_rep_ins:
@@ -335,21 +334,34 @@ instr_opcode_name_suffix(instr_t *instr)
                 return "q";
             break;
         }
+        case OP_pushf:
+        case OP_popf: {
+            uint sz = instr_memory_reference_size(instr);
+            if (sz == 1)
+                return "b";
+            else if (sz == 2)
+                return att ? "w" : "";
+            else if (sz == 4)
+                return "d"; /* Some tools use "l" for att. */
+            else if (sz == 8)
+                return "q";
+            break;
+        }
         case OP_pusha:
         case OP_popa: {
             uint sz = instr_memory_reference_size(instr);
             if (sz == 16)
-                return "w";
+                return att ? "w" : "";
             else if (sz == 32)
-                return "d";
+                return "d"; /* Some tools use "l" for att. */
             break;
         }
         case OP_iret: {
             uint sz = instr_memory_reference_size(instr);
             if (sz == 6)
-                return "w";
+                return att ? "w" : "";
             else if (sz == 12)
-                return "d";
+                return "d"; /* Some tools use "l" for att. */
             else if (sz == 40)
                 return "q";
             break;
@@ -408,8 +420,12 @@ print_instr_prefixes(dcontext_t *dcontext, instr_t *instr, char *buf, size_t buf
      * For data16, we'd look for 16-bit reg or OPSZ_2 immed or base_disp.
      */
     if (!TESTANY(DR_DISASM_INTEL, DYNAMO_OPTION(disasm_mask))) {
-        if (TESTANY(PREFIX_DATA, instr->prefixes))
+        if (TESTANY(PREFIX_DATA, instr->prefixes)) {
+            /* XXX i#8044: Xed now prints "data16" so maybe we should
+             * reconsider whether to print this for Intel style.
+             */
             print_to_buffer(buf, bufsz, sofar, "data16 ");
+        }
         if (TESTANY(PREFIX_ADDR, instr->prefixes) &&
             !suppress_memory_size_annotations(instr)) {
             print_to_buffer(buf, bufsz, sofar,

--- a/suite/tests/api/drdecode_x86.c
+++ b/suite/tests/api/drdecode_x86.c
@@ -62,7 +62,6 @@ test_disasm_style(void)
     /* Test instructions with custom suffixes. */
     instrlist_append(ilist, INSTR_CREATE_iret(GD));
     instrlist_append(ilist, INSTR_CREATE_pushf(GD));
-    instrlist_append(ilist, INSTR_CREATE_pushf(GD));
     instrlist_append(ilist, INSTR_CREATE_popf(GD));
 #ifndef X64
     instrlist_append(ilist, INSTR_CREATE_pusha(GD));

--- a/suite/tests/api/drdecode_x86.c
+++ b/suite/tests/api/drdecode_x86.c
@@ -59,9 +59,37 @@ test_disasm_style(void)
                                          opnd_create_reg(REG_EAX)));
     instrlist_append(
         ilist, INSTR_CREATE_mov_imm(GD, opnd_create_reg(REG_EDI), OPND_CREATE_INT32(17)));
+    /* Test instructions with custom suffixes. */
+    instrlist_append(ilist, INSTR_CREATE_iret(GD));
+    instrlist_append(ilist, INSTR_CREATE_pushf(GD));
+    instrlist_append(ilist, INSTR_CREATE_pushf(GD));
+    instrlist_append(ilist, INSTR_CREATE_popf(GD));
+#ifndef X64
+    instrlist_append(ilist, INSTR_CREATE_pusha(GD));
+    instrlist_append(ilist, INSTR_CREATE_popa(GD));
+#endif
     end = instrlist_encode(GD, ilist, buf, false);
+    ASSERT(end != NULL && end - buf < BUFFER_SIZE_ELEMENTS(buf));
+    /* It's a pain to synthesize the data16 versions so we use the encoding. */
+    *end++ = 0x66;
+    *end++ = 0xcf; /* iret */
+    *end++ = 0x66;
+    *end++ = 0x9c; /* push */
+    *end++ = 0x66;
+    *end++ = 0x9d; /* popf */
+#ifndef X64
+    *end++ = 0x66;
+    *end++ = 0x60; /* pusha */
+    *end++ = 0x66;
+    *end++ = 0x61; /* popa */
+#endif
     ASSERT(end - buf < BUFFER_SIZE_ELEMENTS(buf));
 
+    pc = buf;
+    while (pc < end)
+        pc = disassemble_with_info(GD, pc, STDOUT, false /*no pc*/, true);
+
+    disassemble_set_syntax(DR_DISASM_ATT);
     pc = buf;
     while (pc < end)
         pc = disassemble_with_info(GD, pc, STDOUT, false /*no pc*/, true);

--- a/suite/tests/api/drdecode_x86.template
+++ b/suite/tests/api/drdecode_x86.template
@@ -3,7 +3,6 @@
  bf 11 00 00 00       mov    $0x00000011 -> %edi
  48 cf                iret   %rsp (%rsp)[40byte] -> %rsp
  9c                   pushf  %rsp -> %rsp 0xfffffff8(%rsp)[8byte]
- 9c                   pushf  %rsp -> %rsp 0xfffffff8(%rsp)[8byte]
  9d                   popf   %rsp (%rsp)[8byte] -> %rsp
  66 cf                data16 iret   %rsp (%rsp)[6byte] -> %rsp
  66 9c                data16 pushf  %rsp -> %rsp 0xfffffffe(%rsp)[2byte]
@@ -11,7 +10,6 @@
  89 41 fd             mov    %eax, -0x03(%rcx)
  bf 11 00 00 00       mov    $0x00000011, %edi
  48 cf                iretq
- 9c                   pushfq
  9c                   pushfq
  9d                   popfq
  66 cf                data16 iretw
@@ -21,7 +19,6 @@
  bf 11 00 00 00       mov    edi, 0x00000011
  48 cf                iretq
  9c                   pushfq
- 9c                   pushfq
  9d                   popfq
  66 cf                iret
  66 9c                pushf
@@ -30,7 +27,6 @@
  89 41 fd             mov    %eax -> 0xfffffffd(%ecx)[4byte]
  bf 11 00 00 00       mov    $0x00000011 -> %edi
  cf                   iret   %esp (%esp)[12byte] -> %esp
- 9c                   pushf  %esp -> %esp 0xfffffffc(%esp)[4byte]
  9c                   pushf  %esp -> %esp 0xfffffffc(%esp)[4byte]
  9d                   popf   %esp (%esp)[4byte] -> %esp
  60                   pusha  %esp %eax %ebx %ecx %edx %ebp %esi %edi -> %esp 0xffffffe0(%esp)[32byte]
@@ -44,7 +40,6 @@
  bf 11 00 00 00       mov    $0x00000011, %edi
  cf                   iretd
  9c                   pushfd
- 9c                   pushfd
  9d                   popfd
  60                   pushad
  61                   popad
@@ -56,7 +51,6 @@
  89 41 fd             mov    dword ptr [ecx-0x03], eax
  bf 11 00 00 00       mov    edi, 0x00000011
  cf                   iretd
- 9c                   pushfd
  9c                   pushfd
  9d                   popfd
  60                   pushad

--- a/suite/tests/api/drdecode_x86.template
+++ b/suite/tests/api/drdecode_x86.template
@@ -1,12 +1,70 @@
 #ifdef X64
  89 41 fd             mov    %eax -> 0xfffffffd(%rcx)[4byte]
  bf 11 00 00 00       mov    $0x00000011 -> %edi
+ 48 cf                iret   %rsp (%rsp)[40byte] -> %rsp
+ 9c                   pushf  %rsp -> %rsp 0xfffffff8(%rsp)[8byte]
+ 9c                   pushf  %rsp -> %rsp 0xfffffff8(%rsp)[8byte]
+ 9d                   popf   %rsp (%rsp)[8byte] -> %rsp
+ 66 cf                data16 iret   %rsp (%rsp)[6byte] -> %rsp
+ 66 9c                data16 pushf  %rsp -> %rsp 0xfffffffe(%rsp)[2byte]
+ 66 9d                data16 popf   %rsp (%rsp)[2byte] -> %rsp
+ 89 41 fd             mov    %eax, -0x03(%rcx)
+ bf 11 00 00 00       mov    $0x00000011, %edi
+ 48 cf                iretq
+ 9c                   pushfq
+ 9c                   pushfq
+ 9d                   popfq
+ 66 cf                data16 iretw
+ 66 9c                data16 pushfw
+ 66 9d                data16 popfw
  89 41 fd             mov    dword ptr [rcx-0x03], eax
  bf 11 00 00 00       mov    edi, 0x00000011
+ 48 cf                iretq
+ 9c                   pushfq
+ 9c                   pushfq
+ 9d                   popfq
+ 66 cf                iret
+ 66 9c                pushf
+ 66 9d                popf
 #else
  89 41 fd             mov    %eax -> 0xfffffffd(%ecx)[4byte]
  bf 11 00 00 00       mov    $0x00000011 -> %edi
+ cf                   iret   %esp (%esp)[12byte] -> %esp
+ 9c                   pushf  %esp -> %esp 0xfffffffc(%esp)[4byte]
+ 9c                   pushf  %esp -> %esp 0xfffffffc(%esp)[4byte]
+ 9d                   popf   %esp (%esp)[4byte] -> %esp
+ 60                   pusha  %esp %eax %ebx %ecx %edx %ebp %esi %edi -> %esp 0xffffffe0(%esp)[32byte]
+ 61                   popa   %esp (%esp)[32byte] -> %esp %eax %ebx %ecx %edx %ebp %esi %edi
+ 66 cf                data16 iret   %esp (%esp)[6byte] -> %esp
+ 66 9c                data16 pushf  %esp -> %esp 0xfffffffe(%esp)[2byte]
+ 66 9d                data16 popf   %esp (%esp)[2byte] -> %esp
+ 66 60                data16 pusha  %esp %ax %bx %cx %dx %bp %si %di -> %esp 0xfffffff0(%esp)[16byte]
+ 66 61                data16 popa   %esp (%esp)[16byte] -> %esp %ax %bx %cx %dx %bp %si %di
+ 89 41 fd             mov    %eax, -0x03(%ecx)
+ bf 11 00 00 00       mov    $0x00000011, %edi
+ cf                   iretd
+ 9c                   pushfd
+ 9c                   pushfd
+ 9d                   popfd
+ 60                   pushad
+ 61                   popad
+ 66 cf                data16 iretw
+ 66 9c                data16 pushfw
+ 66 9d                data16 popfw
+ 66 60                data16 pushaw
+ 66 61                data16 popaw
  89 41 fd             mov    dword ptr [ecx-0x03], eax
  bf 11 00 00 00       mov    edi, 0x00000011
+ cf                   iretd
+ 9c                   pushfd
+ 9c                   pushfd
+ 9d                   popfd
+ 60                   pushad
+ 61                   popad
+ 66 cf                iret
+ 66 9c                pushf
+ 66 9d                popf
+ 66 60                pusha
+ 66 61                popa
 #endif
 done


### PR DESCRIPTION
Removes the 'w' suffix from iret, pushf, popf, pusha, and popa, since these do not have a suffix at that size in the Intel manual nor in xed.

Fixes #8043