### PR TITLE
i#8058: Remove missing headers to fix build

### DIFF
--- a/ext/drsyscall/linux_defines.h
+++ b/ext/drsyscall/linux_defines.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -150,8 +150,6 @@
 #elif !defined(ANDROID)
 #    include <sys/mtio.h>
 #endif
-#include <linux/netrom.h>
-#include <linux/scc.h>
 
 /* i#911: linux/smb_fs.h is missing on FC16 so we define on our own */
 #define SMB_IOC_GETMOUNTUID _IOR('u', 1, __kernel_old_uid_t)


### PR DESCRIPTION
Removes the linux/netrom.h and linux/scc.h headers from drsyscall's includes, as these headers have been removed in recent kernels.  The corresponding ioctl codes are already disabled so this removal does not cause any problems.

Tested on a build on a recent kernel which failed without this change and works with the change.

Fixes #8058