### PR TITLE
i#8100: Try rseq_len value range in glibc struct rseq search

### DIFF
--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -664,8 +664,8 @@ try_struct_rseq(void *try_addr)
      * See https://lwn.net/Articles/1033957/ for more details.
      */
     for (size = 32; size <= 33 && res == -EINVAL; size++) {
-        res = dynamorio_syscall(SYS_rseq, 4, try_addr, size,
-                                RSEQ_FLAG_UNREGISTER, RSEQ_RARE_SIGNATURE);
+        res = dynamorio_syscall(SYS_rseq, 4, try_addr, size, RSEQ_FLAG_UNREGISTER,
+                                RSEQ_RARE_SIGNATURE);
         LOG(GLOBAL, LOG_LOADER, 3, "Tried rseq @ " PFX " => %d\n", try_addr, res);
     }
     if (res == -EINVAL) /* Our struct != registered struct. */
@@ -674,8 +674,7 @@ try_struct_rseq(void *try_addr)
      * actually used 42 for its signature we'll have to re-register it.
      */
     if (res == 0) {
-        res = dynamorio_syscall(SYS_rseq, 4, try_addr, size, 0,
-                                RSEQ_RARE_SIGNATURE);
+        res = dynamorio_syscall(SYS_rseq, 4, try_addr, size, 0, RSEQ_RARE_SIGNATURE);
         ASSERT(res == 0);
         res = -EPERM;
     }

--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -660,10 +660,10 @@ try_struct_rseq(void *try_addr)
     /* Originally the rseq_len parameter was supposed to be 32, but on more recent
      * kernels, it may be extended up to getauxval(AT_RSEQ_FEATURE_SIZE).
      * Since we do not want to depend on glibc's getauxval, we hardcode a max
-     * value based on what was observed.
+     * value based on what was observed and some extra for future-proofing.
      * See https://lwn.net/Articles/1033957/ for more details.
      */
-    for (size = 32; size <= 33 && res == -EINVAL; size++) {
+    for (size = 32; size <= 40 && res == -EINVAL; size++) {
         res = dynamorio_syscall(SYS_rseq, 4, try_addr, size, RSEQ_FLAG_UNREGISTER,
                                 RSEQ_RARE_SIGNATURE);
         LOG(GLOBAL, LOG_LOADER, 3, "Tried rseq @ " PFX " => %d\n", try_addr, res);

--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2019-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2026 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -655,17 +655,27 @@ static bool
 try_struct_rseq(void *try_addr)
 {
     static const int RSEQ_RARE_SIGNATURE = 42;
-    int res = dynamorio_syscall(SYS_rseq, 4, try_addr, sizeof(struct rseq),
+    int res = -EINVAL;
+    int size;
+    /* Originally the rseq_len parameter was supposed to be 32, but on more recent
+     * kernels, it may be extended up to getauxval(AT_RSEQ_FEATURE_SIZE).
+     * Since we do not want to depend on glibc's getauxval, we hardcode a max
+     * value based on what was observed.
+     * See https://lwn.net/Articles/1033957/ for more details.
+     */
+    for (size = 32; size <= 33 && res == -EINVAL; size++) {
+        res = dynamorio_syscall(SYS_rseq, 4, try_addr, size,
                                 RSEQ_FLAG_UNREGISTER, RSEQ_RARE_SIGNATURE);
-    LOG(GLOBAL, LOG_LOADER, 3, "Tried rseq @ " PFX " => %d\n", try_addr, res);
+        LOG(GLOBAL, LOG_LOADER, 3, "Tried rseq @ " PFX " => %d\n", try_addr, res);
+    }
     if (res == -EINVAL) /* Our struct != registered struct. */
         return false;
     /* We expect -EPERM on a signature mismatch.  On the small chance the app
      * actually used 42 for its signature we'll have to re-register it.
      */
     if (res == 0) {
-        int res = dynamorio_syscall(SYS_rseq, 4, try_addr, sizeof(struct rseq), 0,
-                                    RSEQ_RARE_SIGNATURE);
+        res = dynamorio_syscall(SYS_rseq, 4, try_addr, size, 0,
+                                RSEQ_RARE_SIGNATURE);
         ASSERT(res == 0);
         res = -EPERM;
     }


### PR DESCRIPTION
Fixes glibc struct rseq detection heuristic, which is broken after recent kernel changes that increased the size of the struct (https://lwn.net/Articles/885818). This affects DR mid-run attach uses where DR did not have a chance to observe glibc's original rseq syscall that registered its struct.

The struct rseq was 32 bytes with padding before, which was supposed to be passed as rseq_len to the rseq syscall. Now rseq_len may be getauxval(AT_RSEQ_FEATURE_SIZE), so we need to try multiple sizes. As we do not want to depend on the getauxval library call in DR code, we hardcode the value actually seen in a more recent environment where the prior try_struct_rseq failed.

See https://lwn.net/Articles/1033957/ for more details.

Fixes: #8100