### PR TITLE
i#8021: Fix wrong return value in instr_predicate_triggered

### DIFF
--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -1660,7 +1660,7 @@ instr_predicate_triggered(instr_t *instr, dr_mcontext_t *mc)
                 ptr_int_t val;
                 if (!d_r_safe_read(opnd_compute_address(src, mc),
                                    MIN(opnd_get_size(src), sizeof(val)), &val))
-                    return false;
+                    return DR_PRED_TRIGGER_UNKNOWN;
                 return (val != 0) ? DR_PRED_TRIGGER_MATCH : DR_PRED_TRIGGER_MISMATCH;
             } else
                 CLIENT_ASSERT(false, "invalid predicate/instr combo");


### PR DESCRIPTION
As discussed in #8049:

> This was flagged by `-Werror=enum-conversion`. Upon a closer look I think it's wrong to return `false` (equivalent to `DR_PRED_TRIGGER_NOPRED`) here. I think the logic here is that there is pred but DR cannot check if it matches or not, so it should return DR_PRED_TRIGGER_UNKNOWN.

Issue: #8021 