### PR TITLE
i#8050 Fix selfmod tests on AArch64

### DIFF
--- a/api/docs/bt.dox
+++ b/api/docs/bt.dox
@@ -522,8 +522,6 @@ internal operation requires that we impose the following limitations:
    a basic block, and it must be the final application branch in the block.
  - The exit control-flow of a block ending in a system call cannot be
    changed.
- - On AArch64, an ISB instruction (#OP_isb) must be the last instruction
-   in its block.
 
 Application instructions, or non-meta instructions, in addition to being
 processed (and followed if control flow), are also considered safe points

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -295,6 +295,8 @@ Further non-compatibility-affecting changes include:
    clients from "none" to "lz4", when built against an lz4 with LZ4F_CustomMem support
    (lz4 >= 1.9.4).  lz4's allocations are routed through DR's private heap in that
    configuration.  Where that support is unavailable the static default remains "none".
+ - On AArch64 the restriction that isb instructions must be the last instruction in a
+   block has been lifted.
 
 **************************************************
 <hr>

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -2880,13 +2880,6 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
             "block's app sources (instr_set_translation() targets) "
             "must remain within original bounds");
 
-#ifdef AARCH64
-        if (instr_get_opcode(inst) == OP_isb) {
-            CLIENT_ASSERT(inst == instrlist_last(bb->ilist),
-                          "OP_isb must be last instruction in block");
-        }
-#endif
-
         /* PR 307284: we didn't process syscalls and ints pre-client
          * so do so now to get bb->flags and bb->exit_type set
          */
@@ -3897,11 +3890,6 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
             if (!bb_process_interrupt(dcontext, bb))
                 break;
         }
-#ifdef AARCH64
-        /* OP_isb, when mangled, has a potential side exit. */
-        else if (instr_get_opcode(bb->instr) == OP_isb)
-            break;
-#endif
 #if 0 /*i#1313, i#1314*/
         else if (instr_get_opcode(bb->instr) == OP_getsec) {
             /* XXX i#1313: if we support CPL0 in the future we'll need to

--- a/core/lib/dr_events.h
+++ b/core/lib/dr_events.h
@@ -267,8 +267,6 @@ DR_API
  * - A system call or interrupt instruction can only be added
  * if it satisfies the above constraints: i.e., if it is the final
  * instruction in the block and the only system call or interrupt.
- * - Any AArch64 #OP_isb instruction must be the last instruction
- * in its block.
  * - All IT blocks must be legal.  For example, application instructions
  * inside an IT block cannot be removed or added to without also
  * updating the OP_it instruction itself.  Clients can use

--- a/suite/tests/security-common/selfmod.c
+++ b/suite/tests/security-common/selfmod.c
@@ -451,6 +451,16 @@ DECL_EXTERN(print_int)
 _MYTEXT SEGMENT ALIGN(4096) READ EXECUTE SHARED ALIAS(".mytext")
 #endif
 
+#ifdef AARCH64
+/* Clear the instruction cache line containing the address in address_reg. */
+#   define CLEAR_ICACHE_LINE(address_reg) \
+        dc      cvau, address_reg @N@\
+        dsb     ish @N@\
+        ic      ivau, address_reg @N@\
+        dsb     ish @N@\
+        isb
+#endif
+
     /* The following code needs to cross a page boundary. */
 #    ifdef AARCH64
 #        define MAX_PAGE_SIZE_BYTES 65536 /* this is also a multiple of 16K and 4K so
@@ -521,12 +531,7 @@ ADDRTAKEN_LABEL(sandbox_cross_page_no_ilt:)
         orr w11, w11, w0, LSL #5 /* set imm16 to w0. */
         str w11, [x10]
 
-        /* need to invalidate the instruction cache. This tests explicit app icache management. */
-        stp x0, x1, [sp, #-16]!
-        adr x0, sandbox_cross_page
-        adr x1, sandbox_cross_page_end
-        bl clear_icache_if_required
-        ldp x0, x1, [sp], #16
+        CLEAR_ICACHE_LINE(x10)
 
         /* More writes to split the block. */
         strb w0, [x1], #1
@@ -661,12 +666,7 @@ ADDRTAKEN_LABEL(fault_immediate_addr_plus_four:)
         orr w10, w10, w0, LSL #5
         str w10, [x9]
 
-        /* need to invalidate the instruction cache. This tests explicit app icache management. */
-        stp x0, x1, [sp, #-16]!
-        adr x0, sandbox_fault
-        adr x1, sandbox_fault_end
-        bl clear_icache_if_required
-        ldp x0, x1, [sp], #16
+        CLEAR_ICACHE_LINE(x9)
 
         movz x0, #0 /* this will get updated by the code above */
 ADDRTAKEN_LABEL(fault_immediate_addr_plus_four:)
@@ -726,12 +726,7 @@ ADDRTAKEN_LABEL(illegal_immediate_addr_plus_four:)
         orr w10, w10, w0, LSL #5
         str w10, [x9]
 
-        /* need to invalidate the instruction cache. This tests explicit app icache management. */
-        stp x0, x1, [sp, #-16]!
-        adr x0, sandbox_illegal_instr
-        adr x1, sandbox_illegal_instr_end
-        bl clear_icache_if_required
-        ldp x0, x1, [sp], #16
+        CLEAR_ICACHE_LINE(x9)
 
         movz x0, #0 /* this will get updated by the code above */
 ADDRTAKEN_LABEL(illegal_immediate_addr_plus_four:)
@@ -810,10 +805,7 @@ loop_orig_target3:
         add w10, w10, 1 /* branch to 1 instr. further. */
         str w10, [x9]
 
-        /* need to invalidate the instruction cache. This tests explicit app icache management. */
-        adr x0, sandbox_cti_tgt
-        adr x1, sandbox_cti_tgt_end
-        bl clear_icache_if_required
+        CLEAR_ICACHE_LINE(x9)
 
         b branch_orig_target
 ADDRTAKEN_LABEL(branch_target_end:)
@@ -830,13 +822,7 @@ branch_orig_target:
         orr w10, w10, w11
         str w10, [x9]
 
-        /* need to invalidate the instruction cache. This tests explicit app icache management. */
-        stp x13, x13, [sp, #-16]!
-        adr x0, sandbox_cti_tgt
-        adr x1, sandbox_cti_tgt_end
-        bl clear_icache_if_required
-        ldr x13, [sp]
-        add sp, sp, #16
+        CLEAR_ICACHE_LINE(x9)
 
         adr x12, branch_orig_target2
         br x12


### PR DESCRIPTION
There was a flaw with AArch64 version of the selfmod tests. The test functions work by modifying the immediate value of a later mov instruction and observing which value was moved.

AArch64 requires explicit synchronisation to guarantee that the modification is seen by the CPU and the updated instruction is executed. The tests implemented this by calling `tools_clear_icache()` after the modification. However this undermines the test because DR detects the call as a control transfer instruction and ends the block before we get to the instruction being modified. By the time DR gets to decode and translate the modified instruction it has already been modified. The original instruction was never translated and placed in the code cache so the test doesn't actually prove that the modification was handled properly.

We can fix this by inlining the cache flush code and ensuring that there are no CTIs in between the code modification write and the modified instruction.

To this end I have also lifted the restriction requiring isb to be the last instruction of a block. This was added as part of the AArch64 selfmod mechanism which mangled ic cvau instructions to store the address range being flushed and mangled isb to do a sideline exit and perform the actual code cache flush. This mechanism has since been changed to directly flush the code cache on ic cvau and isb no longer has any special mangling so we don't need it to be the last instruction.

Fixes #8050