### PR TITLE
Revert "i#8079: Add `none` raw trace output destination mode to drmemtrace (#8084)"

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -73,10 +73,8 @@ droption_t<std::string> op_ipc_name(
 droption_t<std::string> op_outdir(
     DROPTION_SCOPE_ALL, "outdir", ".", "Target directory for offline trace files",
     "For the offline analysis mode (when -offline is requested), specifies the path "
-    "to a directory where per-thread trace files will be written, or "
-    "'none' to discard trace data in-memory (evaluating pure instrumentation overhead). "
-    "The contents of this directory are internal to the tool. Do not alter, add, or "
-    "delete files here.");
+    "to a directory where per-thread trace files will be written.  The contents of this "
+    "directory are internal to the tool.  Do not alter, add, or delete files here.");
 
 droption_t<std::string> op_subdir_prefix(
     DROPTION_SCOPE_ALL, "subdir_prefix", "drmemtrace",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -261,12 +261,6 @@ extern dynamorio::droption::droption_t<int> op_scale_timers;
 extern dynamorio::droption::droption_t<int> op_scale_timeouts;
 extern dynamorio::droption::droption_t<double> op_max_load_imbalance;
 
-inline bool
-outdir_is_none(const std::string &outdir)
-{
-    return outdir == "none";
-}
-
 } // namespace drmemtrace
 } // namespace dynamorio
 

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -325,13 +325,10 @@ _tmain(int argc, const TCHAR *targv[])
     }
 
     if (op_offline.get_value() && !have_trace_file) {
-        const std::string &outdir = op_outdir.get_value();
-        if (!outdir_is_none(outdir)) {
-            // Initial sanity check: may still be unwritable by this user, but this
-            // serves as at least an existence check.
-            if (!file_is_writable(outdir.c_str())) {
-                FATAL_ERROR("invalid -outdir %s", outdir.c_str());
-            }
+        // Initial sanity check: may still be unwritable by this user, but this
+        // serves as at least an existence check.
+        if (!file_is_writable(op_outdir.get_value().c_str())) {
+            FATAL_ERROR("invalid -outdir %s", op_outdir.get_value().c_str());
         }
     } else {
         // We assume RECORD_FILTER isn't a substring of some other tool.

--- a/clients/drcachesim/tests/offline-outdir-none-windows.templatex
+++ b/clients/drcachesim/tests/offline-outdir-none-windows.templatex
@@ -1,5 +1,0 @@
-Hit delay threshold: enabling tracing.
-Hit tracing window #0 limit: disabling tracing.
-Hit retrace threshold: enabling tracing for window #1.
-.*
-Hello, world!

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -325,8 +325,7 @@ instru_funcs_module_load(void *drcontext, const module_data_t *mod, bool loaded)
         }
         NULL_TERMINATE_BUFFER(qual);
         size_t sz = strlen(qual);
-        if (funclist_fd != INVALID_FILE &&
-            write_file_func(funclist_fd, qual, sz) != static_cast<ssize_t>(sz))
+        if (write_file_func(funclist_fd, qual, sz) != static_cast<ssize_t>(sz))
             NOTIFY(0, "Failed to write to funclist file\n");
     }
     dr_mutex_unlock(funcs_wrapped_lock);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -153,10 +153,8 @@ offline_instru_t::~offline_instru_t()
         buf = (char *)dr_global_alloc(size);
         res = drmodtrack_dump_buf(buf, size, &wrote);
         if (res == DRCOVLIB_SUCCESS) {
-            if (modfile_ != INVALID_FILE) {
-                ssize_t written = write_file_func_(modfile_, buf, wrote - 1 /*no null*/);
-                DR_ASSERT(written == (ssize_t)wrote - 1);
-            }
+            ssize_t written = write_file_func_(modfile_, buf, wrote - 1 /*no null*/);
+            DR_ASSERT(written == (ssize_t)wrote - 1);
         }
         dr_global_free(buf, size);
         size *= 2;
@@ -480,14 +478,11 @@ offline_instru_t::flush_instr_encodings()
     size_t size = encoding_buf_ptr_ - encoding_buf_start_;
     if (size == 0)
         return;
-    if (encoding_file_ != INVALID_FILE) {
-        ssize_t written = write_file_func_(encoding_file_, encoding_buf_start_, size);
-        log_(2, "%s: Wrote %zu/%zu bytes to encoding file\n", __FUNCTION__, written,
-             size);
-        DR_ASSERT(written == static_cast<ssize_t>(size));
-        encoding_bytes_written_ += written;
-    }
+    ssize_t written = write_file_func_(encoding_file_, encoding_buf_start_, size);
+    log_(2, "%s: Wrote %zu/%zu bytes to encoding file\n", __FUNCTION__, written, size);
+    DR_ASSERT(written == static_cast<ssize_t>(size));
     encoding_buf_ptr_ = encoding_buf_start_;
