### PR TITLE
 Reuse raw2trace kernel-event lookahead storage in drcachesim

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1585,11 +1585,12 @@ raw2trace_t::interrupted_by_kernel_event(raw2trace_thread_data_t *tdata, uint64_
                                          uint64_t cur_offs)
 {
     bool is_interrupted = false;
-    std::deque<offline_entry_t> pre_read_buffer;
+    std::vector<offline_entry_t> &pre_read_buffer = tdata->kernel_event_lookahead;
+    pre_read_buffer.clear();
 
     const offline_entry_t *next_entry = get_next_entry(tdata);
     while (next_entry != NULL) {
-        pre_read_buffer.push_front(*next_entry);
+        pre_read_buffer.push_back(*next_entry);
         if (next_entry->addr.type == OFFLINE_TYPE_MEMREF ||
             next_entry->addr.type == OFFLINE_TYPE_MEMREF_HIGH) {
             next_entry = get_next_entry(tdata);
@@ -1643,10 +1644,8 @@ raw2trace_t::interrupted_by_kernel_event(raw2trace_thread_data_t *tdata, uint64_
         break;
     }
     // Move the entries back to the pre_read queues.
-    while (!pre_read_buffer.empty()) {
-        tdata->pre_read.push_front(pre_read_buffer.front());
-        pre_read_buffer.pop_front();
-    }
+    for (auto iter = pre_read_buffer.rbegin(); iter != pre_read_buffer.rend(); ++iter)
+        tdata->pre_read.push_front(*iter);
     return is_interrupted;
 }
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -710,6 +710,7 @@ protected:
         offline_file_type_t file_type;
         size_t cache_line_size = 0;
         std::deque<offline_entry_t> pre_read;
+        std::vector<offline_entry_t> kernel_event_lookahead;
         offline_instru_t instru_offline;
 
         // Used to delay a thread-buffer-final branch to keep it next to its target.


### PR DESCRIPTION
Reuse a per-thread vector instead of constructing a deque for every instruction level kernel-event check. The std::deque was being constructed for every instruction and resulted in significant overhead for non-ZIP output of drraw2trace. 

Benchmark with raw input and uncompressed output for a single 970 MiB raw shard (`-jobs 1`):

* master: 75.78s
* this PR: 55.34s (-27.0%)

The output is byte identical.