### PR TITLE
i#8021: Add DR options parsing in the kernel module init

### DIFF
--- a/.github/workflows/ci-kernel-module.yml
+++ b/.github/workflows/ci-kernel-module.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build DynamoRIO Kernel Module against running kernel
         run: |
-          cmake -B build -DBUILD_KERNEL_MODULE=ON
+          cmake -B build -DBUILD_KERNEL_MODULE=ON -DDEBUG=ON
           cmake --build build --parallel $(nproc) --target dynamorio_module
 
       - name: Load module and check dmesg for init/exit success
@@ -73,8 +73,9 @@ jobs:
           sudo dmesg -C
 
           echo "Loading $MODULE"
-          sudo insmod "$MODULE"
+          sudo insmod "$MODULE" options="-loglevel 2"
           sudo dmesg | grep -F "dynamorio_module: Module started"
+          sudo dmesg | grep -F "DYNAMORIO_OPTIONS: -loglevel 2"
 
           echo "Removing dynamorio_module"
           sudo rmmod dynamorio_module

--- a/.github/workflows/ci-kernel-module.yml
+++ b/.github/workflows/ci-kernel-module.yml
@@ -73,7 +73,7 @@ jobs:
           sudo dmesg -C
 
           echo "Loading $MODULE"
-          sudo insmod "$MODULE" options="-loglevel 2"
+          sudo insmod "$MODULE" options='"-loglevel 2"'
           sudo dmesg | grep -F "dynamorio_module: Module started"
           sudo dmesg | grep -F "DYNAMORIO_OPTIONS: -loglevel 2"
 

--- a/.github/workflows/ci-kernel-module.yml
+++ b/.github/workflows/ci-kernel-module.yml
@@ -45,6 +45,10 @@ jobs:
 
   x86-64-insmod:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        debug: ['ON', 'OFF']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -61,7 +65,7 @@ jobs:
 
       - name: Build DynamoRIO Kernel Module against running kernel
         run: |
-          cmake -B build -DBUILD_KERNEL_MODULE=ON -DDEBUG=ON
+          cmake -B build -DBUILD_KERNEL_MODULE=ON -DDEBUG=${{ matrix.debug }}
           cmake --build build --parallel $(nproc) --target dynamorio_module
 
       - name: Load module and check dmesg for init/exit success
@@ -73,9 +77,13 @@ jobs:
           sudo dmesg -C
 
           echo "Loading $MODULE"
-          sudo insmod "$MODULE" options='"-loglevel 2"'
+          if [ "${{ matrix.debug }}" = "ON" ]; then
+            sudo insmod "$MODULE" options='"-loglevel 2"'
+            sudo dmesg | grep -F "DYNAMORIO_OPTIONS: -loglevel 2"
+          else
+            sudo insmod "$MODULE"
+          fi
           sudo dmesg | grep -F "dynamorio_module: Module started"
-          sudo dmesg | grep -F "DYNAMORIO_OPTIONS: -loglevel 2"
 
           echo "Removing dynamorio_module"
           sudo rmmod dynamorio_module

--- a/core/config.c
+++ b/core/config.c
@@ -45,10 +45,6 @@
 #        include "ntdll.h"
 #    endif
 
-#    ifdef LINUX_KERNEL
-#        include "kernel_interface.h"
-#    endif
-
 /* DYNAMORIO_VAR_CONFIGDIR is searched first, and then these: */
 #    ifdef UNIX
 #        define GLOBAL_CONFIG_DIR "/etc/dynamorio"
