### PR TITLE
i#8060: Fix drmemtrace leak across fork

### DIFF
--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -352,6 +352,53 @@ static const LZ4F_CustomMem lz4_custom_mem = { lz4_redirect_malloc, lz4_redirect
                                                /*opaqueState=*/nullptr };
 #endif
 
+/* Frees compression resources tied to the current file, but does not flush
+ * data or close the file.
+ */
+static void
+free_compression_file_data(void *drcontext, per_thread_t *data)
+{
+#ifdef HAS_SNAPPY
+    if (op_offline.get_value() && snappy_enabled()) {
+        data->snappy_writer->~snappy_file_writer_t();
+        dr_custom_free(nullptr, static_cast<dr_alloc_flags_t>(0), data->snappy_writer,
+                       sizeof(*data->snappy_writer));
+        data->snappy_writer = nullptr;
+    }
+#endif
+#ifdef HAS_ZLIB
+    if (op_offline.get_value() &&
+        (op_raw_compress.get_value() == "zlib" ||
+         op_raw_compress.get_value() == "gzip")) {
+        deflateEnd(&data->zstream);
+    }
+#endif
+#ifdef HAS_LZ4
+    if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
+        size_t res = LZ4F_freeCompressionContext(data->lzcxt);
+        DR_ASSERT(!LZ4F_isError(res));
+    }
+#endif
+}
+
+/* Frees compression resources independent of any open file. */
+static void
+exit_compression(void *drcontext, per_thread_t *data)
+{
+#ifdef HAS_ZLIB
+    if (op_offline.get_value() &&
+        (op_raw_compress.get_value() == "zlib" ||
+         op_raw_compress.get_value() == "gzip")) {
+        dr_raw_mem_free(data->buf_compressed, max_buf_size);
+    }
+#endif
+#ifdef HAS_LZ4
+    if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
+        dr_raw_mem_free(data->buf_lz4, data->buf_lz4_size);
+    }
+#endif
+}
+
 int
 append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t window)
 {
@@ -397,12 +444,10 @@ static void
 close_thread_file(void *drcontext)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
+
 #ifdef HAS_SNAPPY
     if (op_offline.get_value() && snappy_enabled()) {
-        data->snappy_writer->~snappy_file_writer_t();
-        dr_custom_free(nullptr, static_cast<dr_alloc_flags_t>(0), data->snappy_writer,
-                       sizeof(*data->snappy_writer));
-        data->snappy_writer = nullptr;
+        free_compression_file_data(drcontext, data);
     }
 #endif
 #ifdef HAS_ZLIB
@@ -425,7 +470,7 @@ close_thread_file(void *drcontext)
                                      max_buf_size - data->zstream.avail_out);
         } while ((res == Z_OK || res == Z_BUF_ERROR) && ++iters < MAX_ITERS);
         DR_ASSERT(res == Z_STREAM_END);
-        deflateEnd(&data->zstream);
+        free_compression_file_data(drcontext, data);
     }
 #endif
 #ifdef HAS_LZ4
@@ -435,8 +480,7 @@ close_thread_file(void *drcontext)
             LZ4F_compressEnd(data->lzcxt, data->buf_lz4, data->buf_lz4_size, nullptr);
         DR_ASSERT(!LZ4F_isError(res));
         file_ops_func.write_file(data->file, data->buf_lz4, res);
-        res = LZ4F_freeCompressionContext(data->lzcxt);
-        DR_ASSERT(!LZ4F_isError(res));
+        free_compression_file_data(drcontext, data);
     }
 #endif
     file_ops_func.close_file(data->file);
@@ -1541,18 +1585,8 @@ exit_thread_io(void *drcontext)
     if (op_offline.get_value() && data->file != INVALID_FILE)
         close_thread_file(drcontext);
 
-#ifdef HAS_ZLIB
-    if (op_offline.get_value() &&
-        (op_raw_compress.get_value() == "zlib" ||
-         op_raw_compress.get_value() == "gzip")) {
-        dr_raw_mem_free(data->buf_compressed, max_buf_size);
-    }
-#endif
-#ifdef HAS_LZ4
-    if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
-        dr_raw_mem_free(data->buf_lz4, data->buf_lz4_size);
-    }
-#endif
+    exit_compression(drcontext, data);
+
 #ifdef BUILD_DRMEMTRACE_WITH_DR_SYSCALL
     if (op_collect_syscall_records.get_value()) {
         if (data->syscall_record_file != INVALID_FILE) {
@@ -1569,6 +1603,16 @@ exit_thread_io(void *drcontext)
         }
     }
 #endif
+}
+
+void
+fork_exit_thread_io(void *drcontext)
+{
+    per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
+    // We need to free data without flushing to the parent's file or closing
+    // the parent's file.
+    free_compression_file_data(drcontext, data);
+    exit_compression(drcontext, data);
 }
 
 void

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -377,6 +377,7 @@ free_compression_file_data(void *drcontext, per_thread_t *data)
     if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
         size_t res = LZ4F_freeCompressionContext(data->lzcxt);
         DR_ASSERT(!LZ4F_isError(res));
+        data->lzcxt = nullptr;
     }
 #endif
 }
@@ -390,11 +391,13 @@ exit_compression(void *drcontext, per_thread_t *data)
         (op_raw_compress.get_value() == "zlib" ||
          op_raw_compress.get_value() == "gzip")) {
         dr_raw_mem_free(data->buf_compressed, max_buf_size);
+        data->buf_compressed = nullptr;
     }
 #endif
 #ifdef HAS_LZ4
     if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
         dr_raw_mem_free(data->buf_lz4, data->buf_lz4_size);
+        data->buf_lz4 = nullptr;
     }
 #endif
 }

--- a/clients/drcachesim/tracer/output.h
+++ b/clients/drcachesim/tracer/output.h
@@ -57,6 +57,9 @@ void
 exit_thread_io(void *drcontext);
 
 void
+fork_exit_thread_io(void *drcontext);
+
+void
 init_buffers(per_thread_t *data);
 
 void

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2275,6 +2275,7 @@ fork_init(void *drcontext)
             FATAL("Failed to create a subdir in %s\n", op_outdir.get_value().c_str());
         }
     }
+    fork_exit_thread_io(drcontext);
     init_thread_in_process(drcontext);
 }
 #endif

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4449,6 +4449,18 @@ if (BUILD_CLIENTS)
       # Test an app with a fork.
       torunonly_drcacheoff(fork linux.fork "" "" "")
       set(tool.drcacheoff.fork_timeout 180) # Can take a while.
+      # Test other compression methods to test resource cleanup, which is
+      # compression-specific.
+      if (libsnappy)
+        torunonly_drcacheoff(fork_snappy linux.fork "-raw_compress snappy_nocrc" "" "")
+        set(tool.drcacheoff.fork_snappy_timeout 180) # Can take a while.
+        set(tool.drcacheoff.fork_snappy_expectbase "offline-fork")
+      endif ()
+      if (ZLIB_FOUND)
+        torunonly_drcacheoff(fork_zlib linux.fork "-raw_compress zlib" "" "")
+        set(tool.drcacheoff.fork_zlib_timeout 180) # Can take a while.
+        set(tool.drcacheoff.fork_zlib_expectbase "offline-fork")
+      endif ()
     endif ()
 
     # Test reading a legacy pre-interleaved file in thread-sharded mode.


### PR DESCRIPTION
Fixes a leak in drmemtrace across a fork where compression-related allocations were not being freed.

Adds compression variant tests of the drcacheoff.fork test to cover leaks in those compression types.

Does not address leaks in other threads at the time of the fork: that will be handled separately.

Issue: #8060