### PR TITLE
i#8021: Include source files in ir/ and ir/x86/ as dependencies for kernel module

### DIFF
--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -684,6 +684,7 @@ internal_opnd_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT,
         }
     } break;
     case IMMED_FLOAT_kind: {
+#ifndef LINUX_KERNEL
         /* Save floating state for float printing. */
         PRESERVE_FLOATING_POINT_STATE({
             uint top;
@@ -693,6 +694,10 @@ internal_opnd_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT,
             print_to_buffer(buf, bufsz, sofar, "%s%s%u.%.6u", immed_prefix(), sign, top,
                             bottom);
         });
+#else
+        print_to_buffer(buf, bufsz, sofar, "%s0x%08x", immed_prefix(),
+                        *(const uint *)&opnd.value.immed_float);
+#endif
         break;
     }
 #ifndef WINDOWS
@@ -701,6 +706,7 @@ internal_opnd_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT,
          * not equal EXPECTED_SIZEOF_OPND, triggering the ASSERT in d_r_arch_init().
          */
     case IMMED_DOUBLE_kind: {
+#    ifndef LINUX_KERNEL
         PRESERVE_FLOATING_POINT_STATE({
             uint top;
             uint bottom;
@@ -709,6 +715,10 @@ internal_opnd_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT,
             print_to_buffer(buf, bufsz, sofar, "%s%s%u.%.6u", immed_prefix(), sign, top,
                             bottom);
         });
+#    else
+        print_to_buffer(buf, bufsz, sofar, "%s0x" ZHEX64_FORMAT_STRING, immed_prefix(),
+                        *(const uint64 *)&opnd.value.immed_double);
+#    endif
         break;
     }
 #endif

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -532,6 +532,7 @@ opnd_get_immed_int64(opnd_t opnd)
         (uint64)(uint)opnd.value.immed_int_multi_part.low;
 }
 
+#ifndef LINUX_KERNEL
 /* NOTE: requires caller to be under PRESERVE_FLOATING_POINT_STATE */
 float
 opnd_get_immed_float(opnd_t opnd)
@@ -544,7 +545,7 @@ opnd_get_immed_float(opnd_t opnd)
     return opnd.value.immed_float;
 }
 
-#ifndef WINDOWS
+#    ifndef WINDOWS
 /* XXX i#4488: x87 floating point immediates should be double precision.
  * Type double currently not included for Windows because sizeof(opnd_t) does
  * not equal EXPECTED_SIZEOF_OPND, triggering the ASSERT in d_r_arch_init().
@@ -556,7 +557,8 @@ opnd_get_immed_double(opnd_t opnd)
                   "opnd_get_immed_double called on non-immed-float");
     return opnd.value.immed_double;
 }
-#endif
+#    endif
+#endif /* !LINUX_KERNEL */
 
 /* address operands */
 

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -1660,7 +1660,7 @@ instr_predicate_triggered(instr_t *instr, dr_mcontext_t *mc)
                 ptr_int_t val;
                 if (!d_r_safe_read(opnd_compute_address(src, mc),
                                    MIN(opnd_get_size(src), sizeof(val)), &val))
-                    return false;
+                    return DR_PRED_TRIGGER_UNKNOWN;
                 return (val != 0) ? DR_PRED_TRIGGER_MATCH : DR_PRED_TRIGGER_MISMATCH;
             } else
                 CLIENT_ASSERT(false, "invalid predicate/instr combo");

--- a/core/kernel_linux/CMakeLists.txt
+++ b/core/kernel_linux/CMakeLists.txt
@@ -70,6 +70,13 @@ set(dynamorio_module_sources
   ../translate.c
   ../utils.c
   ../vmareas.c
+  ../ir/decode_shared.c
+  ../ir/disassemble_shared.c
+  ../ir/encode_shared.c
+  ../ir/instr_shared.c
+  ../ir/instrlist.c
+  ../ir/ir_utils_shared.c
+  ../ir/opnd_shared.c
 )
 
 set(dynamorio_module_ko "${CMAKE_CURRENT_BINARY_DIR}/${dynamorio_module_name}.ko")

