### PR TITLE
i#3544: OPFVF vector-FP scalar operand decoding as FP register

### DIFF
--- a/core/ir/riscv64/isl/v.txt
+++ b/core/ir/riscv64/isl/v.txt
@@ -87,48 +87,48 @@ vs8r.v            | r | rs1 vs3           | 111000101000.....000.....0100111
 # Vector Floating-Point Instructions
 # https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#14-vector-floating-point-instructions
 # OPFVF
-vfadd.vf          | r | vm vs2 rs1 vd     | 000000...........101.....1010111
-vfsub.vf          | r | vm vs2 rs1 vd     | 000010...........101.....1010111
-vfmin.vf          | r | vm vs2 rs1 vd     | 000100...........101.....1010111
-vfmax.vf          | r | vm vs2 rs1 vd     | 000110...........101.....1010111
-vfsgnj.vf         | r | vm vs2 rs1 vd     | 001000...........101.....1010111
-vfsgnjn.vf        | r | vm vs2 rs1 vd     | 001001...........101.....1010111
-vfsgnjx.vf        | r | vm vs2 rs1 vd     | 001010...........101.....1010111
-vfslide1up.vf     | r | vm vs2 rs1 vd     | 001110...........101.....1010111
-vfslide1down.vf   | r | vm vs2 rs1 vd     | 001111...........101.....1010111
-vfmv.s.f          | r | rs1 vd            | 010000100000.....101.....1010111
+vfadd.vf          | r | vm vs2 rs1(fp) vd     | 000000...........101.....1010111
+vfsub.vf          | r | vm vs2 rs1(fp) vd     | 000010...........101.....1010111
+vfmin.vf          | r | vm vs2 rs1(fp) vd     | 000100...........101.....1010111
+vfmax.vf          | r | vm vs2 rs1(fp) vd     | 000110...........101.....1010111
+vfsgnj.vf         | r | vm vs2 rs1(fp) vd     | 001000...........101.....1010111
+vfsgnjn.vf        | r | vm vs2 rs1(fp) vd     | 001001...........101.....1010111
+vfsgnjx.vf        | r | vm vs2 rs1(fp) vd     | 001010...........101.....1010111
+vfslide1up.vf     | r | vm vs2 rs1(fp) vd     | 001110...........101.....1010111
+vfslide1down.vf   | r | vm vs2 rs1(fp) vd     | 001111...........101.....1010111
+vfmv.s.f          | r | rs1(fp) vd            | 010000100000.....101.....1010111
 
-vfmerge.vfm       | r | vs2 rs1 vd        | 0101110..........101.....1010111
-vfmv.v.f          | r | rs1 vd            | 010111100000.....101.....1010111
-vmfeq.vf          | r | vm vs2 rs1 vd     | 011000...........101.....1010111
-vmfle.vf          | r | vm vs2 rs1 vd     | 011001...........101.....1010111
-vmflt.vf          | r | vm vs2 rs1 vd     | 011011...........101.....1010111
-vmfne.vf          | r | vm vs2 rs1 vd     | 011100...........101.....1010111
-vmfgt.vf          | r | vm vs2 rs1 vd     | 011101...........101.....1010111
-vmfge.vf          | r | vm vs2 rs1 vd     | 011111...........101.....1010111
+vfmerge.vfm       | r | vs2 rs1(fp) vd        | 0101110..........101.....1010111
+vfmv.v.f          | r | rs1(fp) vd            | 010111100000.....101.....1010111
+vmfeq.vf          | r | vm vs2 rs1(fp) vd     | 011000...........101.....1010111
+vmfle.vf          | r | vm vs2 rs1(fp) vd     | 011001...........101.....1010111
+vmflt.vf          | r | vm vs2 rs1(fp) vd     | 011011...........101.....1010111
+vmfne.vf          | r | vm vs2 rs1(fp) vd     | 011100...........101.....1010111
+vmfgt.vf          | r | vm vs2 rs1(fp) vd     | 011101...........101.....1010111
+vmfge.vf          | r | vm vs2 rs1(fp) vd     | 011111...........101.....1010111
 
