### PR TITLE
i#8079 fix tool.drcacheoff.outdir-none-windows on CentOS and SLES

### DIFF
--- a/clients/drcachesim/tests/offline-outdir-none-windows.templatex
+++ b/clients/drcachesim/tests/offline-outdir-none-windows.templatex
@@ -2,4 +2,4 @@ Hit delay threshold: enabling tracing.
 Hit tracing window #0 limit: disabling tracing.
 Hit retrace threshold: enabling tracing for window #1.
 .*
-Hello, world!
+Hello, world!(\n|.)*


### PR DESCRIPTION
This test assumes that the final output will be "Hello, world!" but if the application shutdown code reaches a threshold there may be an additional "Hit retrace threshold" message. This happens consistently on CentOS 9 and SLES 15.

Update the .templatex file to allow optional output after "Hello, world!"

Issue: #8079