@@ -196,9 +192,7 @@ static config_vals_t *config_reread_vals;
 const char *
 my_getenv(IF_WINDOWS_ELSE_NP(const wchar_t *, const char *) var, char *buf, size_t bufsz)
 {
-#    ifdef LINUX_KERNEL
-    return kernel_getenv(var);
-#    elif defined(UNIX)
+#    ifdef UNIX
     return getenv(var);
 #    else
     wchar_t wbuf[MAX_CONFIG_VALUE];

--- a/core/kernel_linux/dr_interface.h
+++ b/core/kernel_linux/dr_interface.h
@@ -30,65 +30,14 @@
  * DAMAGE.
  */
 
-/* The kernel's print helpers (pr_info(), pr_err(), etc.) expand pr_fmt(): this must be
- * defined at the top before the #include block to have the module name prepended to
- * every message. Since this is a kernel macro, not a DR one, it has to be lower-case.
+#ifndef _DR_INTERFACE_H_
+#define _DR_INTERFACE_H_
+
+/* Interface exposed by DynamoRIO core to the kernel module entry and lifecycle
+ * management code (dynamorio_module_main.c).
  */
-#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
-#include <linux/module.h>
-#include <linux/preempt.h>
+void
+dynamorio_app_init_part_one_options(void);
 
-#include "configure.h"
-#include "dr_interface.h"
-#include "globals_shared.h"
-#include "kernel_interface.h"
-
-MODULE_LICENSE("Dual BSD/GPL");
-MODULE_DESCRIPTION("DynamoRIO dynamic instrumentation engine");
-MODULE_AUTHOR("DynamoRIO developers");
-
-static ulong dr_heap_size = 257 * 1024 * 1024;
-module_param(dr_heap_size, ulong, 0444);
-MODULE_PARM_DESC(dr_heap_size, "DynamoRIO module heap size in bytes (read-only)");
-
-static char options[KERNEL_ENV_VALUE_MAX];
-module_param_string(options, options, sizeof(options), 0444);
-MODULE_PARM_DESC(
-    options,
-    "DynamoRIO runtime options string (read-only), e.g., \"-loglevel 2 -log_to_stderr\"");
-
-static int __init
-dynamorio_module_init(void)
-{
-    int ret = kernel_module_init(dr_heap_size);
-    if (ret != 0) {
-        return ret;
-    }
-
-    ret = kernel_setenv(DYNAMORIO_VAR_OPTIONS, options);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    preempt_disable();
-    dynamorio_app_init_part_one_options();
-    preempt_enable();
-
-    pr_info("Module started\n");
-    return 0;
-
-fail:
-    kernel_module_exit();
-    return ret;
-}
-
-static void __exit
-dynamorio_module_exit(void)
-{
-    kernel_module_exit();
-    pr_info("Module exited\n");
-}
-
-module_init(dynamorio_module_init);
-module_exit(dynamorio_module_exit);
+#endif /* _DR_INTERFACE_H_ */

--- a/core/kernel_linux/dynamorio_module_main.c
+++ b/core/kernel_linux/dynamorio_module_main.c
@@ -37,6 +37,9 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
 #include <linux/module.h>
+
+#include "configure.h"
+#include "globals_shared.h"
 #include "kernel_interface.h"
 
 MODULE_LICENSE("Dual BSD/GPL");
@@ -47,6 +50,12 @@ static ulong dr_heap_size = 257 * 1024 * 1024;
 module_param(dr_heap_size, ulong, 0444);
 MODULE_PARM_DESC(dr_heap_size, "DynamoRIO module heap size in bytes (read-only)");
 
+static char options[KERNEL_ENV_VALUE_MAX];
+module_param_string(options, options, sizeof(options), 0444);
+MODULE_PARM_DESC(
+    options,
+    "DynamoRIO runtime options string (read-only), e.g., \"-loglevel 2 -log_to_stderr\"");
+
 static int __init
 dynamorio_module_init(void)
 {
@@ -54,8 +63,18 @@ dynamorio_module_init(void)
     if (ret != 0) {
         return ret;
     }
+
+    ret = kernel_setenv(DYNAMORIO_VAR_OPTIONS, options);
+    if (ret != 0) {
+        goto fail;
+    }
+
     pr_info("Module started\n");
     return 0;
+
+fail:
+    kernel_module_exit();
+    return ret;
 }
 
 static void __exit

--- a/core/kernel_linux/dynamorio_module_main.c
+++ b/core/kernel_linux/dynamorio_module_main.c
@@ -52,6 +52,10 @@ static ulong dr_heap_size = 257 * 1024 * 1024;
 module_param(dr_heap_size, ulong, 0444);
 MODULE_PARM_DESC(dr_heap_size, "DynamoRIO module heap size in bytes (read-only)");
 
+/* Initial support accepts global options at module load time only.
+ * XXX: Define support for dynamic updates and per-process options, including how to
+ * reuse the existing configuration infrastructure.
+ */
 static char options[KERNEL_ENV_VALUE_MAX];
 module_param_string(options, options, sizeof(options), 0444);
 MODULE_PARM_DESC(

--- a/core/kernel_linux/dynamorio_module_main.c
+++ b/core/kernel_linux/dynamorio_module_main.c
@@ -56,7 +56,8 @@ MODULE_PARM_DESC(
     options,
     "DynamoRIO runtime options string (read-only), e.g., \"-loglevel 2 -log_to_stderr\"");
 
-void dynamorio_app_init_part_one_options(void);
+void
+dynamorio_app_init_part_one_options(void);
 
 static int __init
 dynamorio_module_init(void)

--- a/core/kernel_linux/dynamorio_module_main.c
+++ b/core/kernel_linux/dynamorio_module_main.c
@@ -71,6 +71,11 @@ dynamorio_module_init(void)
         goto fail;
     }
 
+    /* Although module initialization is single-threaded, options_init() acquires
+     * options_lock through the shared DR code. The write lock records its owner using
+     * d_r_get_thread_id(), which returns the CPU ID in kernel mode. Disabling preemption
+     * prevents migration from breaking lock ownership checks.
+     */
     preempt_disable();
     dynamorio_app_init_part_one_options();
     preempt_enable();

--- a/core/kernel_linux/dynamorio_module_main.c
+++ b/core/kernel_linux/dynamorio_module_main.c
@@ -56,6 +56,8 @@ MODULE_PARM_DESC(
     options,
     "DynamoRIO runtime options string (read-only), e.g., \"-loglevel 2 -log_to_stderr\"");
 
+void dynamorio_app_init_part_one_options(void);
+
 static int __init
 dynamorio_module_init(void)
 {
@@ -68,6 +70,8 @@ dynamorio_module_init(void)
     if (ret != 0) {
         goto fail;
     }
+
+    dynamorio_app_init_part_one_options();
 
     pr_info("Module started\n");
     return 0;

--- a/core/kernel_linux/dynamorio_module_main.c
+++ b/core/kernel_linux/dynamorio_module_main.c
@@ -37,6 +37,7 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
 #include <linux/module.h>
+#include <linux/preempt.h>
 
 #include "configure.h"
 #include "globals_shared.h"
@@ -72,7 +73,9 @@ dynamorio_module_init(void)
         goto fail;
     }
 
+    preempt_disable();
     dynamorio_app_init_part_one_options();
+    preempt_enable();
 
     pr_info("Module started\n");
     return 0;

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -212,6 +212,15 @@ kernel_query_time_seconds(void)
     return (unsigned int)ktime_get_real_seconds();
 }
 
