### PR TITLE
i#8077: Add -raw_compress_level option for lz4 raw trace compression

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -297,6 +297,8 @@ Further non-compatibility-affecting changes include:
    configuration.  Where that support is unavailable the static default remains "none".
  - On AArch64 the restriction that isb instructions must be the last instruction in a
    block has been lifted.
+ - Added the -raw_compress_level option to drmemtrace to allow specifying the
+   compression level for raw offline trace files when using lz4 compression.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -467,8 +467,8 @@ droption_t<int> op_raw_compress_level(
     DROPTION_SCOPE_CLIENT, "raw_compress_level", 0, "Raw compression level",
     "Specifies the compression level to use for raw offline files (when "
     "supported by the selected compression type, currently only lz4). "
-    "For lz4, accepts any integer value including negative numbers (acceleration "
-    "level; values < 0 provide faster compression with lower compression ratios). "
+    "For lz4, accepts any integer value including negative numbers (values < 0 "
+    "provide faster compression with lower compression ratios). "
     "The default value is 0.");
 
 droption_t<std::string> op_trace_compress(

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -463,6 +463,14 @@ droption_t<std::string> op_raw_compress(
     "for an SSD, zlib and gzip typically add overhead and would only be used if space is "
     "at a premium; snappy_nocrc and lz4 are nearly always performance wins.");
 
+droption_t<int> op_raw_compress_level(
+    DROPTION_SCOPE_CLIENT, "raw_compress_level", 0, "Raw compression level",
+    "Specifies the compression level to use for raw offline files (when "
+    "supported by the selected compression type, currently only lz4). "
+    "For lz4, accepts any integer value including negative numbers (acceleration "
+    "level; values < 0 provide faster compression with lower compression ratios). "
+    "The default value is 0.");
+
 droption_t<std::string> op_trace_compress(
     DROPTION_SCOPE_FRONTEND, "compress", DEFAULT_TRACE_COMPRESSION_TYPE,
     "Trace compression: \"zip\",\"gzip\",\"zlib\",\"lz4\",\"none\"",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -145,6 +145,7 @@ extern dynamorio::droption::droption_t<bool> op_split_windows;
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t>
     op_exit_after_tracing;
 extern dynamorio::droption::droption_t<std::string> op_raw_compress;
+extern dynamorio::droption::droption_t<int> op_raw_compress_level;
 extern dynamorio::droption::droption_t<std::string> op_trace_compress;
 extern dynamorio::droption::droption_t<bool> op_online_instr_types;
 extern dynamorio::droption::droption_t<std::string> op_replace_policy;

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1381,9 +1381,12 @@ If built with the zlib library, the canonical trace files are
 automatically compressed with zip or gzip.  The trace reader supports
 reading zip, gzip, or snappy compressed files.
 
-The raw files are also compressed, controlled by the -p raw_compress
+The raw files are also compressed, controlled by the \p -raw_compress
 option.  If built with lz4 support and not statically linked with the
-application, lz4 is used by default.  Whether compressing the raw
+application, lz4 is used by default.  The compression level for lz4 can be
+customized via the \p -raw_compress_level option (which accepts any integer,
+including negative acceleration values where smaller negative numbers compress
+faster with lower compression ratios).  Whether compressing the raw
 files is a net reduction in overhead depends on the storage medium and
 compression scheme.  The "lz4" and "snappy_nocrc" schemes are
 generally performnce wins even for an SSD, while "gzip" or "zlib" slow

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1382,11 +1382,10 @@ automatically compressed with zip or gzip.  The trace reader supports
 reading zip, gzip, or snappy compressed files.
 
 The raw files are also compressed, controlled by the \p -raw_compress
-option.  If built with lz4 support and not statically linked with the
-application, lz4 is used by default.  The compression level for lz4 can be
-customized via the \p -raw_compress_level option (which accepts any integer,
-including negative acceleration values where smaller negative numbers compress
-faster with lower compression ratios).  Whether compressing the raw
+option.  If built with lz4 support, lz4 is used by default.  The compression level
+for lz4 can be customized via the \p -raw_compress_level option (which accepts any
+integer, including negative acceleration values where smaller negative numbers
+compress faster with lower compression ratios).  Whether compressing the raw
 files is a net reduction in overhead depends on the storage medium and
 compression scheme.  The "lz4" and "snappy_nocrc" schemes are
 generally performnce wins even for an SSD, while "gzip" or "zlib" slow

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -250,14 +250,10 @@ get_file_type()
 }
 
 #ifdef HAS_LZ4
-static const LZ4F_preferences_t lz4_ops = {
+static LZ4F_preferences_t lz4_ops = {
     { LZ4F_max256KB, LZ4F_blockLinked, LZ4F_noContentChecksum, LZ4F_frame,
       /*unknown contentSize=*/0, /*dictID=*/0, LZ4F_noBlockChecksum },
-    // We may want to expose this knob as a parameter.  The fastest for my
-    // SSD is -4096, but on another machine 0 is fastest; plus, we may want
-    // to raise it to 3 for cases with higher i/o overhead, where it is
-    // slower but still outperforms zlib/gzip.
-    /*fastest compressionLevel=*/0,
+    /*compressionLevel=*/0,
     /*autoFlush=*/0,
     /*do not favorDecSpeed=*/0,
     /*reserved=*/ { 0, 0, 0 },
@@ -1668,6 +1664,10 @@ init_io()
                "this build's liblz4 lacks LZ4F_CustomMem support\n");
 #    endif
     }
+#endif
+
+#ifdef HAS_LZ4
+    lz4_ops.compressionLevel = op_raw_compress_level.get_value();
 #endif
 
     DR_ASSERT(cur_window_instr_count.is_lock_free());

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -253,6 +253,11 @@ get_file_type()
 static LZ4F_preferences_t lz4_ops = {
     { LZ4F_max256KB, LZ4F_blockLinked, LZ4F_noContentChecksum, LZ4F_frame,
       /*unknown contentSize=*/0, /*dictID=*/0, LZ4F_noBlockChecksum },
+    // Optimal compression levels vary by hardware configuration: level -4096 maximizes
+    // throughput on certain SSDs, whereas level 0 yields superior performance on other
+    // systems. Furthermore, increasing the level to 3 may be preferable in high I/O
+    // overhead scenarios, as it maintains a compression advantage over zlib and gzip
+    // despite reduced compression speed. We still keep level 0 as default.
     /*compressionLevel=*/0,
     /*autoFlush=*/0,
     /*do not favorDecSpeed=*/0,

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4500,7 +4500,7 @@ if (BUILD_CLIENTS)
       torunonly_drcacheoff(raw-lz4 ${ci_shared_app} "-raw_compress lz4" "" "")
       set(tool.drcacheoff.raw-lz4_expectbase "offline-simple")
       torunonly_drcacheoff(raw-lz4-level-neg ${ci_shared_app}
-        "-raw_compress lz4 -raw_compress_level -1" "" "")
+        "-raw_compress lz4 -raw_compress_level -1024" "" "")
       set(tool.drcacheoff.raw-lz4-level-neg_expectbase "offline-simple")
       torunonly_drcacheoff(raw-lz4-level-pos ${ci_shared_app}
         "-raw_compress lz4 -raw_compress_level 3" "" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4499,6 +4499,12 @@ if (BUILD_CLIENTS)
     if (liblz4)
       torunonly_drcacheoff(raw-lz4 ${ci_shared_app} "-raw_compress lz4" "" "")
       set(tool.drcacheoff.raw-lz4_expectbase "offline-simple")
+      torunonly_drcacheoff(raw-lz4-level-neg ${ci_shared_app}
+        "-raw_compress lz4 -raw_compress_level -1" "" "")
+      set(tool.drcacheoff.raw-lz4-level-neg_expectbase "offline-simple")
+      torunonly_drcacheoff(raw-lz4-level-pos ${ci_shared_app}
+        "-raw_compress lz4 -raw_compress_level 3" "" "")
+      set(tool.drcacheoff.raw-lz4-level-pos_expectbase "offline-simple")
     endif ()
 
     # Test that malloc & co. are not invoked.


### PR DESCRIPTION
Adds a new `-raw_compress_level` option to tracer.cpp to allow configuring
the lz4 compression level when collecting offline raw traces with
`-raw_compress lz4`.
The option accepts negative integer values for lz4 acceleration mode,
which provides faster compression throughput at lower compression ratios,
as well as positive integers for higher compression mode, defaulting to 0.

Adds documentation and tests.

lz4 does not save the compression level used in its metadata, but checking the
tests on `simple_app`, the raw trace files have different sizes, which would
suggest the compression level is working as intended:
```
raw-lz4-level-neg (-1024):
346K tool.drcacheoff.raw-lz4-level-neg.simple_app.3086728.0997.raw.lz4

raw-lz4-level-pos (3):
68K tool.drcacheoff.raw-lz4-level-pos.simple_app.3118065.0303.raw.lz4

raw-lz4 (0):
90K tool.drcacheoff.raw-lz4.simple_app.3047195.4715.raw.lz4
```

Fixes #8077