### PR TITLE
i#2073: fix confusing sizeof(XSP_SZ) usage

### DIFF
--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -262,7 +262,7 @@ enum {
     REGPARM_1 = REG_RDX,
     REGPARM_2 = REG_R8,
     REGPARM_3 = REG_R9,
-    REGPARM_MINSTACK = 4 * sizeof(XSP_SZ),
+    REGPARM_MINSTACK = 4 * XSP_SZ,
     REDZONE_SIZE = 0,
 #        endif
     /* In fact, for Windows the stack pointer is supposed to be
@@ -278,7 +278,7 @@ enum {
 #        ifdef MACOS
     REGPARM_END_ALIGN = 16,
 #        else
-    REGPARM_END_ALIGN = sizeof(XSP_SZ),
+    REGPARM_END_ALIGN = XSP_SZ,
 #        endif
 #    endif /* 64/32 */
 #elif defined(AARCHXX)

--- a/core/unix/native_elf.c
+++ b/core/unix/native_elf.c
@@ -780,7 +780,7 @@ native_module_at_runtime_resolve_ret(app_pc xsp, int ret_imm)
     app_pc call_tgt, ret_tgt;
 
     if (!d_r_safe_read(xsp, sizeof(app_pc), &call_tgt) ||
-        !d_r_safe_read(xsp + ret_imm + sizeof(XSP_SZ), sizeof(app_pc), &ret_tgt)) {
+        !d_r_safe_read(xsp + ret_imm + XSP_SZ, sizeof(app_pc), &ret_tgt)) {
         ASSERT(false && "fail to read app stack!\n");
         return;
     }
@@ -789,11 +789,11 @@ native_module_at_runtime_resolve_ret(app_pc xsp, int ret_imm)
         dcontext_t *dcontext = get_thread_private_dcontext();
         app_pc stub_pc = native_module_get_ret_stub(dcontext, ret_tgt);
         DEBUG_DECLARE(bool ok =)
-        safe_write_ex(xsp + ret_imm + sizeof(XSP_SZ), sizeof(app_pc), &stub_pc,
+        safe_write_ex(xsp + ret_imm + XSP_SZ, sizeof(app_pc), &stub_pc,
                       NULL /* bytes written */);
         ASSERT(stub_pc != NULL && ok);
         LOG(THREAD, LOG_ALL, 3, "replace return target " PFX " with " PFX " at " PFX "\n",
-            ret_tgt, stub_pc, (xsp + ret_imm + sizeof(XSP_SZ)));
+            ret_tgt, stub_pc, (xsp + ret_imm + XSP_SZ));
     }
 }
 


### PR DESCRIPTION
XSP_SZ is already defined as `(ssize_t)sizeof(reg_t)`, i.e. the stack
pointer width in bytes. Several call sites wrote `sizeof(XSP_SZ)`,
which actually computes `sizeof(ssize_t)` rather than the intended
value. As noted in the issue discussion, this happens to be
numerically equal on every currently supported platform (`ssize_t`
and `reg_t` are always pointer-width), so it is not a functional bug,
but it reads as one and is worth cleaning up.

Replace `sizeof(XSP_SZ)` with `XSP_SZ` at all three call sites
(core/ir/opnd.h x2, core/unix/native_elf.c x3 occurrences on 3 lines).

Fixes: #2073