-vfdiv.vf          | r | vm vs2 rs1 vd     | 100000...........101.....1010111
-vfrdiv.vf         | r | vm vs2 rs1 vd     | 100001...........101.....1010111
-vfmul.vf          | r | vm vs2 rs1 vd     | 100100...........101.....1010111
-vfrsub.vf         | r | vm vs2 rs1 vd     | 100111...........101.....1010111
-vfmadd.vf         | r | vm vs2 rs1 vd     | 101000...........101.....1010111
-vfnmadd.vf        | r | vm vs2 rs1 vd     | 101001...........101.....1010111
-vfmsub.vf         | r | vm vs2 rs1 vd     | 101010...........101.....1010111
-vfnmsub.vf        | r | vm vs2 rs1 vd     | 101011...........101.....1010111
-vfmacc.vf         | r | vm vs2 rs1 vd     | 101100...........101.....1010111
-vfnmacc.vf        | r | vm vs2 rs1 vd     | 101101...........101.....1010111
-vfmsac.vf         | r | vm vs2 rs1 vd     | 101110...........101.....1010111
-vfnmsac.vf        | r | vm vs2 rs1 vd     | 101111...........101.....1010111
+vfdiv.vf          | r | vm vs2 rs1(fp) vd     | 100000...........101.....1010111
+vfrdiv.vf         | r | vm vs2 rs1(fp) vd     | 100001...........101.....1010111
+vfmul.vf          | r | vm vs2 rs1(fp) vd     | 100100...........101.....1010111
+vfrsub.vf         | r | vm vs2 rs1(fp) vd     | 100111...........101.....1010111
+vfmadd.vf         | r | vm vs2 rs1(fp) vd     | 101000...........101.....1010111
+vfnmadd.vf        | r | vm vs2 rs1(fp) vd     | 101001...........101.....1010111
+vfmsub.vf         | r | vm vs2 rs1(fp) vd     | 101010...........101.....1010111
+vfnmsub.vf        | r | vm vs2 rs1(fp) vd     | 101011...........101.....1010111
+vfmacc.vf         | r | vm vs2 rs1(fp) vd     | 101100...........101.....1010111
+vfnmacc.vf        | r | vm vs2 rs1(fp) vd     | 101101...........101.....1010111
+vfmsac.vf         | r | vm vs2 rs1(fp) vd     | 101110...........101.....1010111
+vfnmsac.vf        | r | vm vs2 rs1(fp) vd     | 101111...........101.....1010111
 
-vfwadd.vf         | r | vm vs2 rs1 vd     | 110000...........101.....1010111
-vfwsub.vf         | r | vm vs2 rs1 vd     | 110010...........101.....1010111
-vfwadd.wf         | r | vm vs2 rs1 vd     | 110100...........101.....1010111
-vfwsub.wf         | r | vm vs2 rs1 vd     | 110110...........101.....1010111
-vfwmul.vf         | r | vm vs2 rs1 vd     | 111000...........101.....1010111
-vfwmacc.vf        | r | vm vs2 rs1 vd     | 111100...........101.....1010111
-vfwnmacc.vf       | r | vm vs2 rs1 vd     | 111101...........101.....1010111
-vfwmsac.vf        | r | vm vs2 rs1 vd     | 111110...........101.....1010111
-vfwnmsac.vf       | r | vm vs2 rs1 vd     | 111111...........101.....1010111
+vfwadd.vf         | r | vm vs2 rs1(fp) vd     | 110000...........101.....1010111
+vfwsub.vf         | r | vm vs2 rs1(fp) vd     | 110010...........101.....1010111
+vfwadd.wf         | r | vm vs2 rs1(fp) vd     | 110100...........101.....1010111
+vfwsub.wf         | r | vm vs2 rs1(fp) vd     | 110110...........101.....1010111
+vfwmul.vf         | r | vm vs2 rs1(fp) vd     | 111000...........101.....1010111
+vfwmacc.vf        | r | vm vs2 rs1(fp) vd     | 111100...........101.....1010111
+vfwnmacc.vf       | r | vm vs2 rs1(fp) vd     | 111101...........101.....1010111
+vfwmsac.vf        | r | vm vs2 rs1(fp) vd     | 111110...........101.....1010111
+vfwnmsac.vf       | r | vm vs2 rs1(fp) vd     | 111111...........101.....1010111
 
 # OPFVV
 vfadd.vv          | r | vm vs2 vs1 vd     | 000000...........001.....1010111

--- a/suite/tests/api/ir_rvv.c
+++ b/suite/tests/api/ir_rvv.c
@@ -152,15 +152,32 @@ static byte buf[8192];
         opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b)); \
     test_instr_encoding(dc, OP_##opcode, instr);
 
+#define TEST_Vd_Rs1fp_Vs2_vm(opcode)                                       \
+    instr = INSTR_CREATE_##opcode(                                         \
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_F11),      \
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b)); \
+    test_instr_encoding(dc, OP_##opcode, instr);
+
 #define TEST_Vd_Rs1_Vs2(opcode)                                                         \
     instr =                                                                             \
         INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0),                          \
                               opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2)); \
     test_instr_encoding(dc, OP_##opcode, instr);
 
+#define TEST_Vd_Rs1fp_Vs2(opcode)                                                        \
+    instr =                                                                              \
+        INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0),                           \
+                              opnd_create_reg(DR_REG_F11), opnd_create_reg(DR_REG_VR2)); \
+    test_instr_encoding(dc, OP_##opcode, instr);
+
 #define TEST_Vd_Rs1(opcode)                                        \
     instr = INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0), \
                                   opnd_create_reg(DR_REG_A1));     \
