### PR TITLE
i#8079: Add `none` raw trace output destination mode to drmemtrace

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -73,8 +73,11 @@ droption_t<std::string> op_ipc_name(
 droption_t<std::string> op_outdir(
     DROPTION_SCOPE_ALL, "outdir", ".", "Target directory for offline trace files",
     "For the offline analysis mode (when -offline is requested), specifies the path "
-    "to a directory where per-thread trace files will be written.  The contents of this "
-    "directory are internal to the tool.  Do not alter, add, or delete files here.");
+    "to a directory where per-thread trace files will be written, or '/dev/null'/'devnull' "
+    "to write output to /dev/null (evaluating write I/O without disk storage), or "
+    "'none'/'' to discard trace data in-memory (evaluating pure instrumentation overhead). "
+    "The contents of this directory are internal to the tool. Do not alter, add, or "
+    "delete files here.");
 
 droption_t<std::string> op_subdir_prefix(
     DROPTION_SCOPE_ALL, "subdir_prefix", "drmemtrace",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -73,8 +73,7 @@ droption_t<std::string> op_ipc_name(
 droption_t<std::string> op_outdir(
     DROPTION_SCOPE_ALL, "outdir", ".", "Target directory for offline trace files",
     "For the offline analysis mode (when -offline is requested), specifies the path "
-    "to a directory where per-thread trace files will be written, or '/dev/null'/'devnull' "
-    "to write output to /dev/null (evaluating write I/O without disk storage), or "
+    "to a directory where per-thread trace files will be written, or "
     "'none'/'' to discard trace data in-memory (evaluating pure instrumentation overhead). "
     "The contents of this directory are internal to the tool. Do not alter, add, or "
     "delete files here.");

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -74,7 +74,7 @@ droption_t<std::string> op_outdir(
     DROPTION_SCOPE_ALL, "outdir", ".", "Target directory for offline trace files",
     "For the offline analysis mode (when -offline is requested), specifies the path "
     "to a directory where per-thread trace files will be written, or "
-    "'none'/'' to discard trace data in-memory (evaluating pure instrumentation overhead). "
+    "'none' to discard trace data in-memory (evaluating pure instrumentation overhead). "
     "The contents of this directory are internal to the tool. Do not alter, add, or "
     "delete files here.");
 

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -263,7 +263,7 @@ extern dynamorio::droption::droption_t<double> op_max_load_imbalance;
 inline bool
 outdir_is_none(const std::string &outdir)
 {
-    return outdir == "none" || outdir.empty();
+    return outdir == "none";
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -261,12 +261,6 @@ extern dynamorio::droption::droption_t<int> op_scale_timeouts;
 extern dynamorio::droption::droption_t<double> op_max_load_imbalance;
 
 inline bool
-outdir_is_devnull(const std::string &outdir)
-{
-    return outdir == "/dev/null" || outdir == "devnull";
-}
-
-inline bool
 outdir_is_none(const std::string &outdir)
 {
     return outdir == "none" || outdir.empty();

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -260,6 +260,18 @@ extern dynamorio::droption::droption_t<int> op_scale_timers;
 extern dynamorio::droption::droption_t<int> op_scale_timeouts;
 extern dynamorio::droption::droption_t<double> op_max_load_imbalance;
 
+inline bool
+outdir_is_devnull(const std::string &outdir)
+{
+    return outdir == "/dev/null" || outdir == "devnull";
+}
+
+inline bool
+outdir_is_none(const std::string &outdir)
+{
+    return outdir == "none" || outdir.empty();
+}
+
 } // namespace drmemtrace
 } // namespace dynamorio
 

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -326,7 +326,7 @@ _tmain(int argc, const TCHAR *targv[])
 
     if (op_offline.get_value() && !have_trace_file) {
         const std::string &outdir = op_outdir.get_value();
-        if (!outdir_is_devnull(outdir) && !outdir_is_none(outdir)) {
+        if (!outdir_is_none(outdir)) {
             // Initial sanity check: may still be unwritable by this user, but this
             // serves as at least an existence check.
             if (!file_is_writable(outdir.c_str())) {

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -325,10 +325,13 @@ _tmain(int argc, const TCHAR *targv[])
     }
 
     if (op_offline.get_value() && !have_trace_file) {
-        // Initial sanity check: may still be unwritable by this user, but this
-        // serves as at least an existence check.
-        if (!file_is_writable(op_outdir.get_value().c_str())) {
-            FATAL_ERROR("invalid -outdir %s", op_outdir.get_value().c_str());
+        const std::string &outdir = op_outdir.get_value();
+        if (!outdir_is_devnull(outdir) && !outdir_is_none(outdir)) {
+            // Initial sanity check: may still be unwritable by this user, but this
+            // serves as at least an existence check.
+            if (!file_is_writable(outdir.c_str())) {
+                FATAL_ERROR("invalid -outdir %s", outdir.c_str());
+            }
         }
     } else {
         // We assume RECORD_FILTER isn't a substring of some other tool.

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -219,32 +219,10 @@ gather_trace(const std::string &tracer_ops, const std::string &out_subdir)
     return post_process(out_subdir);
 }
 
-static void
-test_dest_modes()
-{
-    const std::vector<std::string> modes = {
-        "-outdir none",
-        "-outdir none -raw_compress gzip -max_trace_size 10M",
-    };
-    for (const auto &mode : modes) {
-        std::string dr_ops("-stderr_mask 0xc -client_lib ';;-offline " + mode + "'");
-        if (!my_setenv("DYNAMORIO_OPTIONS", dr_ops.c_str()))
-            std::cerr << "failed to set env var!\n";
-        dr_app_setup();
-        assert(!dr_app_running_under_dynamorio());
-        dr_app_start();
-        assert(dr_app_running_under_dynamorio());
-        do_some_work();
-        dr_app_stop_and_cleanup();
-        assert(!dr_app_running_under_dynamorio());
-    }
-}
-
 int
 test_main(int argc, const char *argv[])
 {
     reg_id_set_unit_tests();
-    test_dest_modes();
 
     std::string dir_opt = gather_trace("", "opt");
     std::string dir_noopt = gather_trace("-disable_optimizations", "noopt");

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -205,7 +205,8 @@ post_process(const std::string &out_subdir)
 static std::string
 gather_trace(const std::string &tracer_ops, const std::string &out_subdir)
 {
-    std::string dr_ops("-stderr_mask 0xc -client_lib ';;-offline " + tracer_ops + "'");
+    std::string dr_ops(
+        "-disable_rseq -stderr_mask 0xc -client_lib ';;-offline " + tracer_ops + "'");
     if (!my_setenv("DYNAMORIO_OPTIONS", dr_ops.c_str()))
         std::cerr << "failed to set env var!\n";
     dr_app_setup();
@@ -219,10 +220,36 @@ gather_trace(const std::string &tracer_ops, const std::string &out_subdir)
     return post_process(out_subdir);
 }
 
+static void
+test_dest_modes()
+{
+    const std::vector<std::string> modes = {
+        "-outdir /dev/null",
+        "-outdir devnull",
+        "-outdir none",
+        "-outdir \"\"",
+        "-outdir none -raw_compress gzip -max_trace_size 10M",
+    };
+    for (const auto &mode : modes) {
+        std::string dr_ops(
+            "-disable_rseq -stderr_mask 0xc -client_lib ';;-offline " + mode + "'");
+        if (!my_setenv("DYNAMORIO_OPTIONS", dr_ops.c_str()))
+            std::cerr << "failed to set env var!\n";
+        dr_app_setup();
+        assert(!dr_app_running_under_dynamorio());
+        dr_app_start();
+        assert(dr_app_running_under_dynamorio());
+        do_some_work();
+        dr_app_stop_and_cleanup();
+        assert(!dr_app_running_under_dynamorio());
+    }
+}
+
 int
 test_main(int argc, const char *argv[])
 {
     reg_id_set_unit_tests();
+    test_dest_modes();
 
     std::string dir_opt = gather_trace("", "opt");
     std::string dir_noopt = gather_trace("-disable_optimizations", "noopt");

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -224,8 +224,6 @@ static void
 test_dest_modes()
 {
     const std::vector<std::string> modes = {
-        "-outdir /dev/null",
-        "-outdir devnull",
         "-outdir none",
         "-outdir \"\"",
         "-outdir none -raw_compress gzip -max_trace_size 10M",

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -205,8 +205,7 @@ post_process(const std::string &out_subdir)
 static std::string
 gather_trace(const std::string &tracer_ops, const std::string &out_subdir)
 {
-    std::string dr_ops(
-        "-disable_rseq -stderr_mask 0xc -client_lib ';;-offline " + tracer_ops + "'");
+    std::string dr_ops("-stderr_mask 0xc -client_lib ';;-offline " + tracer_ops + "'");
     if (!my_setenv("DYNAMORIO_OPTIONS", dr_ops.c_str()))
         std::cerr << "failed to set env var!\n";
     dr_app_setup();
@@ -225,12 +224,10 @@ test_dest_modes()
 {
     const std::vector<std::string> modes = {
         "-outdir none",
-        "-outdir \"\"",
         "-outdir none -raw_compress gzip -max_trace_size 10M",
     };
     for (const auto &mode : modes) {
-        std::string dr_ops(
-            "-disable_rseq -stderr_mask 0xc -client_lib ';;-offline " + mode + "'");
+        std::string dr_ops("-stderr_mask 0xc -client_lib ';;-offline " + mode + "'");
         if (!my_setenv("DYNAMORIO_OPTIONS", dr_ops.c_str()))
             std::cerr << "failed to set env var!\n";
         dr_app_setup();

--- a/clients/drcachesim/tests/offline-outdir-none-windows.templatex
+++ b/clients/drcachesim/tests/offline-outdir-none-windows.templatex
@@ -1,0 +1,5 @@
+Hit delay threshold: enabling tracing.
+Hit tracing window #0 limit: disabling tracing.
+Hit retrace threshold: enabling tracing for window #1.
+.*
+Hello, world!

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -325,7 +325,8 @@ instru_funcs_module_load(void *drcontext, const module_data_t *mod, bool loaded)
         }
         NULL_TERMINATE_BUFFER(qual);
         size_t sz = strlen(qual);
-        if (write_file_func(funclist_fd, qual, sz) != static_cast<ssize_t>(sz))
+        if (funclist_fd != INVALID_FILE &&
+            write_file_func(funclist_fd, qual, sz) != static_cast<ssize_t>(sz))
             NOTIFY(0, "Failed to write to funclist file\n");
     }
     dr_mutex_unlock(funcs_wrapped_lock);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -482,7 +482,8 @@ offline_instru_t::flush_instr_encodings()
         return;
     if (encoding_file_ != INVALID_FILE) {
         ssize_t written = write_file_func_(encoding_file_, encoding_buf_start_, size);
-        log_(2, "%s: Wrote %zu/%zu bytes to encoding file\n", __FUNCTION__, written, size);
+        log_(2, "%s: Wrote %zu/%zu bytes to encoding file\n", __FUNCTION__, written,
+             size);
         DR_ASSERT(written == static_cast<ssize_t>(size));
         encoding_bytes_written_ += written;
     }

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -153,8 +153,10 @@ offline_instru_t::~offline_instru_t()
         buf = (char *)dr_global_alloc(size);
         res = drmodtrack_dump_buf(buf, size, &wrote);
         if (res == DRCOVLIB_SUCCESS) {
-            ssize_t written = write_file_func_(modfile_, buf, wrote - 1 /*no null*/);
-            DR_ASSERT(written == (ssize_t)wrote - 1);
+            if (modfile_ != INVALID_FILE) {
+                ssize_t written = write_file_func_(modfile_, buf, wrote - 1 /*no null*/);
+                DR_ASSERT(written == (ssize_t)wrote - 1);
+            }
         }
         dr_global_free(buf, size);
         size *= 2;
@@ -478,11 +480,13 @@ offline_instru_t::flush_instr_encodings()
     size_t size = encoding_buf_ptr_ - encoding_buf_start_;
     if (size == 0)
         return;
-    ssize_t written = write_file_func_(encoding_file_, encoding_buf_start_, size);
-    log_(2, "%s: Wrote %zu/%zu bytes to encoding file\n", __FUNCTION__, written, size);
-    DR_ASSERT(written == static_cast<ssize_t>(size));
+    if (encoding_file_ != INVALID_FILE) {
+        ssize_t written = write_file_func_(encoding_file_, encoding_buf_start_, size);
+        log_(2, "%s: Wrote %zu/%zu bytes to encoding file\n", __FUNCTION__, written, size);
+        DR_ASSERT(written == static_cast<ssize_t>(size));
+        encoding_bytes_written_ += written;
+    }
     encoding_buf_ptr_ = encoding_buf_start_;
-    encoding_bytes_written_ += written;
 }
 
 void

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -428,12 +428,23 @@ append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t wi
     return size_added;
 }
 
+// Sentinel handle for "none" mode.
+#ifdef WINDOWS
+#    define MEMTRACE_NONE_FILE_HANDLE (reinterpret_cast<file_t>(static_cast<ptr_int_t>(-2)))
+#else
+#    define MEMTRACE_NONE_FILE_HANDLE (static_cast<file_t>(-2))
+#endif
+
 void
 open_new_window_dir(ptr_int_t window_num)
 {
     if (!op_split_windows.get_value())
         return;
     DR_ASSERT(op_offline.get_value());
+    const std::string &outdir = op_outdir.get_value();
+    if (outdir_is_none(outdir) || outdir_is_devnull(outdir))
+        return;
+
     char windir[MAXIMUM_PATH];
     dr_snprintf(windir, BUFFER_SIZE_ELEMENTS(windir), "%s%s" WINDOW_SUBDIR_FORMAT,
                 logsubdir, DIRSEP, window_num);
@@ -447,6 +458,12 @@ static void
 close_thread_file(void *drcontext)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
+    if (data->file == INVALID_FILE)
+        return;
+    if (data->file == MEMTRACE_NONE_FILE_HANDLE) {
+        data->file = INVALID_FILE;
+        return;
+    }
 
 #ifdef HAS_SNAPPY
     if (op_offline.get_value() && snappy_enabled()) {
@@ -497,6 +514,90 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
     bool opened_new_file = false;
     DR_ASSERT(op_offline.get_value());
+    const std::string &outdir = op_outdir.get_value();
+
+    if (has_tracing_windows()) {
+        if (!op_split_windows.get_value() && data->file != INVALID_FILE)
+            return false;
+    }
+
+    // 1. "none" mode: Assign sentinel file handle, no open syscall.
+    if (outdir_is_none(outdir)) {
+        data->file = MEMTRACE_NONE_FILE_HANDLE;
+        return true;
+    }
+
+    // 2. "/dev/null" mode: Open /dev/null directly without REQUIRE_NEW.
+    if (outdir_is_devnull(outdir)) {
+        uint flags =
+            IF_UNIX(DR_FILE_CLOSE_ON_FORK |) DR_FILE_ALLOW_LARGE | DR_FILE_WRITE_ONLY;
+        file_t new_file = file_ops_func.call_open_file(
+            "/dev/null", flags, dr_get_thread_id(drcontext), window_num);
+        if (new_file == INVALID_FILE)
+            return false;
+        if (data->file != INVALID_FILE && data->file != MEMTRACE_NONE_FILE_HANDLE)
+            close_thread_file(drcontext);
+        data->file = new_file;
+#ifdef HAS_SNAPPY
+        if (snappy_enabled()) {
+            // We use placement new for better isolation.
+            void *placement = dr_custom_alloc(
+                nullptr, static_cast<dr_alloc_flags_t>(0), sizeof(*data->snappy_writer),
+                DR_MEMPROT_READ | DR_MEMPROT_WRITE, nullptr);
+            data->snappy_writer = new (placement)
+                snappy_file_writer_t(data->file, file_ops_func.write_file,
+                                     op_raw_compress.get_value() != "snappy_nocrc");
+            data->snappy_writer->write_file_header();
+        }
+#endif
+#ifdef HAS_ZLIB
+        if (op_offline.get_value() && op_raw_compress.get_value() == "zlib") {
+            memset(&data->zstream, 0, sizeof(data->zstream));
+            data->zstream.zalloc = zlib_redirect_malloc;
+            data->zstream.zfree = zlib_redirect_free;
+            data->zstream.opaque = drcontext;
+            int res = deflateInit(&data->zstream, Z_BEST_SPEED);
+            DR_ASSERT(res == Z_OK);
+        } else if (op_offline.get_value() && op_raw_compress.get_value() == "gzip") {
+            memset(&data->zstream, 0, sizeof(data->zstream));
+            data->zstream.zalloc = zlib_redirect_malloc;
+            data->zstream.zfree = zlib_redirect_free;
+            data->zstream.opaque = drcontext;
+            const int ZLIB_WINDOW_SIZE = 15;
+            const int ZLIB_REQUEST_GZIP = 16; /* Added to size to trigger gz headers. */
+            const int ZLIB_MAX_MEM = 9;       /* For optimal speed. */
+            int res = deflateInit2(&data->zstream, Z_BEST_SPEED, Z_DEFLATED,
+                                   ZLIB_WINDOW_SIZE + ZLIB_REQUEST_GZIP, ZLIB_MAX_MEM,
+                                   Z_DEFAULT_STRATEGY);
+            DR_ASSERT(res == Z_OK);
+            /* We use the default gzip header and don't call deflateSetHeader. */
+        }
+#endif
+#ifdef HAS_LZ4
+        if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
+#    ifdef HAS_LZ4_CUSTOM_MEM
+            /* Unlike the legacy entry point, this returns the context itself
+             * (NULL on failure) rather than an error code.
+             */
+            data->lzcxt =
+                LZ4F_createCompressionContext_advanced(lz4_custom_mem, LZ4F_VERSION);
+            DR_ASSERT(data->lzcxt != nullptr);
+            size_t res;
+#    else
+            size_t res = LZ4F_createCompressionContext(&data->lzcxt, LZ4F_VERSION);
+            DR_ASSERT(!LZ4F_isError(res));
+#    endif
+            // Write out the header.
+            res = LZ4F_compressBegin(data->lzcxt, data->buf_lz4, data->buf_lz4_size,
+                                     &lz4_ops);
+            DR_ASSERT(!LZ4F_isError(res));
+            ssize_t wrote = file_ops_func.write_file(data->file, data->buf_lz4, res);
+            DR_ASSERT(static_cast<size_t>(wrote) == res);
+        }
+#endif
+        return true;
+    }
+
     const char *dir = logsubdir;
     char windir[MAXIMUM_PATH];
     if (has_tracing_windows()) {
@@ -505,8 +606,7 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
                         logsubdir, DIRSEP, window_num);
             NULL_TERMINATE_BUFFER(windir);
             dir = windir;
-        } else if (data->file != INVALID_FILE)
-            return false;
+        }
     }
     /* We do not need to call drx_init before using drx_open_unique_appid_file.
      * Since we're now in a subdir we could make the name simpler but this
@@ -661,6 +761,13 @@ write_trace_data(void *drcontext, byte *towrite_start, byte *towrite_end,
         per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
         ssize_t size = towrite_end - towrite_start;
         DR_ASSERT(data->file != INVALID_FILE);
+
+        const std::string &outdir = op_outdir.get_value();
+        if (outdir_is_none(outdir)) {
+            // No-op in-memory discard: skip compression and disk writes entirely.
+            return towrite_start;
+        }
+
         if (file_ops_func.handoff_buf != NULL) {
             if (!file_ops_func.handoff_buf(data->file, towrite_start, size,
                                            max_buf_size)) {
@@ -1501,15 +1608,27 @@ init_thread_io(void *drcontext)
     }
 #ifdef BUILD_DRMEMTRACE_WITH_DR_SYSCALL
     if (op_collect_syscall_records.get_value()) {
-        char filename[MAXIMUM_PATH];
-        dr_snprintf(filename, BUFFER_SIZE_ELEMENTS(filename),
-                    "%s%ssyscall_record_file." PIDFMT "." TIDFMT, logsubdir, DIRSEP,
-                    dr_get_process_id(), dr_get_thread_id(drcontext));
-        NULL_TERMINATE_BUFFER(filename);
-        data->syscall_record_file =
-            file_ops_func.open_file(filename, DR_FILE_WRITE_OVERWRITE);
-        if (data->syscall_record_file == INVALID_FILE) {
-            FATAL("Failed to open syscall record file %s\n", data->syscall_record_file);
+        const std::string &outdir = op_outdir.get_value();
+        if (outdir_is_none(outdir)) {
+            data->syscall_record_file = MEMTRACE_NONE_FILE_HANDLE;
+        } else if (outdir_is_devnull(outdir)) {
+            uint flags = IF_UNIX(DR_FILE_CLOSE_ON_FORK |) DR_FILE_ALLOW_LARGE |
+                DR_FILE_WRITE_ONLY;
+            data->syscall_record_file = file_ops_func.open_file("/dev/null", flags);
+            if (data->syscall_record_file == INVALID_FILE) {
+                FATAL("Failed to open syscall record file /dev/null\n");
+            }
+        } else {
+            char filename[MAXIMUM_PATH];
+            dr_snprintf(filename, BUFFER_SIZE_ELEMENTS(filename),
+                        "%s%ssyscall_record_file." PIDFMT "." TIDFMT, logsubdir, DIRSEP,
+                        dr_get_process_id(), dr_get_thread_id(drcontext));
+            NULL_TERMINATE_BUFFER(filename);
+            data->syscall_record_file =
+                file_ops_func.open_file(filename, DR_FILE_WRITE_OVERWRITE);
+            if (data->syscall_record_file == INVALID_FILE) {
+                FATAL("Failed to open syscall record file %s\n", filename);
+            }
         }
     }
 #endif
@@ -1594,7 +1713,8 @@ exit_thread_io(void *drcontext)
 
 #ifdef BUILD_DRMEMTRACE_WITH_DR_SYSCALL
     if (op_collect_syscall_records.get_value()) {
-        if (data->syscall_record_file != INVALID_FILE) {
+        if (data->syscall_record_file != INVALID_FILE &&
+            data->syscall_record_file != MEMTRACE_NONE_FILE_HANDLE) {
             if (data->syscall_record_buffer_offset > 0) {
                 const ssize_t wrote = file_ops_func.write_file(
                     data->syscall_record_file, data->syscall_record_buffer,
@@ -1687,6 +1807,9 @@ size_t
 write_syscall_record(void *drcontext, char *buf, size_t size)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
+    if (data->syscall_record_file == MEMTRACE_NONE_FILE_HANDLE) {
+        return size;
+    }
     if (size + data->syscall_record_buffer_offset >= SYSCALL_RECORD_BUFFER_SIZE) {
         ssize_t bytes_written = 0;
         if (data->syscall_record_buffer_offset > 0) {

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -442,7 +442,7 @@ open_new_window_dir(ptr_int_t window_num)
         return;
     DR_ASSERT(op_offline.get_value());
     const std::string &outdir = op_outdir.get_value();
-    if (outdir_is_none(outdir) || outdir_is_devnull(outdir))
+    if (outdir_is_none(outdir))
         return;
 
     char windir[MAXIMUM_PATH];
@@ -521,80 +521,9 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
             return false;
     }
 
-    // 1. "none" mode: Assign sentinel file handle, no open syscall.
+    // "none" mode: Assign sentinel file handle, no open syscall.
     if (outdir_is_none(outdir)) {
         data->file = MEMTRACE_NONE_FILE_HANDLE;
-        return true;
-    }
-
-    // 2. "/dev/null" mode: Open /dev/null directly without REQUIRE_NEW.
-    if (outdir_is_devnull(outdir)) {
-        uint flags =
-            IF_UNIX(DR_FILE_CLOSE_ON_FORK |) DR_FILE_ALLOW_LARGE | DR_FILE_WRITE_ONLY;
-        file_t new_file = file_ops_func.call_open_file(
-            "/dev/null", flags, dr_get_thread_id(drcontext), window_num);
-        if (new_file == INVALID_FILE)
-            return false;
-        if (data->file != INVALID_FILE && data->file != MEMTRACE_NONE_FILE_HANDLE)
-            close_thread_file(drcontext);
-        data->file = new_file;
-#ifdef HAS_SNAPPY
-        if (snappy_enabled()) {
-            // We use placement new for better isolation.
-            void *placement = dr_custom_alloc(
-                nullptr, static_cast<dr_alloc_flags_t>(0), sizeof(*data->snappy_writer),
-                DR_MEMPROT_READ | DR_MEMPROT_WRITE, nullptr);
-            data->snappy_writer = new (placement)
-                snappy_file_writer_t(data->file, file_ops_func.write_file,
-                                     op_raw_compress.get_value() != "snappy_nocrc");
-            data->snappy_writer->write_file_header();
-        }
-#endif
-#ifdef HAS_ZLIB
-        if (op_offline.get_value() && op_raw_compress.get_value() == "zlib") {
-            memset(&data->zstream, 0, sizeof(data->zstream));
-            data->zstream.zalloc = zlib_redirect_malloc;
-            data->zstream.zfree = zlib_redirect_free;
-            data->zstream.opaque = drcontext;
-            int res = deflateInit(&data->zstream, Z_BEST_SPEED);
-            DR_ASSERT(res == Z_OK);
-        } else if (op_offline.get_value() && op_raw_compress.get_value() == "gzip") {
-            memset(&data->zstream, 0, sizeof(data->zstream));
-            data->zstream.zalloc = zlib_redirect_malloc;
-            data->zstream.zfree = zlib_redirect_free;
-            data->zstream.opaque = drcontext;
-            const int ZLIB_WINDOW_SIZE = 15;
-            const int ZLIB_REQUEST_GZIP = 16; /* Added to size to trigger gz headers. */
-            const int ZLIB_MAX_MEM = 9;       /* For optimal speed. */
-            int res = deflateInit2(&data->zstream, Z_BEST_SPEED, Z_DEFLATED,
-                                   ZLIB_WINDOW_SIZE + ZLIB_REQUEST_GZIP, ZLIB_MAX_MEM,
-                                   Z_DEFAULT_STRATEGY);
-            DR_ASSERT(res == Z_OK);
-            /* We use the default gzip header and don't call deflateSetHeader. */
-        }
-#endif
-#ifdef HAS_LZ4
-        if (op_offline.get_value() && op_raw_compress.get_value() == "lz4") {
-#    ifdef HAS_LZ4_CUSTOM_MEM
-            /* Unlike the legacy entry point, this returns the context itself
-             * (NULL on failure) rather than an error code.
-             */
-            data->lzcxt =
-                LZ4F_createCompressionContext_advanced(lz4_custom_mem, LZ4F_VERSION);
-            DR_ASSERT(data->lzcxt != nullptr);
-            size_t res;
-#    else
-            size_t res = LZ4F_createCompressionContext(&data->lzcxt, LZ4F_VERSION);
-            DR_ASSERT(!LZ4F_isError(res));
-#    endif
-            // Write out the header.
-            res = LZ4F_compressBegin(data->lzcxt, data->buf_lz4, data->buf_lz4_size,
-                                     &lz4_ops);
-            DR_ASSERT(!LZ4F_isError(res));
-            ssize_t wrote = file_ops_func.write_file(data->file, data->buf_lz4, res);
-            DR_ASSERT(static_cast<size_t>(wrote) == res);
-        }
-#endif
         return true;
     }
 
@@ -1611,13 +1540,6 @@ init_thread_io(void *drcontext)
         const std::string &outdir = op_outdir.get_value();
         if (outdir_is_none(outdir)) {
             data->syscall_record_file = MEMTRACE_NONE_FILE_HANDLE;
-        } else if (outdir_is_devnull(outdir)) {
-            uint flags = IF_UNIX(DR_FILE_CLOSE_ON_FORK |) DR_FILE_ALLOW_LARGE |
-                DR_FILE_WRITE_ONLY;
-            data->syscall_record_file = file_ops_func.open_file("/dev/null", flags);
-            if (data->syscall_record_file == INVALID_FILE) {
-                FATAL("Failed to open syscall record file /dev/null\n");
-            }
         } else {
             char filename[MAXIMUM_PATH];
             dr_snprintf(filename, BUFFER_SIZE_ELEMENTS(filename),

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -430,7 +430,8 @@ append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t wi
 
 // Sentinel handle for "none" mode.
 #ifdef WINDOWS
-#    define MEMTRACE_NONE_FILE_HANDLE (reinterpret_cast<file_t>(static_cast<ptr_int_t>(-2)))
+#    define MEMTRACE_NONE_FILE_HANDLE \
+        (reinterpret_cast<file_t>(static_cast<ptr_int_t>(-2)))
 #else
 #    define MEMTRACE_NONE_FILE_HANDLE (static_cast<file_t>(-2))
 #endif
@@ -517,6 +518,8 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
     const std::string &outdir = op_outdir.get_value();
 
     if (has_tracing_windows()) {
+        // The first window sets data->file = MEMTRACE_NONE_FILE_HANDLE, and subsequent
+        // window return false (meaning "no new file needed").
         if (!op_split_windows.get_value() && data->file != INVALID_FILE)
             return false;
     }

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -430,7 +430,7 @@ append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t wi
 
 // Sentinel handle for "-outdir none" mode.
 #ifdef WINDOWS
-#    define MEMTRACE_NONE_FILE_HANDLE static_cast<filet_t>(2)
+#    define MEMTRACE_NONE_FILE_HANDLE static_cast<file_t>(2)
 #else
 #    define MEMTRACE_NONE_FILE_HANDLE -2
 #endif

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -428,7 +428,9 @@ append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t wi
     return size_added;
 }
 
-// Sentinel handle for "-outdir none" mode.
+// MEMTRACE_NONE_FILE_HANDLE is a sentinel value used in "-outdir none" mode when
+// discarding an in-memory trace, while INVALID_FILE indicates that no trace output is
+// currently open or active.
 #ifdef WINDOWS
 #    define MEMTRACE_NONE_FILE_HANDLE \
         (reinterpret_cast<file_t>(static_cast<ptr_int_t>(-2)))
@@ -517,17 +519,10 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
     DR_ASSERT(op_offline.get_value());
     const std::string &outdir = op_outdir.get_value();
 
-    if (has_tracing_windows()) {
-        // The first window sets data->file = MEMTRACE_NONE_FILE_HANDLE, and subsequent
-        // window return false (meaning "no new file needed").
-        if (!op_split_windows.get_value() && data->file != INVALID_FILE)
-            return false;
-    }
-
     // "-outdir none" mode.
     if (outdir_is_none(outdir)) {
         data->file = MEMTRACE_NONE_FILE_HANDLE;
-        return true;
+        return false;
     }
 
     const char *dir = logsubdir;
@@ -538,6 +533,8 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
                         logsubdir, DIRSEP, window_num);
             NULL_TERMINATE_BUFFER(windir);
             dir = windir;
+        } else if (data->file != INVALID_FILE) {
+            return false;
         }
     }
     /* We do not need to call drx_init before using drx_open_unique_appid_file.

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -429,7 +429,11 @@ append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t wi
 }
 
 // Sentinel handle for "-outdir none" mode.
-#define MEMTRACE_NONE_FILE_HANDLE -2
+#ifdef WINDOWS
+#    define MEMTRACE_NONE_FILE_HANDLE static_cast<filet_t>(2)
+#else
+#    define MEMTRACE_NONE_FILE_HANDLE -2
+#endif
 
 void
 open_new_window_dir(ptr_int_t window_num)

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -695,7 +695,7 @@ write_trace_data(void *drcontext, byte *towrite_start, byte *towrite_end,
 
         const std::string &outdir = op_outdir.get_value();
         if (outdir_is_none(outdir)) {
-            // No-op in-memory discard: skip compression and disk writes entirely.
+            // Skip compression and disk writes entirely.
             return towrite_start;
         }
 

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -428,13 +428,8 @@ append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t wi
     return size_added;
 }
 
-// Sentinel handle for "none" mode.
-#ifdef WINDOWS
-#    define MEMTRACE_NONE_FILE_HANDLE \
-        (reinterpret_cast<file_t>(static_cast<ptr_int_t>(-2)))
-#else
-#    define MEMTRACE_NONE_FILE_HANDLE (static_cast<file_t>(-2))
-#endif
+// Sentinel handle for "-outdir none" mode.
+#define MEMTRACE_NONE_FILE_HANDLE -2
 
 void
 open_new_window_dir(ptr_int_t window_num)
@@ -524,7 +519,7 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
             return false;
     }
 
-    // "none" mode: Assign sentinel file handle, no open syscall.
+    // "-outdir none" mode.
     if (outdir_is_none(outdir)) {
         data->file = MEMTRACE_NONE_FILE_HANDLE;
         return true;

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -430,7 +430,8 @@ append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t wi
 
 // Sentinel handle for "-outdir none" mode.
 #ifdef WINDOWS
-#    define MEMTRACE_NONE_FILE_HANDLE static_cast<file_t>(2)
+#    define MEMTRACE_NONE_FILE_HANDLE \
+        (reinterpret_cast<file_t>(static_cast<ptr_int_t>(-2)))
 #else
 #    define MEMTRACE_NONE_FILE_HANDLE -2
 #endif

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2106,7 +2106,8 @@ event_exit(void)
     dr_global_free(instru, MAX_INSTRU_SIZE);
 
     if (op_offline.get_value()) {
-        file_ops_func.close_file(module_file);
+        if (module_file != INVALID_FILE)
+            file_ops_func.close_file(module_file);
         if (funclist_file != INVALID_FILE)
             file_ops_func.close_file(funclist_file);
         if (encoding_file != INVALID_FILE)
@@ -2165,6 +2166,59 @@ event_exit(void)
 static bool
 init_offline_dir(void)
 {
+    const std::string &outdir = op_outdir.get_value();
+
+    // 1. "none" mode: No directories, no files, no I/O.
+    if (outdir_is_none(outdir)) {
+        logsubdir[0] = '\0';
+        modlist_path[0] = '\0';
+        funclist_path[0] = '\0';
+        encoding_path[0] = '\0';
+#ifdef BUILD_PT_TRACER
+        kernel_trace_logsubdir[0] = '\0';
+        kcore_path[0] = '\0';
+        kallsyms_path[0] = '\0';
+#endif
+        module_file = INVALID_FILE;
+        funclist_file = INVALID_FILE;
+        encoding_file = INVALID_FILE;
+        return true;
+    }
+
+    // 2. "/dev/null" mode: Set file paths to /dev/null and open without REQUIRE_NEW.
+    if (outdir_is_devnull(outdir)) {
+        dr_snprintf(logsubdir, BUFFER_SIZE_ELEMENTS(logsubdir), "/dev/null");
+        NULL_TERMINATE_BUFFER(logsubdir);
+
+#ifdef BUILD_PT_TRACER
+        dr_snprintf(kernel_trace_logsubdir, BUFFER_SIZE_ELEMENTS(kernel_trace_logsubdir),
+                    "/dev/null");
+        NULL_TERMINATE_BUFFER(kernel_trace_logsubdir);
+        dr_snprintf(kcore_path, BUFFER_SIZE_ELEMENTS(kcore_path), "/dev/null");
+        NULL_TERMINATE_BUFFER(kcore_path);
+        dr_snprintf(kallsyms_path, BUFFER_SIZE_ELEMENTS(kallsyms_path), "/dev/null");
+        NULL_TERMINATE_BUFFER(kallsyms_path);
+#endif
+        dr_snprintf(modlist_path, BUFFER_SIZE_ELEMENTS(modlist_path), "/dev/null");
+        NULL_TERMINATE_BUFFER(modlist_path);
+
+        dr_snprintf(funclist_path, BUFFER_SIZE_ELEMENTS(funclist_path), "/dev/null");
+        NULL_TERMINATE_BUFFER(funclist_path);
+
+        dr_snprintf(encoding_path, BUFFER_SIZE_ELEMENTS(encoding_path), "/dev/null");
+        NULL_TERMINATE_BUFFER(encoding_path);
+
+        // Note: DR_FILE_WRITE_REQUIRE_NEW uses O_EXCL|O_CREAT which fails on /dev/null.
+        // We use DR_FILE_WRITE_ONLY instead.
+        uint flags = DR_FILE_WRITE_ONLY IF_UNIX(| DR_FILE_CLOSE_ON_FORK);
+        module_file = file_ops_func.open_process_file(modlist_path, flags);
+        funclist_file = file_ops_func.open_process_file(funclist_path, flags);
+        encoding_file = file_ops_func.open_process_file(encoding_path, flags);
+
+        return (module_file != INVALID_FILE && funclist_file != INVALID_FILE &&
+                encoding_file != INVALID_FILE);
+    }
+
     char buf[MAXIMUM_PATH];
     int i;
     const int NUM_OF_TRIES = 10000;
@@ -2459,9 +2513,6 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
     }
     if (!op_offline.get_value() && op_ipc_name.get_value().empty()) {
         FATAL("Usage error: ipc name is required\nUsage:\n%s",
-              droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
-    } else if (op_offline.get_value() && op_outdir.get_value().empty()) {
-        FATAL("Usage error: outdir is required\nUsage:\n%s",
               droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     } else if (!op_offline.get_value() &&
                (op_record_heap.get_value() || !op_record_function.get_value().empty())) {

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2480,6 +2480,9 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
     if (!op_offline.get_value() && op_ipc_name.get_value().empty()) {
         FATAL("Usage error: ipc name is required\nUsage:\n%s",
               droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
+    } else if (op_offline.get_value() && op_outdir.get_value().empty()) {
+        FATAL("Usage error: outdir is required\nUsage:\n%s",
+              droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     } else if (!op_offline.get_value() &&
                (op_record_heap.get_value() || !op_record_function.get_value().empty())) {
         FATAL("Usage error: function recording is only supported for -offline\n");

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2168,7 +2168,7 @@ init_offline_dir(void)
 {
     const std::string &outdir = op_outdir.get_value();
 
-    // 1. "none" mode: No directories, no files, no I/O.
+    // "none" mode: No directories, no files, no I/O.
     if (outdir_is_none(outdir)) {
         logsubdir[0] = '\0';
         modlist_path[0] = '\0';
@@ -2183,40 +2183,6 @@ init_offline_dir(void)
         funclist_file = INVALID_FILE;
         encoding_file = INVALID_FILE;
         return true;
-    }
-
-    // 2. "/dev/null" mode: Set file paths to /dev/null and open without REQUIRE_NEW.
-    if (outdir_is_devnull(outdir)) {
-        dr_snprintf(logsubdir, BUFFER_SIZE_ELEMENTS(logsubdir), "/dev/null");
-        NULL_TERMINATE_BUFFER(logsubdir);
-
-#ifdef BUILD_PT_TRACER
-        dr_snprintf(kernel_trace_logsubdir, BUFFER_SIZE_ELEMENTS(kernel_trace_logsubdir),
-                    "/dev/null");
-        NULL_TERMINATE_BUFFER(kernel_trace_logsubdir);
-        dr_snprintf(kcore_path, BUFFER_SIZE_ELEMENTS(kcore_path), "/dev/null");
-        NULL_TERMINATE_BUFFER(kcore_path);
-        dr_snprintf(kallsyms_path, BUFFER_SIZE_ELEMENTS(kallsyms_path), "/dev/null");
-        NULL_TERMINATE_BUFFER(kallsyms_path);
-#endif
-        dr_snprintf(modlist_path, BUFFER_SIZE_ELEMENTS(modlist_path), "/dev/null");
-        NULL_TERMINATE_BUFFER(modlist_path);
-
-        dr_snprintf(funclist_path, BUFFER_SIZE_ELEMENTS(funclist_path), "/dev/null");
-        NULL_TERMINATE_BUFFER(funclist_path);
-
-        dr_snprintf(encoding_path, BUFFER_SIZE_ELEMENTS(encoding_path), "/dev/null");
-        NULL_TERMINATE_BUFFER(encoding_path);
-
-        // Note: DR_FILE_WRITE_REQUIRE_NEW uses O_EXCL|O_CREAT which fails on /dev/null.
-        // We use DR_FILE_WRITE_ONLY instead.
-        uint flags = DR_FILE_WRITE_ONLY IF_UNIX(| DR_FILE_CLOSE_ON_FORK);
-        module_file = file_ops_func.open_process_file(modlist_path, flags);
-        funclist_file = file_ops_func.open_process_file(funclist_path, flags);
-        encoding_file = file_ops_func.open_process_file(encoding_path, flags);
-
-        return (module_file != INVALID_FILE && funclist_file != INVALID_FILE &&
-                encoding_file != INVALID_FILE);
     }
 
     char buf[MAXIMUM_PATH];

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4518,17 +4518,12 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.check-malloc-lz4_expectbase "offline-simple")
     endif ()
 
-    # Test none outdir destination mode.
+    # Test "-outdir none" mode.
     if (UNIX)
       set(tool.drcacheoff.none_nopost ON)
       torunonly_drcacheoff(none ${ci_shared_app} "-outdir none" "" "")
       set(tool.drcacheoff.none_expectbase "simple_app")
       set(tool.drcacheoff.none_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
-
-      set(tool.drcacheoff.none-compress_nopost ON)
-      torunonly_drcacheoff(none-compress ${ci_shared_app} "-outdir none -raw_compress gzip -max_trace_size 10M" "" "")
-      set(tool.drcacheoff.none-compress_expectbase "simple_app")
-      set(tool.drcacheoff.none-compress_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
     endif ()
 
     # Test reading a trace in sharded snappy-compressed files.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4520,10 +4520,15 @@ if (BUILD_CLIENTS)
 
     # Test "-outdir none" mode.
     if (UNIX)
-      set(tool.drcacheoff.none_nopost ON)
-      torunonly_drcacheoff(none ${ci_shared_app} "-outdir none" "" "")
-      set(tool.drcacheoff.none_expectbase "simple_app")
-      set(tool.drcacheoff.none_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
+      set(tool.drcacheoff.outdir-none_nopost ON)
+      torunonly_drcacheoff(outdir-none ${ci_shared_app} "-outdir none" "" "")
+      set(tool.drcacheoff.outdir-none_expectbase "simple_app")
+      set(tool.drcacheoff.outdir-none_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
+
+      set(tool.drcacheoff.outdir-none-windows_nopost ON)
+      torunonly_drcacheoff(outdir-none-windows ${ci_shared_app}
+        "-outdir none -trace_after_instrs 20K -trace_for_instrs 10K -retrace_every_instrs 30K"
+        "" "")
     endif ()
 
     # Test reading a trace in sharded snappy-compressed files.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4518,18 +4518,8 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.check-malloc-lz4_expectbase "offline-simple")
     endif ()
 
-    # Test /dev/null and none outdir destination modes.
+    # Test none outdir destination mode.
     if (UNIX)
-      set(tool.drcacheoff.devnull_nopost ON)
-      torunonly_drcacheoff(devnull ${ci_shared_app} "-outdir /dev/null" "" "")
-      set(tool.drcacheoff.devnull_expectbase "simple_app")
-      set(tool.drcacheoff.devnull_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
-
-      set(tool.drcacheoff.devnull-name_nopost ON)
-      torunonly_drcacheoff(devnull-name ${ci_shared_app} "-outdir devnull" "" "")
-      set(tool.drcacheoff.devnull-name_expectbase "simple_app")
-      set(tool.drcacheoff.devnull-name_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
-
       set(tool.drcacheoff.none_nopost ON)
       torunonly_drcacheoff(none ${ci_shared_app} "-outdir none" "" "")
       set(tool.drcacheoff.none_expectbase "simple_app")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4518,6 +4518,29 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.check-malloc-lz4_expectbase "offline-simple")
     endif ()
 
+    # Test /dev/null and none outdir destination modes.
+    if (UNIX)
+      set(tool.drcacheoff.devnull_nopost ON)
+      torunonly_drcacheoff(devnull ${ci_shared_app} "-outdir /dev/null" "" "")
+      set(tool.drcacheoff.devnull_expectbase "simple_app")
+      set(tool.drcacheoff.devnull_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
+
+      set(tool.drcacheoff.devnull-name_nopost ON)
+      torunonly_drcacheoff(devnull-name ${ci_shared_app} "-outdir devnull" "" "")
+      set(tool.drcacheoff.devnull-name_expectbase "simple_app")
+      set(tool.drcacheoff.devnull-name_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
+
+      set(tool.drcacheoff.none_nopost ON)
+      torunonly_drcacheoff(none ${ci_shared_app} "-outdir none" "" "")
+      set(tool.drcacheoff.none_expectbase "simple_app")
+      set(tool.drcacheoff.none_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
+
+      set(tool.drcacheoff.none-compress_nopost ON)
+      torunonly_drcacheoff(none-compress ${ci_shared_app} "-outdir none -raw_compress gzip -max_trace_size 10M" "" "")
+      set(tool.drcacheoff.none-compress_expectbase "simple_app")
+      set(tool.drcacheoff.none-compress_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
+    endif ()
+
     # Test reading a trace in sharded snappy-compressed files.
     if (libsnappy)
       # with a parallel tool (basic_counts)


### PR DESCRIPTION
Adds support for `-outdir none` in  offline tracing to measure pure
instrumentation and tracing overhead without incurring disk I/O overhead.

Adds `tool.drcacheoff.outdir-none` and
`tool.drcacheoff.outdir-none-windows` tests.

Measured execution time of `tar -czvf` app with `-outdir none` and
regular `-outdir ${TMP_DIR}` three times.
With `-outdir none`:
```
$ /usr/bin/time drrun -s 90 -quiet -debug -killpg -stderr_mask 0xC -dumpcore_mask 0 -code_api -t drmemtrace -offline -subdir_prefix tool.drcacheoff.none -outdir none -- tar -czvf archive.tar.gz ./sizeable_dir
[...]
13.58user 6.21system 0:13.93elapsed 142%CPU (0avgtext+0avgdata 21016maxresident)k
13.45user 6.00system 0:13.71elapsed 141%CPU (0avgtext+0avgdata 21252maxresident)k
13.44user 5.95system 0:13.66elapsed 141%CPU (0avgtext+0avgdata 21180maxresident)k
```
With `-outdir ${TMP_DIR}`:
```
$ /usr/bin/time drrun -s 90 -quiet -debug -killpg -stderr_mask 0xC -dumpcore_mask 0 -code_api -t drmemtrace -offline -subdir_prefix tool.drcacheoff.none -outdir ./to_remove -- tar -czvf archive.tar.gz ./sizeable_dir
[...]
20.37user 7.55system 0:21.88elapsed 127%CPU (0avgtext+0avgdata 21536maxresident)k
20.03user 7.73system 0:21.87elapsed 126%CPU (0avgtext+0avgdata 22264maxresident)k
20.48user 7.69system 0:22.75elapsed 123%CPU (0avgtext+0avgdata 21720maxresident)k
```
Consistently getting ~1.6x speedup for `none` compared to dumping
the trace.

Issue #8079