+    encoding_bytes_written_ += written;
 }
 
 void

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -429,26 +429,12 @@ append_unit_header(void *drcontext, byte *buf_ptr, thread_id_t tid, ptr_int_t wi
     return size_added;
 }
 
-// MEMTRACE_NONE_FILE_HANDLE is a sentinel value used in "-outdir none" mode when
-// discarding an in-memory trace, while INVALID_FILE indicates that no trace output is
-// currently open or active.
-#ifdef WINDOWS
-#    define MEMTRACE_NONE_FILE_HANDLE \
-        (reinterpret_cast<file_t>(static_cast<ptr_int_t>(-2)))
-#else
-#    define MEMTRACE_NONE_FILE_HANDLE -2
-#endif
-
 void
 open_new_window_dir(ptr_int_t window_num)
 {
     if (!op_split_windows.get_value())
         return;
     DR_ASSERT(op_offline.get_value());
-    const std::string &outdir = op_outdir.get_value();
-    if (outdir_is_none(outdir))
-        return;
-
     char windir[MAXIMUM_PATH];
     dr_snprintf(windir, BUFFER_SIZE_ELEMENTS(windir), "%s%s" WINDOW_SUBDIR_FORMAT,
                 logsubdir, DIRSEP, window_num);
@@ -462,12 +448,6 @@ static void
 close_thread_file(void *drcontext)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
-    if (data->file == INVALID_FILE)
-        return;
-    if (data->file == MEMTRACE_NONE_FILE_HANDLE) {
-        data->file = INVALID_FILE;
-        return;
-    }
 
 #ifdef HAS_SNAPPY
     if (op_offline.get_value() && snappy_enabled()) {
@@ -518,14 +498,6 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
     bool opened_new_file = false;
     DR_ASSERT(op_offline.get_value());
-    const std::string &outdir = op_outdir.get_value();
-
-    // "-outdir none" mode.
-    if (outdir_is_none(outdir)) {
-        data->file = MEMTRACE_NONE_FILE_HANDLE;
-        return false;
-    }
-
     const char *dir = logsubdir;
     char windir[MAXIMUM_PATH];
     if (has_tracing_windows()) {
@@ -534,9 +506,8 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
                         logsubdir, DIRSEP, window_num);
             NULL_TERMINATE_BUFFER(windir);
             dir = windir;
-        } else if (data->file != INVALID_FILE) {
+        } else if (data->file != INVALID_FILE)
             return false;
-        }
     }
     /* We do not need to call drx_init before using drx_open_unique_appid_file.
      * Since we're now in a subdir we could make the name simpler but this
@@ -691,13 +662,6 @@ write_trace_data(void *drcontext, byte *towrite_start, byte *towrite_end,
         per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
         ssize_t size = towrite_end - towrite_start;
         DR_ASSERT(data->file != INVALID_FILE);
-
-        const std::string &outdir = op_outdir.get_value();
-        if (outdir_is_none(outdir)) {
-            // Skip compression and disk writes entirely.
-            return towrite_start;
-        }
-
         if (file_ops_func.handoff_buf != NULL) {
             if (!file_ops_func.handoff_buf(data->file, towrite_start, size,
                                            max_buf_size)) {
@@ -1538,20 +1502,15 @@ init_thread_io(void *drcontext)
     }
 #ifdef BUILD_DRMEMTRACE_WITH_DR_SYSCALL
     if (op_collect_syscall_records.get_value()) {
-        const std::string &outdir = op_outdir.get_value();
-        if (outdir_is_none(outdir)) {
-            data->syscall_record_file = MEMTRACE_NONE_FILE_HANDLE;
-        } else {
-            char filename[MAXIMUM_PATH];
-            dr_snprintf(filename, BUFFER_SIZE_ELEMENTS(filename),
-                        "%s%ssyscall_record_file." PIDFMT "." TIDFMT, logsubdir, DIRSEP,
-                        dr_get_process_id(), dr_get_thread_id(drcontext));
-            NULL_TERMINATE_BUFFER(filename);
-            data->syscall_record_file =
-                file_ops_func.open_file(filename, DR_FILE_WRITE_OVERWRITE);
-            if (data->syscall_record_file == INVALID_FILE) {
-                FATAL("Failed to open syscall record file %s\n", filename);
-            }
+        char filename[MAXIMUM_PATH];
+        dr_snprintf(filename, BUFFER_SIZE_ELEMENTS(filename),
+                    "%s%ssyscall_record_file." PIDFMT "." TIDFMT, logsubdir, DIRSEP,
+                    dr_get_process_id(), dr_get_thread_id(drcontext));
+        NULL_TERMINATE_BUFFER(filename);
+        data->syscall_record_file =
+            file_ops_func.open_file(filename, DR_FILE_WRITE_OVERWRITE);
+        if (data->syscall_record_file == INVALID_FILE) {
+            FATAL("Failed to open syscall record file %s\n", data->syscall_record_file);
         }
     }
 #endif
@@ -1636,8 +1595,7 @@ exit_thread_io(void *drcontext)
 
 #ifdef BUILD_DRMEMTRACE_WITH_DR_SYSCALL
     if (op_collect_syscall_records.get_value()) {
-        if (data->syscall_record_file != INVALID_FILE &&
-            data->syscall_record_file != MEMTRACE_NONE_FILE_HANDLE) {
+        if (data->syscall_record_file != INVALID_FILE) {
             if (data->syscall_record_buffer_offset > 0) {
                 const ssize_t wrote = file_ops_func.write_file(
                     data->syscall_record_file, data->syscall_record_buffer,
@@ -1734,9 +1692,6 @@ size_t
 write_syscall_record(void *drcontext, char *buf, size_t size)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
-    if (data->syscall_record_file == MEMTRACE_NONE_FILE_HANDLE) {
-        return size;
-    }
     if (size + data->syscall_record_buffer_offset >= SYSCALL_RECORD_BUFFER_SIZE) {
         ssize_t bytes_written = 0;
         if (data->syscall_record_buffer_offset > 0) {

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2106,8 +2106,7 @@ event_exit(void)
     dr_global_free(instru, MAX_INSTRU_SIZE);
 
     if (op_offline.get_value()) {
-        if (module_file != INVALID_FILE)
-            file_ops_func.close_file(module_file);
+        file_ops_func.close_file(module_file);
         if (funclist_file != INVALID_FILE)
             file_ops_func.close_file(funclist_file);
         if (encoding_file != INVALID_FILE)
@@ -2166,25 +2165,6 @@ event_exit(void)
 static bool
 init_offline_dir(void)
 {
-    const std::string &outdir = op_outdir.get_value();
-
-    // "none" mode: No directories, no files, no I/O.
-    if (outdir_is_none(outdir)) {
-        logsubdir[0] = '\0';
-        modlist_path[0] = '\0';
-        funclist_path[0] = '\0';
-        encoding_path[0] = '\0';
-#ifdef BUILD_PT_TRACER
-        kernel_trace_logsubdir[0] = '\0';
-        kcore_path[0] = '\0';
-        kallsyms_path[0] = '\0';
-#endif
-        module_file = INVALID_FILE;
-        funclist_file = INVALID_FILE;
-        encoding_file = INVALID_FILE;
-        return true;
-    }
-
     char buf[MAXIMUM_PATH];
     int i;
     const int NUM_OF_TRIES = 10000;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4524,19 +4524,6 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.check-malloc-lz4_expectbase "offline-simple")
     endif ()
 
-    # Test "-outdir none" mode.
-    if (UNIX)
-      set(tool.drcacheoff.outdir-none_nopost ON)
-      torunonly_drcacheoff(outdir-none ${ci_shared_app} "-outdir none" "" "")
-      set(tool.drcacheoff.outdir-none_expectbase "simple_app")
-      set(tool.drcacheoff.outdir-none_basedir "${PROJECT_SOURCE_DIR}/suite/tests/client-interface")
-
-      set(tool.drcacheoff.outdir-none-windows_nopost ON)
-      torunonly_drcacheoff(outdir-none-windows ${ci_shared_app}
-        "-outdir none -trace_after_instrs 20K -trace_for_instrs 10K -retrace_every_instrs 30K"
-        "" "")
-    endif ()
-
     # Test reading a trace in sharded snappy-compressed files.
     if (libsnappy)
       # with a parallel tool (basic_counts)


### PR DESCRIPTION
This reverts commit f5e2bada5428752a5dcf74c7fee2fe126e240c7a because it calls malloc mid-run for long -outdir paths, breaking transparency and crashing static-link setups.

I directly observed it crash a large internal application.

You can see it trip our malloc check in a debug build by running an app with multiple threads and a path long enough to exceed std::string's inlined buffer:

```
$ bin64/drrun -t drcachesim -offline -raw_compress none -outdir $PWD -- ~/dr/test/threadsig 8 20
<Application ~/dr/test/threadsig (2440162) DynamoRIO usage error : malloc invoked mid-run when disallowed by DR_DISALLOW_UNSAFE_STATIC>
```