+void
+kernel_printk(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    vprintk(fmt, args);
+    va_end(args);
+}
+
 #define KERNEL_ENV_MAX 20
 
 typedef struct {

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -219,12 +219,46 @@ typedef struct {
     char value[KERNEL_ENV_VALUE_MAX];
 } kernel_env_t;
 
+/* The env table is not protected by any lock: it is only written during module
+ * initialization (single-threaded) and read afterwards.
+ */
 static kernel_env_t env_vars[KERNEL_ENV_MAX];
 static int env_count = 0;
+
+int
+kernel_setenv(const char *name, const char *value)
+{
+    if (name == NULL || name[0] == '\0' || strchr(name, '=') != NULL || value == NULL) {
+        return -EINVAL;
+    }
+    if (strlen(name) >= KERNEL_ENV_NAME_MAX || strlen(value) >= KERNEL_ENV_VALUE_MAX) {
+        return -E2BIG;
+    }
+
+    /* If name already exists in env_vars, overwrite the existing value. */
+    for (int i = 0; i < env_count; i++) {
+        if (strncmp(name, env_vars[i].name, KERNEL_ENV_NAME_MAX) == 0) {
+            strncpy(env_vars[i].value, value, KERNEL_ENV_VALUE_MAX);
+            return 0;
+        }
+    }
+
+    /* If name doesn't exist in env_vars, try appending a new entry. */
+    if (env_count >= KERNEL_ENV_MAX) {
+        return -ENOSPC;
+    }
+    strncpy(env_vars[env_count].name, name, KERNEL_ENV_NAME_MAX);
+    strncpy(env_vars[env_count].value, value, KERNEL_ENV_VALUE_MAX);
+    env_count++;
+    return 0;
+}
 
 const char *
 kernel_getenv(const char *name)
 {
+    if (name == NULL || name[0] == '\0' || strchr(name, '=') != NULL) {
+        return NULL;
+    }
     for (int i = 0; i < env_count; i++) {
         if (strncmp(name, env_vars[i].name, KERNEL_ENV_NAME_MAX) == 0) {
             return (const char *)env_vars[i].value;

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -238,7 +238,7 @@ kernel_setenv(const char *name, const char *value)
     /* If name already exists in env_vars, overwrite the existing value. */
     for (int i = 0; i < env_count; i++) {
         if (strncmp(name, env_vars[i].name, KERNEL_ENV_NAME_MAX) == 0) {
-            strncpy(env_vars[i].value, value, KERNEL_ENV_VALUE_MAX);
+            strscpy(env_vars[i].value, value, KERNEL_ENV_VALUE_MAX);
             return 0;
         }
     }
@@ -247,8 +247,8 @@ kernel_setenv(const char *name, const char *value)
     if (env_count >= KERNEL_ENV_MAX) {
         return -ENOSPC;
     }
-    strncpy(env_vars[env_count].name, name, KERNEL_ENV_NAME_MAX);
-    strncpy(env_vars[env_count].value, value, KERNEL_ENV_VALUE_MAX);
+    strscpy(env_vars[env_count].name, name, KERNEL_ENV_NAME_MAX);
+    strscpy(env_vars[env_count].value, value, KERNEL_ENV_VALUE_MAX);
     env_count++;
     return 0;
 }

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -43,6 +43,7 @@
 #include <linux/cpumask.h>
 #include <linux/kprobes.h>
 #include <linux/ktime.h>
+#include <linux/panic.h>
 #include <linux/printk.h>
 #include <linux/preempt.h>
 #include <linux/smp.h>
@@ -237,6 +238,12 @@ kernel_printk(const char *fmt, ...)
     va_start(args, fmt);
     vprintk(fmt, args);
     va_end(args);
+}
+
+void
+kernel_panic(const char *message)
+{
+    panic("%s", message);
 }
 
 #define KERNEL_ENV_MAX 20

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -44,6 +44,7 @@
 #include <linux/kprobes.h>
 #include <linux/ktime.h>
 #include <linux/printk.h>
+#include <linux/preempt.h>
 #include <linux/smp.h>
 #include <linux/stdarg.h>
 #include <linux/string.h>
@@ -206,6 +207,7 @@ kernel_allocate_heap(size_t size)
 int
 kernel_get_cpu_id(void)
 {
+    KERNEL_ASSERT(!preemptible());
     return smp_processor_id();
 }
 

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -39,6 +39,7 @@
 
 #include "kernel_interface.h"
 
+#include <asm/page.h>
 #include <linux/kprobes.h>
 #include <linux/ktime.h>
 #include <linux/printk.h>
@@ -205,6 +206,12 @@ int
 kernel_get_cpu_id(void)
 {
     return smp_processor_id();
+}
+
+size_t
+kernel_get_page_size(void)
+{
+    return PAGE_SIZE;
 }
 
 unsigned int

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -39,10 +39,11 @@
 
 #include "kernel_interface.h"
 
-#include <linux/kallsyms.h>
 #include <linux/kprobes.h>
 #include <linux/ktime.h>
+#include <linux/printk.h>
 #include <linux/smp.h>
+#include <linux/stdarg.h>
 #include <linux/string.h>
 #include <linux/vmalloc.h>
 
@@ -216,6 +217,7 @@ void
 kernel_printk(const char *fmt, ...)
 {
     va_list args;
+
     va_start(args, fmt);
     vprintk(fmt, args);
     va_end(args);

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -264,7 +264,7 @@ kernel_setenv(const char *name, const char *value)
 
     /* If name already exists in env_vars, overwrite the existing value. */
     for (int i = 0; i < env_count; i++) {
-        if (strncmp(name, env_vars[i].name, KERNEL_ENV_NAME_MAX) == 0) {
+        if (strcmp(name, env_vars[i].name) == 0) {
             strscpy(env_vars[i].value, value, KERNEL_ENV_VALUE_MAX);
             return 0;
         }
@@ -287,7 +287,7 @@ kernel_getenv(const char *name)
         return NULL;
     }
     for (int i = 0; i < env_count; i++) {
-        if (strncmp(name, env_vars[i].name, KERNEL_ENV_NAME_MAX) == 0) {
+        if (strcmp(name, env_vars[i].name) == 0) {
             return (const char *)env_vars[i].value;
         }
     }

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -40,6 +40,7 @@
 #include "kernel_interface.h"
 
 #include <asm/page.h>
+#include <linux/cpumask.h>
 #include <linux/kprobes.h>
 #include <linux/ktime.h>
 #include <linux/printk.h>
@@ -206,6 +207,12 @@ int
 kernel_get_cpu_id(void)
 {
     return smp_processor_id();
+}
+
+int
+kernel_get_online_processor_count(void)
+{
+    return num_online_cpus();
 }
 
 size_t

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -221,6 +221,7 @@ kernel_get_online_processor_count(void)
 size_t
 kernel_get_page_size(void)
 {
+    /* PAGE_SIZE is the target kernel's base page size, defined by <asm/page.h>. */
     return PAGE_SIZE;
 }
 

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -57,6 +57,18 @@ kernel_query_time_seconds(void);
 #define KERNEL_ENV_NAME_MAX 50
 #define KERNEL_ENV_VALUE_MAX 512
 
+/* Sets the environment variable |name| to |value|, overwriting the value of any existing
+ * entry with the same name. Returns 0 on success, -EINVAL for a NULL/empty name, a name
+ * containing '=', or a NULL value, -E2BIG if the name or value exceeds the maximum
+ * length, and -ENOSPC if the table is full and no entry with |name| exists.
+ */
+int
+kernel_setenv(const char *name, const char *value);
+
+/* Returns the value of the environment variable |name|, or NULL if it is not set.
+ * Malformed names (NULL, empty, or containing '=') also return NULL, mirroring
+ * our_getenv() in core/unix/os.c.
+ */
 const char *
 kernel_getenv(const char *name);
 

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -54,8 +54,7 @@ kernel_get_cpu_id(void);
 unsigned int
 kernel_query_time_seconds(void);
 
-__printf(1, 2)
-void kernel_printk(const char *fmt, ...);
+__printf(1, 2) void kernel_printk(const char *fmt, ...);
 
 #define KERNEL_ENV_NAME_MAX 50
 #define KERNEL_ENV_VALUE_MAX 512

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -54,6 +54,9 @@ kernel_get_cpu_id(void);
 unsigned int
 kernel_query_time_seconds(void);
 
+__printf(1, 2)
+void kernel_printk(const char *fmt, ...);
+
 #define KERNEL_ENV_NAME_MAX 50
 #define KERNEL_ENV_VALUE_MAX 512
 

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -51,6 +51,9 @@ kernel_find_symbol(const char *name, size_t *size);
 int
 kernel_get_cpu_id(void);
 
+int
+kernel_get_online_processor_count(void);
+
 size_t
 kernel_get_page_size(void);
 

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -51,6 +51,9 @@ kernel_find_symbol(const char *name, size_t *size);
 int
 kernel_get_cpu_id(void);
 
+size_t
+kernel_get_page_size(void);
+
 unsigned int
 kernel_query_time_seconds(void);
 

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -63,6 +63,9 @@ kernel_query_time_seconds(void);
 __attribute__((format(gnu_printf, 1, 2))) void
 kernel_printk(const char *fmt, ...);
 
+__attribute__((noreturn)) void
+kernel_panic(const char *message);
+
 #define KERNEL_ENV_NAME_MAX 64
 #define KERNEL_ENV_VALUE_MAX 2048
 

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -63,8 +63,8 @@ kernel_query_time_seconds(void);
 __attribute__((format(gnu_printf, 1, 2))) void
 kernel_printk(const char *fmt, ...);
 
-#define KERNEL_ENV_NAME_MAX 50
-#define KERNEL_ENV_VALUE_MAX 512
+#define KERNEL_ENV_NAME_MAX 64
+#define KERNEL_ENV_VALUE_MAX 2048
 
 /* Sets the environment variable |name| to |value|, overwriting the value of any existing
  * entry with the same name. Returns 0 on success, -EINVAL for a NULL/empty name, a name

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -54,7 +54,8 @@ kernel_get_cpu_id(void);
 unsigned int
 kernel_query_time_seconds(void);
 
-__printf(1, 2) void kernel_printk(const char *fmt, ...);
+__attribute__((format(gnu_printf, 1 ,2))) void
+kernel_printk(const char *fmt, ...);
 
 #define KERNEL_ENV_NAME_MAX 50
 #define KERNEL_ENV_VALUE_MAX 512

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -54,7 +54,7 @@ kernel_get_cpu_id(void);
 unsigned int
 kernel_query_time_seconds(void);
 
-__attribute__((format(gnu_printf, 1 ,2))) void
+__attribute__((format(gnu_printf, 1, 2))) void
 kernel_printk(const char *fmt, ...);
 
 #define KERNEL_ENV_NAME_MAX 50

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -110,6 +110,18 @@ os_wait_thread_terminated(dcontext_t *dcontext)
     ASSERT_NOT_PORTED(false);
 }
 
+char *
+get_application_name(void)
+{
+    return "Linux kernel";
+}
+
+DYNAMORIO_EXPORT const char *
+get_application_short_name(void)
+{
+    return get_application_name();
+}
+
 /* Only supports text as it's backed by printk.
  * Long messages are chunked and each chunk becomes a separate printk record,
  * so they may gain line breaks when displayed and interleave with other output.

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -274,3 +274,11 @@ get_num_processors(void)
     }
     return num_online_processors;
 }
+
+uint
+os_random_seed(void)
+{
+    uint64 cycles;
+    RDTSC_LL(cycles);
+    return (uint)cycles;
+}

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -282,3 +282,9 @@ os_random_seed(void)
     RDTSC_LL(cycles);
     return (uint)cycles;
 }
+
+void
+os_file_init(void)
+{
+    /* No-op in kernel mode: there are no process fds to steal or limits to adjust. */
+}

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -49,8 +49,6 @@ DR_API file_t our_stderr = 2;
 app_pc vsyscall_syscall_end_pc = NULL;
 app_pc vsyscall_sysenter_return_pc = NULL;
 
-static bool os_initialized = false;
-
 #define ASSERT_NOT_PORTED(x) assert_not_ported(__FILE__, __LINE__, __func__)
 
 static void
@@ -103,7 +101,6 @@ dcontext_t *
 get_thread_private_dcontext(void)
 {
     /* TODO i#8021: Return per-CPU dcontext after CPU takeover. */
-    ASSERT(!os_initialized);
     return NULL;
 }
 

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -262,3 +262,15 @@ os_check_option_compatibility(void)
 
     return changed_options;
 }
+
+static int num_online_processors = 0;
+
+int
+get_num_processors(void)
+{
+    /* Assume that this is called at init time, so synchronization isn't necessary. */
+    if (num_online_processors == 0) {
+        num_online_processors = kernel_get_online_processor_count();
+    }
+    return num_online_processors;
+}

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -288,3 +288,11 @@ os_file_init(void)
 {
     /* No-op in kernel mode: there are no process fds to steal or limits to adjust. */
 }
+
+#define KERNEL_PROCESS_ID 0
+
+process_id_t
+get_process_id(void)
+{
+    return KERNEL_PROCESS_ID;
+}

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -312,3 +312,9 @@ get_thread_private_dcontext(void)
     ASSERT(!os_initialized);
     return NULL;
 }
+
+char *
+our_getenv(const char *name)
+{
+    return (char *)kernel_getenv(name);
+}

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -245,6 +245,7 @@ os_check_option_compatibility(void)
             changed_options = true;          \
         }                                    \
     } while (0)
