### PR TITLE
i#8070: Fix NULL deref of RtlGetExtendedContextLength on non-AVX CPUs

### DIFF
--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -1200,26 +1200,12 @@ nt_get_context64_size(void)
         ASSERT(ntdll64 != 0);
         ntdll64_RtlGetExtendedContextLength =
             get_proc_address_64(ntdll64, "RtlGetExtendedContextLength");
-        bool extended = false;
-        if (ntdll64_RtlGetExtendedContextLength != 0) {
-            invoke_func64_t args = { ntdll64_RtlGetExtendedContextLength, CONTEXT_XSTATE,
-                                     len_param };
-            extended = NT_SUCCESS(switch_modes_and_call(&args));
-        }
-        if (extended && len > 0) {
-            /* Add 16 so we can align it forward to 16. */
-            context64_size = len + 16;
-        } else {
-            /* RtlGetExtendedContextLength fails when XSTATE is not supported
-             * (e.g. non-AVX CPUs).  The old code asserted NT_SUCCESS and in
-             * release builds fell through with len == 0, leaving the size at
-             * just 16 bytes: thread_get_context_64() then writes a whole
-             * CONTEXT_64 past the end of the undersized buffer and corrupts
-             * the heap.  Fall back to the plain CONTEXT_64 size, plus 16 so
-             * we can align it forward to 16.
-             */
-            context64_size = sizeof(CONTEXT_64) + 16;
-        }
+        invoke_func64_t args = { ntdll64_RtlGetExtendedContextLength, CONTEXT_XSTATE,
+                                 len_param };
+        NTSTATUS res = switch_modes_and_call(&args);
+        ASSERT(NT_SUCCESS(res));
+        /* Add 16 so we can align it forward to 16. */
+        context64_size = len + 16;
     }
     return context64_size;
 }

--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -1200,12 +1200,26 @@ nt_get_context64_size(void)
         ASSERT(ntdll64 != 0);
         ntdll64_RtlGetExtendedContextLength =
             get_proc_address_64(ntdll64, "RtlGetExtendedContextLength");
-        invoke_func64_t args = { ntdll64_RtlGetExtendedContextLength, CONTEXT_XSTATE,
-                                 len_param };
-        NTSTATUS res = switch_modes_and_call(&args);
-        ASSERT(NT_SUCCESS(res));
-        /* Add 16 so we can align it forward to 16. */
-        context64_size = len + 16;
+        bool extended = false;
+        if (ntdll64_RtlGetExtendedContextLength != 0) {
+            invoke_func64_t args = { ntdll64_RtlGetExtendedContextLength, CONTEXT_XSTATE,
+                                     len_param };
+            extended = NT_SUCCESS(switch_modes_and_call(&args));
+        }
+        if (extended && len > 0) {
+            /* Add 16 so we can align it forward to 16. */
+            context64_size = len + 16;
+        } else {
+            /* RtlGetExtendedContextLength fails when XSTATE is not supported
+             * (e.g. non-AVX CPUs).  The old code asserted NT_SUCCESS and in
+             * release builds fell through with len == 0, leaving the size at
+             * just 16 bytes: thread_get_context_64() then writes a whole
+             * CONTEXT_64 past the end of the undersized buffer and corrupts
+             * the heap.  Fall back to the plain CONTEXT_64 size, plus 16 so
+             * we can align it forward to 16.
+             */
+            context64_size = sizeof(CONTEXT_64) + 16;
+        }
     }
     return context64_size;
 }

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -5402,7 +5402,18 @@ nt_get_context_size(DWORD flags)
      *   ff15b0007a76    call    dword ptr [_imp__RtlGetExtendedContextLength]
      */
     int len;
