### PR TITLE
i#8076: Fix query_time_seconds() inconsistency in kernel build

### DIFF
--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -108,8 +108,8 @@ query_time_seconds(void)
 {
     /* kernel_query_time_seconds() returns seconds since the Unix Epoch
      * (1970-01-01), but DR's cross-platform contract for query_time_seconds()
-     * is seconds since 1601-01-01 (see os_shared.h). Convert so the kernel
-     * build matches the user space build.
+     * is seconds since 1601-01-01 (see os_shared.h). add UTC_TO_EPOCH_SECONDS
+     * so the kernel build matches the user space build.
      */
-    return (uint)(kernel_query_time_seconds() + UTC_TO_EPOCH_SECONDS);
+    return (kernel_query_time_seconds() + UTC_TO_EPOCH_SECONDS);
 }

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -108,8 +108,8 @@ query_time_seconds(void)
 {
     /* kernel_query_time_seconds() returns seconds since the Unix Epoch
      * (1970-01-01), but DR's cross-platform contract for query_time_seconds()
-     * is seconds since 1601-01-01 (see os_shared.h). add UTC_TO_EPOCH_SECONDS
+     * is seconds since 1601-01-01 (see os_shared.h). Add UTC_TO_EPOCH_SECONDS
      * so the kernel build matches the user space build.
      */
-    return (kernel_query_time_seconds() + UTC_TO_EPOCH_SECONDS);
+    return kernel_query_time_seconds() + UTC_TO_EPOCH_SECONDS;
 }

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -106,5 +106,10 @@ os_wait_thread_terminated(dcontext_t *dcontext)
 uint
 query_time_seconds(void)
 {
-    return kernel_query_time_seconds();
+    /* kernel_query_time_seconds() returns seconds since the Unix Epoch
+     * (1970-01-01), but DR's cross-platform contract for query_time_seconds()
+     * is seconds since 1601-01-01 (see os_shared.h). Convert so the kernel
+     * build matches the user space build.
+     */
+    return (uint)(kernel_query_time_seconds() + UTC_TO_EPOCH_SECONDS);
 }

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -996,6 +996,11 @@ wait_for_event(event_t e, int timeout_ms);
 timestamp_t
 get_timer_frequency(void);
 
+/* DR has standardized on UTC time which counts from since Jan 1, 1601.
+ * That's the Windows standard.  But Linux uses the Epoch of Jan 1, 1970.
+ */
+#define UTC_TO_EPOCH_SECONDS 11644473600
+
 /* Returns the number of seconds since Jan 1, 1601 (this is
  * the current UTC time).
  */

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -996,7 +996,7 @@ wait_for_event(event_t e, int timeout_ms);
 timestamp_t
 get_timer_frequency(void);
 
-/* DR has standardized on UTC time which counts from since Jan 1, 1601.
+/* DR has standardized on UTC time which counts from Jan 1, 1601.
  * That's the Windows standard.  But Linux uses the Epoch of Jan 1, 1970.
  */
 #define UTC_TO_EPOCH_SECONDS 11644473600

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1366,11 +1366,6 @@ get_timer_frequency(void)
     return get_timer_frequency_cpuinfo();
 }
 
-/* DR has standardized on UTC time which counts from since Jan 1, 1601.
- * That's the Windows standard.  But Linux uses the Epoch of Jan 1, 1970.
- */
-#define UTC_TO_EPOCH_SECONDS 11644473600
-
 /* seconds since 1601 */
 uint
 query_time_seconds(void)


### PR DESCRIPTION
The kernel implementation of query_time_seconds() currently returns seconds since the Unix Epoch (1970-01-01), while DR's documented cross-platform contract uses seconds since 1601-01-01.

This causes the kernel build to return a different time base from the user-space implementation.

Moves UTC_TO_EPOCH_SECONDS to os_shared.h making it available to both the Unix and Linux kernel implementations, and converts the kernel query_time_seconds() result to the 1601-based time.

No changes are made to the existing Unix implementations of query_time_millis() or query_time_micros().

Fixes #8076