+
     bool changed_options = false;
 
 #ifdef X64

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -122,6 +122,18 @@ get_application_short_name(void)
     return get_application_name();
 }
 
+file_t
+os_open(const char *fname, int os_open_flags)
+{
+    return INVALID_FILE;
+}
+
+void
+os_close(file_t f)
+{
+    /* No-op in kernel mode. */
+}
+
 /* Only supports text as it's backed by printk.
  * Long messages are chunked and each chunk becomes a separate printk record,
  * so they may gain line breaks when displayed and interleave with other output.

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -249,6 +249,11 @@ os_check_option_compatibility(void)
     FORCE_OPTION_VALUE(heap_in_lower_4GB, false);
 #endif
 
+    /* Currently the kernel module has no filesystem logging support.
+     * Only logging to printk is supported.
+     */
+    FORCE_OPTION_VALUE(log_to_stderr, true);
+
     /* Reserve all DR-managed virtual memory before takeover. Falling back to
      * the kernel allocator afterward could re-enter instrumented allocation paths.
      */

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -77,7 +77,7 @@ os_get_app_tls_reg_offset(reg_id_t reg)
 }
 
 thread_id_t
-get_thread_id(void)
+d_r_get_thread_id(void)
 {
     /* kernel_get_cpu_id is reentrant and fast
      * (it just reads gs:[&per_cpu_var(cpu_number)])
@@ -88,7 +88,7 @@ get_thread_id(void)
 thread_id_t
 get_tls_thread_id(void)
 {
-    return get_thread_id();
+    return d_r_get_thread_id();
 }
 
 thread_id_t

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -99,6 +99,14 @@ get_sys_thread_id(void)
     return kernel_get_cpu_id();
 }
 
+dcontext_t *
+get_thread_private_dcontext(void)
+{
+    /* TODO i#8021: Return per-CPU dcontext after CPU takeover. */
+    ASSERT(!os_initialized);
+    return NULL;
+}
+
 bool
 is_thread_terminated(dcontext_t *dcontext)
 {
@@ -308,14 +316,6 @@ os_check_option_compatibility(void)
 #undef FORCE_OPTION_VALUE
 
     return changed_options;
-}
-
-dcontext_t *
-get_thread_private_dcontext(void)
-{
-    /* TODO i#8021: Return per-CPU dcontext after CPU takeover. */
-    ASSERT(!os_initialized);
-    return NULL;
 }
 
 char *

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -117,6 +117,16 @@ os_wait_thread_terminated(dcontext_t *dcontext)
     ASSERT_NOT_PORTED(false);
 }
 
