### PR TITLE
i#8060 fork leak: Free other thread data on fork

### DIFF
--- a/clients/drcachesim/tests/offline-fork-multithread.templatex
+++ b/clients/drcachesim/tests/offline-fork-multithread.templatex
@@ -4,5 +4,5 @@ child has exited
 Basic counts tool results:
 Total counts:
 .*
-           1 total threads
+           5 total threads
 .*

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1532,6 +1532,8 @@ exit_thread_io(void *drcontext)
      * and it is asserted.
      */
     if (dr_get_process_id() != dr_get_process_id_from_drcontext(drcontext)) {
+        /* Free compression buffer memory. */
+        fork_exit_thread_io(drcontext);
         return;
     }
 #endif

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4446,21 +4446,23 @@ if (BUILD_CLIENTS)
     endif()
 
     if (UNIX)
-      # Test an app with a fork.
-      torunonly_drcacheoff(fork linux.fork "" "" "")
-      set(tool.drcacheoff.fork_timeout 180) # Can take a while.
+      # Test an app with a fork. Use basic_counts to speed the test up.
+      torunonly_drcacheoff(fork linux.fork "" "@-tool@basic_counts" "")
       # Test other compression methods to test resource cleanup, which is
       # compression-specific.
       if (libsnappy)
-        torunonly_drcacheoff(fork_snappy linux.fork "-raw_compress snappy_nocrc" "" "")
-        set(tool.drcacheoff.fork_snappy_timeout 180) # Can take a while.
+        torunonly_drcacheoff(fork_snappy linux.fork "-raw_compress snappy_nocrc"
+          "@-tool@basic_counts" "")
         set(tool.drcacheoff.fork_snappy_expectbase "offline-fork")
       endif ()
       if (ZLIB_FOUND)
-        torunonly_drcacheoff(fork_zlib linux.fork "-raw_compress zlib" "" "")
-        set(tool.drcacheoff.fork_zlib_timeout 180) # Can take a while.
+        torunonly_drcacheoff(fork_zlib linux.fork "-raw_compress zlib"
+          "@-tool@basic_counts" "")
         set(tool.drcacheoff.fork_zlib_expectbase "offline-fork")
       endif ()
+      # Test other threads at the time of the fork.
+      torunonly_drcacheoff(fork-multithread linux.fork-multithread ""
+        "@-tool@basic_counts" "")
     endif ()
 
     # Test reading a legacy pre-interleaved file in thread-sharded mode.
@@ -6027,6 +6029,8 @@ if (UNIX)
   tobuild(linux.exit linux/exit.c)
   if (NOT ANDROID) # XXX i#1874: get working on Android: just output order?!?
     tobuild(linux.fork linux/fork.c)
+    tobuild(linux.fork-multithread linux/fork-multithread.c)
+    link_with_pthread(linux.fork-multithread)
   endif ()
   tobuild(linux.fork-sleep linux/fork-sleep.c)
   if (X86)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4461,8 +4461,11 @@ if (BUILD_CLIENTS)
         set(tool.drcacheoff.fork_zlib_expectbase "offline-fork")
       endif ()
       # Test other threads at the time of the fork.
-      torunonly_drcacheoff(fork-multithread linux.fork-multithread ""
-        "@-tool@basic_counts" "")
+      # XXX i#8069: This hits an os.c assert in 32-bit; disabled until fixed.
+      if (X64)
+        torunonly_drcacheoff(fork-multithread linux.fork-multithread ""
+          "@-tool@basic_counts" "")
+      endif ()
     endif ()
 
     # Test reading a legacy pre-interleaved file in thread-sharded mode.
@@ -6029,8 +6032,11 @@ if (UNIX)
   tobuild(linux.exit linux/exit.c)
   if (NOT ANDROID) # XXX i#1874: get working on Android: just output order?!?
     tobuild(linux.fork linux/fork.c)
-    tobuild(linux.fork-multithread linux/fork-multithread.c)
-    link_with_pthread(linux.fork-multithread)
+    # XXX i#8069: This hits an os.c assert in 32-bit; disabled until fixed.
+    if (X64)
+      tobuild(linux.fork-multithread linux/fork-multithread.c)
+      link_with_pthread(linux.fork-multithread)
+    endif ()
   endif ()
   tobuild(linux.fork-sleep linux/fork-sleep.c)
   if (X86)

--- a/suite/tests/linux/fork-multithread.c
+++ b/suite/tests/linux/fork-multithread.c
@@ -1,0 +1,91 @@
+/* **********************************************************
+ * Copyright (c) 2014-2026 Google, Inc.  All rights reserved.
+ * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * Test of fork with extra threads in the parent at fork time.
+ */
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/types.h> /* for wait and mmap */
+#include <sys/wait.h>  /* for wait */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "tools.h"
+#include "condvar.h"
+#include "thread.h"
+
+static void *sideline_continue;
+
+static THREAD_FUNC_RETURN_TYPE
+thread_function(void *arg)
+{
+    wait_cond_var(sideline_continue);
+    return THREAD_FUNC_RETURN_ZERO;
+}
+
+int
+main(int argc, char **argv)
+{
+    pid_t child;
+    sideline_continue = create_cond_var();
+#define NUM_THREADS 4
+    thread_t thread[NUM_THREADS];
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        thread[i] = create_thread(thread_function, NULL);
+    }
+    if (find_dynamo_library())
+        print("parent is running under DynamoRIO\n");
+    else
+        print("parent is running natively\n");
+    child = fork();
+    if (child < 0) {
+        perror("ERROR on fork");
+    } else if (child > 0) {
+        pid_t result;
+        result = waitpid(child, NULL, 0);
+        assert(result == child);
+        print("child has exited\n");
+        signal_cond_var(sideline_continue);
+        for (int i = 0; i < NUM_THREADS; ++i) {
+            join_thread(thread[i]);
+        }
+        destroy_cond_var(sideline_continue);
+    } else {
+        if (find_dynamo_library())
+            print("child is running under DynamoRIO\n");
+        else
+            print("child is running natively\n");
+    }
+}

--- a/suite/tests/linux/fork-multithread.expect
+++ b/suite/tests/linux/fork-multithread.expect
@@ -1,8 +1,3 @@
 parent is running under DynamoRIO
 child is running under DynamoRIO
 child has exited
-Basic counts tool results:
-Total counts:
-.*
-           1 total threads
-.*


### PR DESCRIPTION
Augments drmemtrace to free compression buffers in other threads at the time of a fork.

Adds a new linux.fork-multithread test for a simpler, flake-free alternative to pthreads_fork_FLAKY which is trying to stress DR itself: here we just want some threads around at the time of the fork.

Confirmed a large (1639616 byte) leak is reported without the leak fix, from the 4 other threads. The leak goes away with the fix.

Adds a new drcacheoff test that runs the new fork-multithread app. Uses basic_counts instead of dr$sim to speed things up from 50s locally to 10s (probably 6x slower on GA CI). Switches the existing drcacheoff fork tests to also use basic_counts which makes them 3x faster, allowing removal of the doubled timeouts.

The new test is disabled for 32-bit until #8069 is fixed.

Fixes #8060