--- a/core/kernel_linux/CMakeLists.txt
+++ b/core/kernel_linux/CMakeLists.txt
@@ -69,6 +69,7 @@ set(dynamorio_module_sources
   ../synch.c
   ../translate.c
   ../utils.c
+  ../vmareas.c
 )
 
 set(dynamorio_module_ko "${CMAKE_CURRENT_BINARY_DIR}/${dynamorio_module_name}.ko")

--- a/core/kernel_linux/CMakeLists.txt
+++ b/core/kernel_linux/CMakeLists.txt
@@ -67,6 +67,7 @@ set(dynamorio_module_sources
   ../stats.c
   ../string.c
   ../synch.c
+  ../translate.c
 )
 
 set(dynamorio_module_ko "${CMAKE_CURRENT_BINARY_DIR}/${dynamorio_module_name}.ko")

--- a/core/kernel_linux/CMakeLists.txt
+++ b/core/kernel_linux/CMakeLists.txt
@@ -46,6 +46,8 @@ set(dynamorio_module_sources
   dynamorio_module_main.c
   kernel_interface.c
   os.c
+
+  # core/
   ../buildmark.c
   ../config.c
   ../dispatch.c
@@ -70,6 +72,8 @@ set(dynamorio_module_sources
   ../translate.c
   ../utils.c
   ../vmareas.c
+
+  # core/ir/
   ../ir/decode_shared.c
   ../ir/disassemble_shared.c
   ../ir/encode_shared.c
@@ -77,6 +81,16 @@ set(dynamorio_module_sources
   ../ir/instrlist.c
   ../ir/ir_utils_shared.c
   ../ir/opnd_shared.c
+
+  # core/ir/x86/
+  ../ir/x86/decode.c
+  ../ir/x86/decode_fast.c
+  ../ir/x86/decode_table.c
+  ../ir/x86/disassemble.c
+  ../ir/x86/encode.c
+  ../ir/x86/instr.c
+  ../ir/x86/ir_utils.c
+  ../ir/x86/opnd.c
 )
 
 set(dynamorio_module_ko "${CMAKE_CURRENT_BINARY_DIR}/${dynamorio_module_name}.ko")

--- a/core/kernel_linux/CMakeLists.txt
+++ b/core/kernel_linux/CMakeLists.txt
@@ -68,6 +68,7 @@ set(dynamorio_module_sources
   ../string.c
   ../synch.c
   ../translate.c
+  ../utils.c
 )
 
 set(dynamorio_module_ko "${CMAKE_CURRENT_BINARY_DIR}/${dynamorio_module_name}.ko")

--- a/core/translate.c
+++ b/core/translate.c
@@ -1267,6 +1267,13 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
 {
     recreate_success_t res = (just_pc ? RECREATE_SUCCESS_PC : RECREATE_SUCCESS_STATE);
 #ifndef LINUX_KERNEL
+    /* These hold copies of the state so a client tool can inspect/adjust it before we
+     * restore it. We are skipping this under LINUX_KERNEL for now: client instrumentation
+     * events aren't wired up there yet, and skipping also keeps us under the kernel's
+     * -Wframe-larger-than=4096 stack limit.
+     * TODO i#8021: Once we start implementing kernel instrumentation we may need heap
+     * allocation for these fields instead.
+     */
     dr_mcontext_t xl8_mcontext;
     dr_mcontext_t raw_mcontext;
     dr_mcontext_init(&xl8_mcontext);

--- a/core/translate.c
+++ b/core/translate.c
@@ -1266,10 +1266,12 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
                             bool just_pc, fragment_t *owning_f, bool restore_memory)
 {
     recreate_success_t res = (just_pc ? RECREATE_SUCCESS_PC : RECREATE_SUCCESS_STATE);
+#ifndef LINUX_KERNEL
     dr_mcontext_t xl8_mcontext;
     dr_mcontext_t raw_mcontext;
     dr_mcontext_init(&xl8_mcontext);
     dr_mcontext_init(&raw_mcontext);
+#endif
 #ifdef WINDOWS
     if (get_syscall_method() == SYSCALL_METHOD_SYSENTER &&
         mcontext->pc == vsyscall_after_syscall && mcontext->xsp != 0) {
@@ -1344,11 +1346,13 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
 #    endif
         if (!just_pc) {
             restore_stolen_register(tdcontext, mcontext);
+#    ifndef LINUX_KERNEL
             if (dr_xl8_hook_exists()) {
                 if (!instrument_restore_nonfcache_state_prealloc(
                         tdcontext, restore_memory, mcontext, &xl8_mcontext))
                     return RECREATE_FAILURE;
             }
+#    endif
         }
         return res;
     }
@@ -1393,11 +1397,13 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
         mcontext->pc = dr_fragment_app_pc(POST_SYSCALL_PC(tdcontext));
         if (!just_pc) {
             restore_stolen_register(tdcontext, mcontext);
+#ifndef LINUX_KERNEL
             if (dr_xl8_hook_exists()) {
                 if (!instrument_restore_nonfcache_state_prealloc(
                         tdcontext, restore_memory, mcontext, &xl8_mcontext))
                     return RECREATE_FAILURE;
             }
+#endif
         }
         return res;
     } else if (mcontext->pc == get_reset_exit_stub(tdcontext)) {
@@ -1408,11 +1414,13 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
         mcontext->pc = dr_fragment_app_pc(tdcontext->next_tag);
         if (!just_pc) {
             restore_stolen_register(tdcontext, mcontext);
+#ifndef LINUX_KERNEL
             if (dr_xl8_hook_exists()) {
                 if (!instrument_restore_nonfcache_state_prealloc(
                         tdcontext, restore_memory, mcontext, &xl8_mcontext))
                     return RECREATE_FAILURE;
             }
+#endif
         }
         return res;
     } else if (in_generated_routine(tdcontext, mcontext->pc)) {
@@ -1437,7 +1445,9 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
 #ifdef WINDOWS
         bool swap_peb = false;
 #endif
+#ifndef LINUX_KERNEL
         dr_restore_state_info_t client_info;
+#endif
 #ifdef WINDOWS
         /* i#889: restore private PEB/TEB for faithful recreation */
         /* i#1832: swap_peb_pointer() calls is_dynamo_address() in debug build, which
@@ -1570,10 +1580,12 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
         ASSERT(ok);
 
         /* now recreate the state */
+#ifndef LINUX_KERNEL
         /* keep a copy of the pre-translation state */
         priv_mcontext_to_dr_mcontext(&raw_mcontext, mcontext);
         client_info.raw_mcontext = &raw_mcontext;
         client_info.raw_mcontext_valid = true;
+#endif
         if (ilist == NULL) {
             ASSERT(f != NULL && FRAGMENT_TRANSLATION_INFO(f) != NULL);
             ASSERT(!TESTANY(FRAG_WAS_DELETED, f->flags) ||
@@ -1593,6 +1605,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
 
         if (!just_pc)
             restore_stolen_register(tdcontext, mcontext);
+#ifndef LINUX_KERNEL
         if (res != RECREATE_FAILURE) {
             /* PR 214962: if the client has a restore callback, invoke it to
              * fix up the state (and pc).
@@ -1615,6 +1628,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
                 res = RECREATE_FAILURE;
             dr_mcontext_to_priv_mcontext(mcontext, &xl8_mcontext);
         }
+#endif
 
     recreate_app_state_done:
         /* free the instrlist_t elements */

--- a/core/utils.c
+++ b/core/utils.c
@@ -55,13 +55,15 @@
 #endif
 
 #ifdef UNIX
-#    include <sys/types.h>
-#    include <sys/stat.h>
-#    include <fcntl.h>
-#    include <stdio.h>
-#    include <stdlib.h>
-#    include <unistd.h>
-#    include <errno.h>
+#    include "types_wrapper.h"
+#    ifndef LINUX_KERNEL
+#        include <sys/stat.h>
+#        include <fcntl.h>
+#        include <stdio.h>
+#        include <stdlib.h>
+#        include <unistd.h>
+#        include <errno.h>
+#    endif
 #else
 #    include <errno.h>
 /* XXX : remove when syslog macros fixed */
@@ -76,8 +78,8 @@
 #    include "synch.h" /* all_threads_synch_lock */
 #endif
 
-#include <stdarg.h> /* for varargs */
-#include <stddef.h> /* for offsetof */
+#include "stdarg_wrapper.h" /* for varargs */
+#include "stddef_wrapper.h" /* for offsetof */
 
 try_except_t global_try_except;
 #ifdef UNIX
@@ -1711,6 +1713,7 @@ divide_uint64_print(uint64 numerator, uint64 denominator, bool percentage, uint 
                      (precision_multiple * *top));
 }
 
+#ifndef LINUX_KERNEL
 /* When building with /QIfist casting rounds instead of truncating (i#763)
  * so we use these routines from io.c.
  */
@@ -1745,6 +1748,7 @@ double_print(double val, uint precision, uint *top, uint *bottom, const char **s
     *top = double2int_trunc(val);
     *bottom = double2int_trunc((val - *top) * precision_multiple);
 }
+#endif
 
 #ifdef WINDOWS
 /* for pre_inject, injector, and core shared files, is just wrapper for syslog
@@ -2569,7 +2573,6 @@ strcasecmp_with_wildcards(const char *regexp, const char *consider)
             return -1;
         } else if (*consider == '\0')
             return 1;
-        ASSERT((sbyte)*regexp != EOF && (sbyte)*consider != EOF);
         cr = (char)tolower(*regexp);
         cc = (char)tolower(*consider);
         if (cr != '?' && cr != cc) {
@@ -3841,7 +3844,7 @@ MD5Transform(uint32 state[4], const unsigned char block[MD5_BLOCK_LENGTH])
 {
     uint32 a, b, c, d, in[MD5_BLOCK_LENGTH / 4];
 
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     memcpy(in, block, sizeof(in));
 #else
     for (a = 0; a < MD5_BLOCK_LENGTH / 4; a++) {

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -8319,7 +8319,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                 result = false;
             }
         }
-#endif
+#endif /* LINUX && !LINUX_KERNEL*/
         LOG(THREAD, LOG_INTERP | LOG_VMAREAS, 4,
             "check_thread_vm_area: check_stop = " PFX "\n", *stop);
     }

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -8272,7 +8272,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
     if (stop != NULL) {
         *stop = area->end;
         ASSERT(*stop != NULL);
-#ifdef LINUX
+#if defined(LINUX) && !defined(LINUX_KERNEL)
         if (!vmvector_empty(d_r_rseq_areas)) {
             /* XXX i#3798: While for core operation we do not need to end a block at
              * an rseq endpoint, we need clients to treat the endpoint as a barrier and


### PR DESCRIPTION
- Include source files as dependencies for kernel module:
    - 3 remaining files in `core/`: `translate.c`, `utils.c`, and `vmareas.c`.
    - Relevant files in `core/ir/`
    - Relevant files in `core/ir/x86/`
- Exclude functions and logic that don't apply in kernel space, such as rseq and floating point arithmetic.
- Update include headers. This includes using wrapper headers or excluding headers that don't have an equivalent in kernel.
- Some bug fixes that are uncovered by Kbuild compiler flags.

Issue: #8021 