+void
+os_terminate(dcontext_t *dcontext, terminate_flags_t flags)
+{
+    /* All termination requests are system-fatal in kernel mode. Returning, killing
+     * the current task, or resuming native execution could leave locks held and
+     * shared state inconsistent. Expected failures must use explicit error returns.
+     */
+    kernel_panic("DynamoRIO kernel termination requested");
+}
+
 #define KERNEL_PROCESS_ID 0
 
 process_id_t

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -110,6 +110,20 @@ os_wait_thread_terminated(dcontext_t *dcontext)
     ASSERT_NOT_PORTED(false);
 }
 
+#define KERNEL_PROCESS_ID 0
+
+process_id_t
+get_process_id(void)
+{
+    return KERNEL_PROCESS_ID;
+}
+
+char *
+get_application_pid(void)
+{
+    return STRINGIFY(KERNEL_PROCESS_ID);
+}
+
 char *
 get_application_name(void)
 {
@@ -120,6 +134,12 @@ DYNAMORIO_EXPORT const char *
 get_application_short_name(void)
 {
     return get_application_name();
+}
+
+void
+os_file_init(void)
+{
+    /* No-op in kernel mode: there are no process fds to steal or limits to adjust. */
 }
 
 file_t
@@ -171,6 +191,24 @@ os_flush(file_t f)
     /* This is a no-op as there is no DR-side buffering for printk output. */
 }
 
