### PR TITLE
i#8056: Fix flaky fork tests

### DIFF
--- a/clients/drcachesim/tests/offline-fork.templatex
+++ b/clients/drcachesim/tests/offline-fork.templatex
@@ -1,5 +1,4 @@
 parent is running under DynamoRIO
-parent waiting for child
 child is running under DynamoRIO
 child has exited
 Cache simulation results:

--- a/suite/tests/linux/execve-client.expect
+++ b/suite/tests/linux/execve-client.expect
@@ -1,6 +1,5 @@
 large_options passed: -paramA foo -paramB bar
 parent is running under DynamoRIO
-parent waiting for child
 child is running under DynamoRIO
 large_options passed: -paramA foo -paramB bar
 it_worked

--- a/suite/tests/linux/execve.c
+++ b/suite/tests/linux/execve.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -66,7 +66,6 @@ main(int argc, char *argv[])
         perror("ERROR on fork");
     } else if (child > 0) {
         pid_t result;
-        print("parent waiting for child\n");
         result = waitpid(child, NULL, 0);
         assert(result == child);
         print("child has exited\n");

--- a/suite/tests/linux/execve.expect
+++ b/suite/tests/linux/execve.expect
@@ -1,5 +1,4 @@
 parent is running under DynamoRIO
-parent waiting for child
 child is running under DynamoRIO
 it_worked
 running under DynamoRIO

--- a/suite/tests/linux/fork.c
+++ b/suite/tests/linux/fork.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -58,7 +58,6 @@ main(int argc, char **argv)
         perror("ERROR on fork");
     } else if (child > 0) {
         pid_t result;
-        print("parent waiting for child\n");
         result = waitpid(child, NULL, 0);
         assert(result == child);
         print("child has exited\n");

--- a/suite/tests/linux/fork.expect
+++ b/suite/tests/linux/fork.expect
@@ -1,4 +1,3 @@
 parent is running under DynamoRIO
-parent waiting for child
 child is running under DynamoRIO
 child has exited


### PR DESCRIPTION
Removes a parent printout that races with the child's print and results in a flaky test (though it is very rare and we've only seen it once in the last several years).

Fixes #8056