### PR TITLE
i#8092: Mark RDSSPQ as predicated

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -7294,8 +7294,9 @@ const instr_info_t mod_extensions[][2] = {
     {OP_nop_modrm, 0xf30f1e31, catOther, "nop", xx, xx, Ed, xx, xx, mrm, x, END_LIST},
     /* Disassembled as rdsspd for 32-bit operands or rdsspq for 64-bit.
      * The suffix is appended by instr_opcode_name_suffix().
+     * This is a nop when CET is not enabled, hence "predcx".
      */
-    {OP_rdssp,     0xf30f1e31, catState, "rdssp", Ry, xx, xx, xx, xx, mrm, x, END_LIST},
+    {OP_rdssp,     0xf30f1e31, catState, "rdssp", Ry, xx, xx, xx, xx, mrm|predcx, x, END_LIST},
   }
 };
 

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -1158,7 +1158,9 @@
 /* XXX: real assembly only has size-suffixed rdsspd/rdsspq mnemonics, no bare
  * "rdssp". Unclear whether splitting into separate d/q macros is worth it.
  */
-#define INSTR_CREATE_rdssp(dc, d) instr_create_1dst_0src((dc), OP_rdssp, (d))
+#define INSTR_CREATE_rdssp(dc, d) \
+    INSTR_PRED(instr_create_1dst_0src((dc), OP_rdssp, (d)), DR_PRED_COMPLEX)
+
 /**
  * This INSTR_CREATE_xxx macro creates an #instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.


### PR DESCRIPTION
Fixes a crash in drmemtrace due to RDSSPQ being treated as always writing its destination register, when it's a nop if CET is unsupported.

Tested on SPECCPU 2017 omnetpp and leela, which both hit SIGILL without this fix and work with it.

Fixes #8092