+size_t
+os_page_size(void)
+{
+    return kernel_get_page_size();
+}
+
+static int num_online_processors = 0;
+
+int
+get_num_processors(void)
+{
+    /* Assume that this is called at init time, so synchronization isn't necessary. */
+    if (num_online_processors == 0) {
+        num_online_processors = kernel_get_online_processor_count();
+    }
+    return num_online_processors;
+}
+
 uint
 query_time_seconds(void)
 {
@@ -182,10 +220,12 @@ query_time_seconds(void)
     return kernel_query_time_seconds() + UTC_TO_EPOCH_SECONDS;
 }
 
-size_t
-os_page_size(void)
+uint
+os_random_seed(void)
 {
-    return kernel_get_page_size();
+    uint64 cycles;
+    RDTSC_LL(cycles);
+    return (uint)cycles;
 }
 
 bool
@@ -261,38 +301,4 @@ os_check_option_compatibility(void)
 #undef FORCE_OPTION_VALUE
 
     return changed_options;
-}
-
-static int num_online_processors = 0;
-
-int
-get_num_processors(void)
-{
-    /* Assume that this is called at init time, so synchronization isn't necessary. */
-    if (num_online_processors == 0) {
-        num_online_processors = kernel_get_online_processor_count();
-    }
-    return num_online_processors;
-}
-
-uint
-os_random_seed(void)
-{
-    uint64 cycles;
-    RDTSC_LL(cycles);
-    return (uint)cycles;
-}
-
-void
-os_file_init(void)
-{
-    /* No-op in kernel mode: there are no process fds to steal or limits to adjust. */
-}
-
-#define KERNEL_PROCESS_ID 0
-
-process_id_t
-get_process_id(void)
-{
-    return KERNEL_PROCESS_ID;
 }

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -49,6 +49,8 @@ DR_API file_t our_stderr = 2;
 app_pc vsyscall_syscall_end_pc = NULL;
 app_pc vsyscall_sysenter_return_pc = NULL;
 
