### PR TITLE
i#8082: Fix heap overflow in nt_get_context64_size on non-XSTATE CPUs

### DIFF
--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -1200,12 +1200,19 @@ nt_get_context64_size(void)
         ASSERT(ntdll64 != 0);
         ntdll64_RtlGetExtendedContextLength =
             get_proc_address_64(ntdll64, "RtlGetExtendedContextLength");
-        invoke_func64_t args = { ntdll64_RtlGetExtendedContextLength, CONTEXT_XSTATE,
-                                 len_param };
-        NTSTATUS res = switch_modes_and_call(&args);
-        ASSERT(NT_SUCCESS(res));
-        /* Add 16 so we can align it forward to 16. */
-        context64_size = len + 16;
+        bool extended = false;
+        if (ntdll64_RtlGetExtendedContextLength != 0) {
+            invoke_func64_t args = { ntdll64_RtlGetExtendedContextLength, CONTEXT_XSTATE,
+                                     len_param };
+            extended = NT_SUCCESS(switch_modes_and_call(&args));
+        }
+        if (extended && len > 0) {
+            /* Add 16 so we can align it forward to 16. */
+            context64_size = len + 16;
+        } else {
+            /* Fall back to plain CONTEXT_64 size; add 16 to align forward to 16. */
+            context64_size = sizeof(CONTEXT_64) + 16;
+        }
     }
     return context64_size;
 }


### PR DESCRIPTION
## Summary
Fix heap overflow risk in `nt_get_context64_size()` on non-XSTATE CPUs.

`RtlGetExtendedContextLength(CONTEXT_XSTATE)` can fail on non-XSTATE paths.  
This change checks availability/success of that query and falls back to
`sizeof(CONTEXT_64) + 16` when unavailable, avoiding undersized allocation
and out-of-bounds write in later context handling.

## Root cause
`nt_get_context64_size()` assumed extended context query success and could
cache a too-small size (effectively 16 bytes) on failure paths in release
builds.

## Fix
- Guard `RtlGetExtendedContextLength` usage.
- Require successful NTSTATUS and valid returned length for extended path.
- Fallback to non-extended `CONTEXT_64` size + alignment headroom.

Issue: https://github.com/DynamoRIO/dynamorio/issues/8082
