### PR TITLE
i#1972: add DISABLE_DRGUI CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1688,6 +1688,11 @@ endif (WIN32)
 
 option(BUILD_EXT "build Extension libraries" ON)
 
+# i#1972: allow disabling DrGUI even when Qt5 is found, for reproducible
+# builds and to avoid Qt5-related build failures or unwanted build time/disk
+# space.
+option(DISABLE_DRGUI "Disable looking for and using Qt5 for DrGUI" OFF)
+
 # should we disallow selecting samples when core is not built?
 # right now the samples build will just fail
 option(BUILD_SAMPLES "build client samples" ON)

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -139,7 +139,7 @@ macro(add_ext_asm_target asm_file_arm asm_file_aarch64 asm_file_riscv64 asm_file
 endmacro()
 
 add_subdirectory(drcontainers)
-if (NOT ANDROID AND NOT ARM AND NOT AARCH64)
+if (NOT ANDROID AND NOT ARM AND NOT AARCH64 AND NOT DISABLE_DRGUI)
   # XXX i#1701: fails to build on Android.  May not be worth porting.
   # XXX: fails when cross-compiling for ARM or A64 on a machine with x86 Qt5 installing.
   # Working around that by just disabling for ARM and A64 completely.


### PR DESCRIPTION
Adds a DISABLE_DRGUI option, following the same pattern as the existing
DISABLE_ZLIB option, so DrGUI can be skipped even when Qt5 is found.

This is useful for:
1. Reproducible builds that always give the same result whether or not
   Qt5 is installed.
2. Situations where compiling Qt5-related code fails, so the user can
   move on instead of spending time debugging it.
3. Saving build time and disk space when DrGUI is not wanted.

Defaults to OFF, so existing behavior (build DrGUI if Qt5 is found) is
unchanged.

Fixes: #1972