### PR TITLE
i#8047: organize name comparison against vdso

### DIFF
--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -175,9 +175,11 @@ offline_instru_t::load_custom_module_data(module_data_t *module, int seg_idx)
     // for vdso code.  So we just find the vdso here, and pass through the user's data
     // for all modules.
     if (seg_idx == 0 &&
-        (name != nullptr &&
-         (strstr(name, "linux-gate.so") == name ||
-          strstr(name, "linux-vdso.so") == name || strcmp(name, "[vdso]") == 0))) {
+        ((name != nullptr &&
+          (strstr(name, "linux-gate.so") == name ||
+           strstr(name, "linux-vdso.so") == name)) ||
+         (module->names.file_name != NULL &&
+          strcmp(module->names.file_name, "[vdso]") == 0))) {
         DR_ASSERT(vdso_modbase_.load(std::memory_order_acquire) == 0 ||
                   vdso_modbase_.load(std::memory_order_acquire) ==
                       reinterpret_cast<uintptr_t>(module->start));

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -176,9 +176,8 @@ offline_instru_t::load_custom_module_data(module_data_t *module, int seg_idx)
     // for all modules.
     if (seg_idx == 0 &&
         (name != nullptr &&
-          (strstr(name, "linux-gate.so") == name ||
-           strstr(name, "linux-vdso.so") == name ||
-           strcmp(name, "[vdso]") == 0))) {
+         (strstr(name, "linux-gate.so") == name ||
+          strstr(name, "linux-vdso.so") == name || strcmp(name, "[vdso]") == 0))) {
         DR_ASSERT(vdso_modbase_.load(std::memory_order_acquire) == 0 ||
                   vdso_modbase_.load(std::memory_order_acquire) ==
                       reinterpret_cast<uintptr_t>(module->start));

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -175,10 +175,10 @@ offline_instru_t::load_custom_module_data(module_data_t *module, int seg_idx)
     // for vdso code.  So we just find the vdso here, and pass through the user's data
     // for all modules.
     if (seg_idx == 0 &&
-        ((name != nullptr &&
+        (name != nullptr &&
           (strstr(name, "linux-gate.so") == name ||
-           strstr(name, "linux-vdso.so") == name)) ||
-         (module->names.file_name != NULL && strcmp(name, "[vdso]") == 0))) {
+           strstr(name, "linux-vdso.so") == name ||
+           strcmp(name, "[vdso]") == 0))) {
         DR_ASSERT(vdso_modbase_.load(std::memory_order_acquire) == 0 ||
                   vdso_modbase_.load(std::memory_order_acquire) ==
                       reinterpret_cast<uintptr_t>(module->start));


### PR DESCRIPTION
Remove the redundant `module->names.file_name` check and move the `name == "[vdso]"` check beside `name != nullptr`.

Fixes: #8047