-    int res = ntdll_RtlGetExtendedContextLength(flags, &len);
+    int res;
+    if (ntdll_RtlGetExtendedContextLength == NULL) {
+        /* The extended-context pointers are only resolved when YMM_ENABLED()
+         * (see nt_get_context_extended_functions); on non-AVX CPUs they stay
+         * NULL and calling through them crashes (xref i#6763).  Fall back to
+         * the plain CONTEXT size for flags without an XSTATE layout.  Add 16
+         * so we can align it forward to 16.
+         */
+        ASSERT(!TESTALL(CONTEXT_XSTATE, flags));
+        return sizeof(CONTEXT) + 16;
+    }
+    res = ntdll_RtlGetExtendedContextLength(flags, &len);
     ASSERT(res >= 0);
     /* Add 16 so we can align it forward to 16. */
     return len + 16;

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -5397,6 +5397,7 @@ nt_get_context_size(DWORD flags)
 {
     int len;
     if (TESTALL(CONTEXT_XSTATE, flags)) {
+        ASSERT(proc_avx_enabled());
         /* Moved out of nt_initialize_context():
          *   8d450c          lea     eax,[ebp+0Ch]
          *   50              push    eax

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -5395,27 +5395,19 @@ initialize_known_SID(PSID_IDENTIFIER_AUTHORITY IdentifierAuthority, ULONG SubAut
 size_t
 nt_get_context_size(DWORD flags)
 {
-    /* Moved out of nt_initialize_context():
-     *   8d450c          lea     eax,[ebp+0Ch]
-     *   50              push    eax
-     *   57              push    edi
-     *   ff15b0007a76    call    dword ptr [_imp__RtlGetExtendedContextLength]
-     */
     int len;
-    int res;
-    if (ntdll_RtlGetExtendedContextLength == NULL) {
-        /* The extended-context pointers are only resolved when YMM_ENABLED()
-         * (see nt_get_context_extended_functions); on non-AVX CPUs they stay
-         * NULL and calling through them crashes (xref i#6763).  Fall back to
-         * the plain CONTEXT size for flags without an XSTATE layout.  Add 16
-         * so we can align it forward to 16.
+    if (TESTALL(CONTEXT_XSTATE, flags)) {
+        /* Moved out of nt_initialize_context():
+         *   8d450c          lea     eax,[ebp+0Ch]
+         *   50              push    eax
+         *   57              push    edi
+         *   ff15b0007a76    call    dword ptr [_imp__RtlGetExtendedContextLength]
          */
-        ASSERT(!TESTALL(CONTEXT_XSTATE, flags));
-        return sizeof(CONTEXT) + 16;
+        int res = ntdll_RtlGetExtendedContextLength(flags, &len);
+        ASSERT(res >= 0);
+    } else {
+        len = sizeof(CONTEXT);
     }
-    res = ntdll_RtlGetExtendedContextLength(flags, &len);
-    ASSERT(res >= 0);
-    /* Add 16 so we can align it forward to 16. */
     return len + 16;
 }
 


### PR DESCRIPTION
The extended-context `ntdll` function pointers are only resolved when `YMM_ENABLED()` (in `nt_get_context_extended_functions()`), so on CPUs/OS without AVX support they remain `NULL`. `nt_get_context_size()` previously called `ntdll_RtlGetExtendedContextLength()` unconditionally, crashing with an indirect call to address 0 (e.g., in `postsys_CreateUserProcess()` when an app creates a child process).

Restructure `nt_get_context_size()` to check `TESTALL(CONTEXT_XSTATE, flags)`, mirroring `nt_initialize_context()`. When `CONTEXT_XSTATE` is not requested (such as on non-AVX systems where `CONTEXT_DR_STATE` omits it), fall back to `sizeof(CONTEXT)` plus alignment headroom, avoiding the `NULL` dereference.

Verified on real hardware (Celeron J1900, no AVX, Win10 1809): before the fix every child-spawning app crashed 100% under `drrun`; after the fix child following works in both release and `-debug` builds. CI cannot cover this (needs non-AVX hardware), so verification was manual.

AI assistance disclosure: root-cause analysis and the patch were developed with AI assistance; I reviewed the change and verified it manually on the affected hardware.

Fixes #8070
Issue: #6763
