### PR TITLE
i#1819: close imagelist file handle in DRload

### DIFF
--- a/tools/DRload.c
+++ b/tools/DRload.c
@@ -262,6 +262,7 @@ main(int argc, char *argv[])
             else
                 fprintf(stderr, "  => FAILED\n");
         }
+        fclose(f);
         fprintf(stderr, "loaded %d images successfully\n", count);
         fflush(stderr);
     } else {


### PR DESCRIPTION
DRload's `-imagelist` handling opens the list file with `fopen()` but never
closes it after reading through it with `fgets()`, leaking the file handle
for the lifetime of the process.

Add the missing `fclose(f)` once the read loop completes.

Fixes: #1819