+static bool os_initialized = false;
+
 #define ASSERT_NOT_PORTED(x) assert_not_ported(__FILE__, __LINE__, __func__)
 
 static void
@@ -301,4 +303,12 @@ os_check_option_compatibility(void)
 #undef FORCE_OPTION_VALUE
 
     return changed_options;
+}
+
+dcontext_t *
+get_thread_private_dcontext(void)
+{
+    /* TODO i#8021: Return per-CPU dcontext after CPU takeover. */
+    ASSERT(!os_initialized);
+    return NULL;
 }

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -181,3 +181,9 @@ query_time_seconds(void)
      */
     return kernel_query_time_seconds() + UTC_TO_EPOCH_SECONDS;
 }
+
+size_t
+os_page_size(void)
+{
+    return kernel_get_page_size();
+}

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -141,6 +141,12 @@ os_write(file_t f, const void *buf, size_t count)
     return count;
 }
 
+void
+os_flush(file_t f)
+{
+    /* This is a no-op as there is no DR-side buffering for printk output. */
+}
+
 uint
 query_time_seconds(void)
 {

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -39,6 +39,13 @@
 #include "globals.h"
 #include "kernel_interface.h"
 
+/* Kernel code has no standard streams of its own. These synthetic handles use
+ * conventional descriptor numbers for compatibility with shared DR code.
+ */
+DR_API file_t our_stdin = 0;
+DR_API file_t our_stdout = 1;
+DR_API file_t our_stderr = 2;
+
 app_pc vsyscall_syscall_end_pc = NULL;
 app_pc vsyscall_sysenter_return_pc = NULL;
 
@@ -101,6 +108,37 @@ void
 os_wait_thread_terminated(dcontext_t *dcontext)
 {
     ASSERT_NOT_PORTED(false);
+}
+
+/* Only supports text as it's backed by printk.
+ * Long messages are chunked and each chunk becomes a separate printk record,
+ * so they may gain line breaks when displayed and interleave with other output.
+ */
+ssize_t
+os_write(file_t f, const void *buf, size_t count)
+{
+    if (f != STDOUT && f != STDERR) {
+        return -1;
+    }
+    if (buf == NULL && count != 0) {
+        return -1;
+    }
+
+    /* Each printk record reservation is capped at 1024 bytes (PRINTKRB_RECORD_MAX).
+     * Leave headroom for a possible text prefix and the terminating NUL.
+     */
+    const size_t chunk_size = 900;
+    const char *cursor = (const char *)buf;
+    size_t remaining = count;
+
+    while (remaining > 0) {
+        int chunk = MIN(remaining, chunk_size);
+        kernel_printk("%.*s", chunk, cursor);
+        cursor += chunk;
+        remaining -= chunk;
+    }
+
+    return count;
 }
 
 uint

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -283,6 +283,9 @@ os_check_option_compatibility(void)
 
     /* The kernel interrupt path only supports CPU-private fragments. Shared-fragment
      * unlinking and state-reconstruction races have not been addressed.
+     * XXX: This is a temporary restriction. We want CPU-shared fragments in the future,
+     * which requires revisiting interrupt patching, unlink/relink coordination across
+     * CPUs, and TLS bootstrapping at kernel entry points.
      */
     FORCE_OPTION_VALUE(shared_bbs, false);
 

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -187,3 +187,78 @@ os_page_size(void)
 {
     return kernel_get_page_size();
 }
+
+bool
+os_check_option_compatibility(void)
+{
+#define FORCE_OPTION_VALUE(opt, value)       \
+    do {                                     \
+        if (DYNAMO_OPTION(opt) != (value)) { \
+            dynamo_options.opt = (value);    \
+            changed_options = true;          \
+        }                                    \
+    } while (0)
+    bool changed_options = false;
+
+#ifdef X64
+    /* Kernel and module virtual addresses are above 4 GB, so the user-space
+     * heap_in_lower_4GB placement constraint cannot be satisfied.
+     */
+    FORCE_OPTION_VALUE(heap_in_lower_4GB, false);
+#endif
+
+    /* Reserve all DR-managed virtual memory before takeover. Falling back to
+     * the kernel allocator afterward could re-enter instrumented allocation paths.
+     */
+    FORCE_OPTION_VALUE(switch_to_os_at_vmm_reset_limit, false);
+    FORCE_OPTION_VALUE(vm_reserve, true);
+
+    /* SMP takeover requires CPUs to initialize and enter DR concurrently; the
+     * global single-thread-in-DR mode would serialize them.
+     */
+    FORCE_OPTION_VALUE(single_thread_in_DR, false);
+
+    /* The kernel interrupt path only supports CPU-private fragments. Shared-fragment
+     * unlinking and state-reconstruction races have not been addressed.
+     */
+    FORCE_OPTION_VALUE(shared_bbs, false);
+
+    /* Coarse units require shared BBs and would otherwise re-enable them during
+     * recursive compatibility checking.
+     */
+    FORCE_OPTION_VALUE(coarse_units, false);
+
+    /* Shared traces have the same unsupported interrupt-handling races. */
+    FORCE_OPTION_VALUE(shared_traces, false);
+
+    /* Do not request a shared trace IBL routine. On x86-64, the unconditional
+     * shared-gencode path currently overrides this option and must be addressed as
+     * part of takeover support.
+     */
+    FORCE_OPTION_VALUE(shared_trace_ibl_routine, false);
+
+    /* Full state reconstruction from a PC in a separate direct-exit stub remains
+     * unsupported, so keep exit stubs with their owning fragments.
+     */
+    FORCE_OPTION_VALUE(separate_private_stubs, false);
+    FORCE_OPTION_VALUE(separate_shared_stubs, false);
+
+    /* Independent stub freeing requires separate stubs; shared-stub freeing also
+     * lacks the required linking atomicity.
+     */
+    FORCE_OPTION_VALUE(free_private_stubs, false);
+    FORCE_OPTION_VALUE(unsafe_free_shared_stubs, false);
+
+    /* Asynchronous interrupts require exact reconstruction of application EFLAGS.
+     * The unsafe flag-preservation elisions are unsupported in the kernel.
+     */
+    FORCE_OPTION_VALUE(unsafe_ignore_overflow, false);
+    FORCE_OPTION_VALUE(unsafe_ignore_eflags, false);
+    FORCE_OPTION_VALUE(unsafe_ignore_eflags_trace, false);
+    FORCE_OPTION_VALUE(unsafe_ignore_eflags_prefix, false);
+    FORCE_OPTION_VALUE(unsafe_ignore_eflags_ibl, false);
+
+#undef FORCE_OPTION_VALUE
+
+    return changed_options;
+}


### PR DESCRIPTION
- Add an `options` module parameter to accept DynamoRIO options on `insmod` and initialize them via `dynamorio_app_init_part_one_options()` during module init.
- Added functions in `core/kernel_linux/os.c` that `dynamorio_app_init_part_one_options()` depends on. They are exercised by the init path and tested in the insmod CI.
- Implement `kernel_setenv()` for saving the options value. 
- Implement `os_check_option_compatibility()` to enforce kernel-mode options constraints.
- Update the kernel module insmod workflow to build with both `-DDEBUG=ON` and `OFF`, and verify that runtime options (`-loglevel 2`) are parsed and logged correctly in the debug build.

On configuration lookup: the shared init path still performs it, but `os_open()` is intentionally not implemented in kernel mode and returns `INVALID_FILE` unconditionally. So no config file can be found and options can only be set using the module parameter.

The kernel-mode options constraints implemented in `os_check_option_compatibility()` are mostly copied from drk and may need future adjustments. For example, #8116 tracks CPU-private fragment restrictions (`shared_bbs`, `shared_traces`, `coarse_units`).

This initial implementation only supports setting options at module load time. Dynamic updates and per-process options are tracked by #8115.

Issue: #8021 