+    test_instr_encoding(dc, OP_##opcode, instr);
+
+#define TEST_Vd_Rs1fp(opcode)                                      \
+    instr = INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0), \
+                                  opnd_create_reg(DR_REG_F11));    \
     test_instr_encoding(dc, OP_##opcode, instr);
 
 #define TEST_Vd_Vs1_Vs2_vm(opcode)                                         \
@@ -365,47 +382,47 @@ test_load_store(void *dc)
 static void
 test_FVF(void *dc)
 {
-    TEST_Vd_Rs1_Vs2_vm(vfadd_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfsub_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfmin_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfmax_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfsgnj_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfsgnjn_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfsgnjx_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfslide1up_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfslide1down_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfadd_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfsub_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfmin_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfmax_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfsgnj_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfsgnjn_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfsgnjx_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfslide1up_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfslide1down_vf);
 
-    TEST_Vd_Rs1(vfmv_s_f);
-    TEST_Vd_Rs1(vfmv_v_f);
+    TEST_Vd_Rs1fp(vfmv_s_f);
+    TEST_Vd_Rs1fp(vfmv_v_f);
 
-    TEST_Vd_Rs1_Vs2(vfmerge_vfm);
-    TEST_Vd_Rs1_Vs2_vm(vmfeq_vf);
-    TEST_Vd_Rs1_Vs2_vm(vmfle_vf);
-    TEST_Vd_Rs1_Vs2_vm(vmflt_vf);
-    TEST_Vd_Rs1_Vs2_vm(vmfne_vf);
-    TEST_Vd_Rs1_Vs2_vm(vmfgt_vf);
-    TEST_Vd_Rs1_Vs2_vm(vmfge_vf);
+    TEST_Vd_Rs1fp_Vs2(vfmerge_vfm);
+    TEST_Vd_Rs1fp_Vs2_vm(vmfeq_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vmfle_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vmflt_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vmfne_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vmfgt_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vmfge_vf);
 
-    TEST_Vd_Rs1_Vs2_vm(vfrdiv_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfmul_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfrsub_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfmadd_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfnmadd_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfmsub_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfnmsub_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfmacc_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfnmacc_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfmsac_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfnmsac_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfwadd_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfwsub_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfwadd_wf);
-    TEST_Vd_Rs1_Vs2_vm(vfwsub_wf);
-    TEST_Vd_Rs1_Vs2_vm(vfwmul_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfwmacc_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfwnmacc_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfwmsac_vf);
-    TEST_Vd_Rs1_Vs2_vm(vfwnmsac_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfrdiv_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfmul_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfrsub_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfmadd_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfnmadd_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfmsub_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfnmsub_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfmacc_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfnmacc_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfmsac_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfnmsac_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwadd_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwsub_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwadd_wf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwsub_wf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwmul_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwmacc_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwnmacc_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwmsac_vf);
+    TEST_Vd_Rs1fp_Vs2_vm(vfwnmsac_vf);
 }
 
 static void

--- a/suite/tests/api/ir_rvv.expect
+++ b/suite/tests/api/ir_rvv.expect
@@ -61,44 +61,44 @@ vs2r.v v0 -> (a1)
 vs4r.v v0 -> (a1)
 vs8r.v v0 -> (a1)
 test_load_store complete
-vfadd.vf a1 v2 0x1 -> v0
-vfsub.vf a1 v2 0x1 -> v0
-vfmin.vf a1 v2 0x1 -> v0
-vfmax.vf a1 v2 0x1 -> v0
-vfsgnj.vf a1 v2 0x1 -> v0
-vfsgnjn.vf a1 v2 0x1 -> v0
-vfsgnjx.vf a1 v2 0x1 -> v0
-vfslide1up.vf a1 v2 0x1 -> v0
-vfslide1down.vf a1 v2 0x1 -> v0
-vfmv.s.f a1 -> v0
-vfmv.v.f a1 -> v0
-vfmerge.vfm a1 v2 -> v0
-vmfeq.vf a1 v2 0x1 -> v0
-vmfle.vf a1 v2 0x1 -> v0
-vmflt.vf a1 v2 0x1 -> v0
-vmfne.vf a1 v2 0x1 -> v0
-vmfgt.vf a1 v2 0x1 -> v0
-vmfge.vf a1 v2 0x1 -> v0
-vfrdiv.vf a1 v2 0x1 -> v0
-vfmul.vf a1 v2 0x1 -> v0
-vfrsub.vf a1 v2 0x1 -> v0
-vfmadd.vf a1 v2 0x1 -> v0
-vfnmadd.vf a1 v2 0x1 -> v0
-vfmsub.vf a1 v2 0x1 -> v0
-vfnmsub.vf a1 v2 0x1 -> v0
-vfmacc.vf a1 v2 0x1 -> v0
-vfnmacc.vf a1 v2 0x1 -> v0
-vfmsac.vf a1 v2 0x1 -> v0
-vfnmsac.vf a1 v2 0x1 -> v0
-vfwadd.vf a1 v2 0x1 -> v0
-vfwsub.vf a1 v2 0x1 -> v0
-vfwadd.wf a1 v2 0x1 -> v0
-vfwsub.wf a1 v2 0x1 -> v0
-vfwmul.vf a1 v2 0x1 -> v0
-vfwmacc.vf a1 v2 0x1 -> v0
-vfwnmacc.vf a1 v2 0x1 -> v0
-vfwmsac.vf a1 v2 0x1 -> v0
-vfwnmsac.vf a1 v2 0x1 -> v0
+vfadd.vf fa1 v2 0x1 -> v0
+vfsub.vf fa1 v2 0x1 -> v0
+vfmin.vf fa1 v2 0x1 -> v0
+vfmax.vf fa1 v2 0x1 -> v0
+vfsgnj.vf fa1 v2 0x1 -> v0
+vfsgnjn.vf fa1 v2 0x1 -> v0
+vfsgnjx.vf fa1 v2 0x1 -> v0
+vfslide1up.vf fa1 v2 0x1 -> v0
+vfslide1down.vf fa1 v2 0x1 -> v0
+vfmv.s.f fa1 -> v0
+vfmv.v.f fa1 -> v0
+vfmerge.vfm fa1 v2 -> v0
+vmfeq.vf fa1 v2 0x1 -> v0
+vmfle.vf fa1 v2 0x1 -> v0
+vmflt.vf fa1 v2 0x1 -> v0
+vmfne.vf fa1 v2 0x1 -> v0
+vmfgt.vf fa1 v2 0x1 -> v0
+vmfge.vf fa1 v2 0x1 -> v0
+vfrdiv.vf fa1 v2 0x1 -> v0
+vfmul.vf fa1 v2 0x1 -> v0
+vfrsub.vf fa1 v2 0x1 -> v0
+vfmadd.vf fa1 v2 0x1 -> v0
+vfnmadd.vf fa1 v2 0x1 -> v0
+vfmsub.vf fa1 v2 0x1 -> v0
+vfnmsub.vf fa1 v2 0x1 -> v0
+vfmacc.vf fa1 v2 0x1 -> v0
+vfnmacc.vf fa1 v2 0x1 -> v0
+vfmsac.vf fa1 v2 0x1 -> v0
+vfnmsac.vf fa1 v2 0x1 -> v0
+vfwadd.vf fa1 v2 0x1 -> v0
+vfwsub.vf fa1 v2 0x1 -> v0
+vfwadd.wf fa1 v2 0x1 -> v0
+vfwsub.wf fa1 v2 0x1 -> v0
+vfwmul.vf fa1 v2 0x1 -> v0
+vfwmacc.vf fa1 v2 0x1 -> v0
+vfwnmacc.vf fa1 v2 0x1 -> v0
+vfwmsac.vf fa1 v2 0x1 -> v0
+vfwnmsac.vf fa1 v2 0x1 -> v0
 test_FVF complete
 vfadd.vv v1 v2 0x1 -> v0
 vfredusum.vs v1 v2 0x1 -> v0


### PR DESCRIPTION
The OPFVF vector floating-point instructions (OP-V major opcode with funct3=3'b101, e.g. vfadd.vf, vfmv.s.f, vfmerge.vfm) encode their scalar operand in the rs1 field as a floating-point register (f0-f31), per the RISC-V V spec.  Their ISL entries in core/ir/riscv64/isl/v.txt declared this operand as rs1, which selects the integer-register decoder (decode_rs1_opnd -> DR_REG_X0+) instead of the floating-point decoder (decode_rs1fp_opnd -> DR_REG_F0+).  As a result the scalar FP operand was decoded from the wrong register file.

Issue: #3544