### PR TITLE
i#7914 skipped memrefs: Refactor scatter/gather into raw2trace helper

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2027,7 +2027,6 @@ raw2trace_t::append_scatter_gather(raw2trace_thread_data_t *tdata,
                                    bool expect_all_memrefs,
                                    DR_PARAM_OUT int &consumed_memrefs)
 {
-    trace_entry_t *buf = *buf_in;
     // The instr should either load or store, but not both. Also,
     // it should have a single src or dest operand.
     DR_ASSERT(instr->num_mem_srcs() + instr->num_mem_dests() == 1);
@@ -2105,6 +2104,7 @@ raw2trace_t::append_scatter_gather(raw2trace_thread_data_t *tdata,
     --memref_count; // The final append_memref did not find one.
     DR_ASSERT(!add_skipped_markers || memref_count <= element_count);
     sg_buf_cur = sg_buf.get();
+    trace_entry_t *buf = *buf_in;
     int element_index = 0;
     for (int memref_index = 0; memref_index < memref_count ||
          (add_skipped_markers && element_index < element_count);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1930,120 +1930,9 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
             // No following memref for instruction-only trace type.
             !is_instr_only_trace) {
             if (instr->is_scatter_or_gather()) {
-                // The instr should either load or store, but not both. Also,
-                // it should have a single src or dest operand.
-                DR_ASSERT(instr->num_mem_srcs() + instr->num_mem_dests() == 1);
-                bool is_scatter = instr->num_mem_dests() == 1;
-                bool reached_end_of_memrefs = false;
-                // For expanded scatter/gather instrs, we do not have prior knowledge
-                // of the number of store/load memrefs that will be present. So we
-                // continue reading entries until we find a non-memref entry.
-                // This works only because drx_expand_scatter_gather ensures that the
-                // expansion has its own basic block, with no other app instr in it.
-                //
-                // For a contiguous scatter/gather we do know the count and
-                // offsets statically and can fill in skipped memrefs if we
-                // have the base address, which we do via a special record
-                // read below.
-                bool add_skipped_markers = false;
-                addr_t base_addr = 0;
-                int mem_element_size = 0;
-                int element_count = 0;
-                // Conservative upper bound.
-                constexpr int MAX_SG_ELEMENTS = 2048;
-                auto sg_buf = std::make_unique<trace_entry_t[]>(MAX_SG_ELEMENTS);
-                trace_entry_t *sg_buf_cur = sg_buf.get();
-                in_entry = get_next_entry(tdata);
-                if (in_entry != nullptr) {
-                    if (!(in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
-                          in_entry->extended.ext ==
-                              OFFLINE_EXT_TYPE_SCATTER_GATHER_BASE)) {
-                        // Support older traces without such records.
-                        unread_last_entry(tdata);
-                    } else {
-                        add_skipped_markers = true;
-                        base_addr = in_entry->extended.valueA;
-                        opnd_t memref = is_scatter ? instr->mem_dest_at(0).opnd
-                                                   : instr->mem_src_at(0).opnd;
-                        if (!TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS,
-                                     get_file_type(tdata)) &&
-                            tdata->instru_offline.opnd_disp_is_elidable(memref)) {
-                            // We stored only the base reg, as an optimization.
-                            // This happens even with predicated instructions where we
-                            // don't do base reg elision.
-                            base_addr += opnd_get_disp(memref);
-                        }
-                        int reg_element_size = instr->scatter_gather_element_size();
-                        DR_ASSERT(reg_element_size > 0);
-                        mem_element_size = opnd_size_in_bytes(opnd_get_size(memref));
-                        // dr_get_vector_length() is in bits.
-                        element_count = dr_get_vector_length() / 8 / reg_element_size;
-                        // We want the sum across all vectors, if multiple: e.g.,
-                        // LD4H writes into 4 separate vector registers.
-                        int vector_count = instr->scatter_gather_vector_count();
-                        DR_ASSERT(vector_count > 0);
-                        element_count *= vector_count;
-                        log(4,
-                            "Scatter/gather skip info: base=%p reg_el_sz=%d mem_el_sz=%d "
-                            "el_cnt=%d (for %d vectors)\n",
-                            base_addr, reg_element_size, mem_element_size, element_count,
-                            vector_count);
-                    }
-                }
-                int memref_count = 0;
-                for (; !reached_end_of_memrefs; ++memref_count) {
-                    // XXX: Add sanity check for max count of store/load memrefs
-                    // possible for a given scatter/gather instr. For now we have
-                    // a conservative single max.
-                    DR_ASSERT(memref_count < MAX_SG_ELEMENTS);
-                    if (!append_memref(
-                            tdata, &sg_buf_cur, instr,
-                            // These memrefs were output by multiple store/load instrs in
-                            // the expanded scatter/gather sequence. In raw2trace we see
-                            // only the original app instr though. So we use the 0th
-                            // dest/src of the original scatter/gather instr for all.
-                            is_scatter ? instr->mem_dest_at(0) : instr->mem_src_at(0),
-                            is_scatter, reg_vals, &reached_end_of_memrefs,
-                            expect_all_memrefs, consumed_memrefs))
-                        return false;
-                }
-                --memref_count; // The final append_memref did not find one.
-                DR_ASSERT(!add_skipped_markers || memref_count <= element_count);
-                sg_buf_cur = sg_buf.get();
-                int element_index = 0;
-                for (int memref_index = 0; memref_index < memref_count ||
-                     (add_skipped_markers && element_index < element_count);
-                     ++memref_index) {
-                    if (add_skipped_markers) {
-                        addr_t next_addr = base_addr + element_index * mem_element_size;
-                        log(4, "Scatter/gather el %d: next_addr=%p cur memref %d %p\n",
-                            element_index, next_addr, memref_index,
-                            memref_index < memref_count ? sg_buf_cur->addr : 0);
-                        while (element_index < element_count &&
-                               (memref_index >= memref_count ||
-                                sg_buf_cur->addr > next_addr)) {
-                            log(4, "Scatter/gather el %d: filling in skipped addr=%p\n",
-                                element_index, next_addr);
-                            buf->type = TRACE_TYPE_MARKER;
-                            buf->size = TRACE_MARKER_TYPE_SKIPPED_MEMREF;
-                            buf->addr = next_addr;
-                            ++buf;
-                            ++element_index;
-                            next_addr = base_addr + element_index * mem_element_size;
-                        }
-                        DR_ASSERT(memref_index >= memref_count ||
-                                  sg_buf_cur->addr == next_addr);
-                    }
-                    if (memref_index < memref_count) {
-                        log(4, "Scatter/gather el %d writing memref %d %p\n",
-                            element_index, memref_index, sg_buf_cur->addr);
-                        *buf = *sg_buf_cur;
-                        ++buf;
-                        ++sg_buf_cur;
-                        ++element_index;
-                    }
-                }
-                DR_ASSERT(!add_skipped_markers || element_index == element_count);
+                if (!append_scatter_gather(tdata, instr, &buf, reg_vals,
+                                           expect_all_memrefs, consumed_memrefs))
+                    return false;
             } else if (instrs_are_separate) {
                 // There is only one memref entry (each memref is after a count=0 PC
                 // entry). Full info (type and size) is provided via
@@ -2127,6 +2016,128 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         return false;
     }
     *handled = true;
+    return true;
+}
+
+bool
+raw2trace_t::append_scatter_gather(raw2trace_thread_data_t *tdata,
+                                   const instr_summary_t *instr,
+                                   DR_PARAM_INOUT trace_entry_t **buf_in,
+                                   std::unordered_map<reg_id_t, addr_t> &reg_vals,
+                                   bool expect_all_memrefs,
+                                   DR_PARAM_OUT int &consumed_memrefs)
+{
+    trace_entry_t *buf = *buf_in;
+    // The instr should either load or store, but not both. Also,
+    // it should have a single src or dest operand.
+    DR_ASSERT(instr->num_mem_srcs() + instr->num_mem_dests() == 1);
+    bool is_scatter = instr->num_mem_dests() == 1;
+    bool reached_end_of_memrefs = false;
+    // For expanded scatter/gather instrs, we do not have prior knowledge
+    // of the number of store/load memrefs that will be present. So we
+    // continue reading entries until we find a non-memref entry.
+    // This works only because drx_expand_scatter_gather ensures that the
+    // expansion has its own basic block, with no other app instr in it.
+    //
+    // For a contiguous scatter/gather we do know the count and
+    // offsets statically and can fill in skipped memrefs if we
+    // have the base address, which we do via a special record
+    // read below.
+    bool add_skipped_markers = false;
+    addr_t base_addr = 0;
+    int mem_element_size = 0;
+    int element_count = 0;
+    // Conservative upper bound.
+    constexpr int MAX_SG_ELEMENTS = 2048;
+    auto sg_buf = std::make_unique<trace_entry_t[]>(MAX_SG_ELEMENTS);
+    trace_entry_t *sg_buf_cur = sg_buf.get();
+    const offline_entry_t *in_entry = get_next_entry(tdata);
+    if (in_entry != nullptr) {
+        if (!(in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
+              in_entry->extended.ext == OFFLINE_EXT_TYPE_SCATTER_GATHER_BASE)) {
+            // Support older traces without such records.
+            unread_last_entry(tdata);
+        } else {
+            add_skipped_markers = true;
+            base_addr = in_entry->extended.valueA;
+            opnd_t memref =
+                is_scatter ? instr->mem_dest_at(0).opnd : instr->mem_src_at(0).opnd;
+            if (!TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS, get_file_type(tdata)) &&
+                tdata->instru_offline.opnd_disp_is_elidable(memref)) {
+                // We stored only the base reg, as an optimization.
+                // This happens even with predicated instructions where we
+                // don't do base reg elision.
+                base_addr += opnd_get_disp(memref);
+            }
+            int reg_element_size = instr->scatter_gather_element_size();
+            DR_ASSERT(reg_element_size > 0);
+            mem_element_size = opnd_size_in_bytes(opnd_get_size(memref));
+            // dr_get_vector_length() is in bits.
+            element_count = dr_get_vector_length() / 8 / reg_element_size;
+            // We want the sum across all vectors, if multiple: e.g.,
+            // LD4H writes into 4 separate vector registers.
+            int vector_count = instr->scatter_gather_vector_count();
+            DR_ASSERT(vector_count > 0);
+            element_count *= vector_count;
+            log(4,
+                "Scatter/gather skip info: base=%p reg_el_sz=%d mem_el_sz=%d "
+                "el_cnt=%d (for %d vectors)\n",
+                base_addr, reg_element_size, mem_element_size, element_count,
+                vector_count);
+        }
+    }
+    int memref_count = 0;
+    for (; !reached_end_of_memrefs; ++memref_count) {
+        // XXX: Add sanity check for max count of store/load memrefs
+        // possible for a given scatter/gather instr. For now we have
+        // a conservative single max.
+        DR_ASSERT(memref_count < MAX_SG_ELEMENTS);
+        if (!append_memref(tdata, &sg_buf_cur, instr,
+                           // These memrefs were output by multiple store/load instrs in
+                           // the expanded scatter/gather sequence. In raw2trace we see
+                           // only the original app instr though. So we use the 0th
+                           // dest/src of the original scatter/gather instr for all.
+                           is_scatter ? instr->mem_dest_at(0) : instr->mem_src_at(0),
+                           is_scatter, reg_vals, &reached_end_of_memrefs,
+                           expect_all_memrefs, consumed_memrefs))
+            return false;
+    }
+    --memref_count; // The final append_memref did not find one.
+    DR_ASSERT(!add_skipped_markers || memref_count <= element_count);
+    sg_buf_cur = sg_buf.get();
+    int element_index = 0;
+    for (int memref_index = 0; memref_index < memref_count ||
+         (add_skipped_markers && element_index < element_count);
+         ++memref_index) {
+        if (add_skipped_markers) {
+            addr_t next_addr = base_addr + element_index * mem_element_size;
+            log(4, "Scatter/gather el %d: next_addr=%p cur memref %d %p\n", element_index,
+                next_addr, memref_index,
+                memref_index < memref_count ? sg_buf_cur->addr : 0);
+            while (element_index < element_count &&
+                   (memref_index >= memref_count || sg_buf_cur->addr > next_addr)) {
+                log(4, "Scatter/gather el %d: filling in skipped addr=%p\n",
+                    element_index, next_addr);
+                buf->type = TRACE_TYPE_MARKER;
+                buf->size = TRACE_MARKER_TYPE_SKIPPED_MEMREF;
+                buf->addr = next_addr;
+                ++buf;
+                ++element_index;
+                next_addr = base_addr + element_index * mem_element_size;
+            }
+            DR_ASSERT(memref_index >= memref_count || sg_buf_cur->addr == next_addr);
+        }
+        if (memref_index < memref_count) {
+            log(4, "Scatter/gather el %d writing memref %d %p\n", element_index,
+                memref_index, sg_buf_cur->addr);
+            *buf = *sg_buf_cur;
+            ++buf;
+            ++sg_buf_cur;
+            ++element_index;
+        }
+    }
+    DR_ASSERT(!add_skipped_markers || element_index == element_count);
+    *buf_in = buf;
     return true;
 }
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1255,6 +1255,12 @@ private:
     could_entry_be_address(offline_entry_t entry);
 
     bool
+    append_scatter_gather(raw2trace_thread_data_t *tdata, const instr_summary_t *instr,
+                          DR_PARAM_INOUT trace_entry_t **buf_in,
+                          std::unordered_map<reg_id_t, addr_t> &reg_vals,
+                          bool expect_all_memrefs, DR_PARAM_OUT int &consumed_memrefs);
+
+    bool
     append_memref(raw2trace_thread_data_t *tdata, DR_PARAM_INOUT trace_entry_t **buf_in,
                   const instr_summary_t *instr, instr_summary_t::memref_summary_t memref,
                   bool write, std::unordered_map<reg_id_t, addr_t> &reg_vals,


### PR DESCRIPTION
Refactors the raw2trace scatter/gather skipped-memref code into a separate helper function to keep the code easier to read and maintain.

This is a prelude to adding rep string expansion in raw2trace for parallel helper function.

Issue: #7914, #4914