### PR TITLE
i#6662: Add year to BibTeX citation of Google Workload Traces

### DIFF
--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1223,6 +1223,7 @@ If you would like to cite this work, you can use the following BibTeX entry:
 \verbatim
 @misc{Google_Workload_Traces_Version_2,
   title = {Google Workload Traces Version 2},
+  year = {2025},
   howpublished = {\url{https://console.cloud.google.com/storage/browser/external-traces-v2}},
   note = {Accessed: yyyy-mm-dd}
 }


### PR DESCRIPTION
Adds year 2025 (when we published the traces) to the
BibTeX citation of the Google Workload Traces Version 2.

Issue #6662