### PR TITLE
i#8091: Preserve signal masks across ptrace attach

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -3002,11 +3002,12 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
             os_thread_sleep(1);
     } while (found_threads && attempts < max_takeover_attempts);
 #ifdef PTRACE_TAKEOVER_SUPPORTED
-    if (DYNAMO_OPTION(attach_unmask_suspend_signal))
+    if (DYNAMO_OPTION(attach_unmask_suspend_signal)) {
         /* Functions and data structures named *pre_unmask* manage the
          * preservation of signal masks across ptrace assisted attach.
          */
         os_clear_pre_unmask_sigmasks();
+    }
 #endif
     os_process_under_dynamorio_complete(dcontext);
 

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -3001,6 +3001,13 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
         if (DYNAMO_OPTION(sleep_between_takeovers))
             os_thread_sleep(1);
     } while (found_threads && attempts < max_takeover_attempts);
+#ifdef PTRACE_TAKEOVER_SUPPORTED
+    if (DYNAMO_OPTION(attach_unmask_suspend_signal))
+        /* Functions and data structures named *pre_unmask* manage the
+         * preservation of signal masks across ptrace assisted attach.
+         */
+        os_clear_pre_unmask_sigmasks();
+#endif
     os_process_under_dynamorio_complete(dcontext);
 
     instrument_post_attach_event();

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -99,6 +99,9 @@ os_take_over_all_unknown_threads(dcontext_t *dcontext);
 #ifdef PTRACE_TAKEOVER_SUPPORTED
 bool
 os_unmask_suspend_signal_via_ptrace(thread_id_t skip_tid);
+
+void
+os_clear_pre_unmask_sigmasks(void);
 #endif
 
 bool

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -11497,6 +11497,7 @@ os_thread_take_over(priv_mcontext_t *mc, kernel_sigset_t *sigset)
     priv_mcontext_t *dc_mc;
 #ifdef PTRACE_TAKEOVER_SUPPORTED
     void *pt_param = NULL;
+    kernel_sigset_t pre_unmask_sigset;
 #endif
 
     LOG(GLOBAL, LOG_THREADS, 1, "TAKEOVER: received signal in thread " TIDFMT "\n",
@@ -11520,6 +11521,17 @@ os_thread_take_over(priv_mcontext_t *mc, kernel_sigset_t *sigset)
         dcontext = get_thread_private_dcontext();
         ASSERT(dcontext != NULL);
     }
+#ifdef PTRACE_TAKEOVER_SUPPORTED
+    /* Look up the current thread's TID in the table populated by
+     * ptrace_unmask_all_threads() and if found, save the thread's original
+     * mask into pre_unmask_sigset.
+     */
+    if (DYNAMO_OPTION(attach_unmask_suspend_signal) &&
+        ptrace_get_pre_unmask_sigmask(get_sys_thread_id(), &pre_unmask_sigset)) {
+        /* Initialise application visible mask from original mask. */
+        sigset = &pre_unmask_sigset;
+    }
+#endif
     signal_set_mask(dcontext, sigset);
     signal_swap_mask(dcontext, true /*to app*/);
     dynamo_thread_under_dynamo(dcontext);

--- a/core/unix/ptrace_attach.c
+++ b/core/unix/ptrace_attach.c
@@ -73,6 +73,12 @@ typedef struct _ptrace_thread_events_t {
     event_t done;
 } ptrace_thread_events_t;
 
+/* Stores the original per-thread signal mask before SUSPEND_SIGNAL cleared. */
+typedef struct _ptrace_sigmask_record_t {
+    thread_id_t tid;
+    kernel_sigset_t sigmask;
+} ptrace_sigmask_record_t;
+
 typedef struct _ptrace_unmask_state_t {
     ptrace_thread_events_t events;
     process_id_t target_pid;
@@ -80,6 +86,9 @@ typedef struct _ptrace_unmask_state_t {
     thread_id_t tracer_tid;
     int suspend_sig;
     bool success;
+    ptrace_sigmask_record_t *sigmask_records;
+    uint num_sigmask_records;
+    size_t sigmask_records_size;
 } ptrace_unmask_state_t;
 
 typedef struct _ptrace_takeover_param_t {
@@ -98,12 +107,47 @@ typedef struct _ptrace_takeover_state_t {
     bool success;
 } ptrace_takeover_state_t;
 
+/* The ptrace helper makes this table accessible to threads being taken over.
+ * It must only be read, enabling multiple threads to concurrently search it
+ * without a lock.
+ */
+static ptrace_sigmask_record_t *pre_unmask_sigmask_records;
+static uint num_pre_unmask_sigmask_records;
+static size_t pre_unmask_sigmask_records_size;
+
 static void
 destroy_events(ptrace_thread_events_t *events)
 {
     destroy_event(events->ready);
     destroy_event(events->go);
     destroy_event(events->done);
+}
+
+bool
+ptrace_get_pre_unmask_sigmask(thread_id_t tid, kernel_sigset_t *sigmask)
+{
+    ASSERT(sigmask != NULL);
+    ASSERT(pre_unmask_sigmask_records != NULL || num_pre_unmask_sigmask_records == 0);
+    for (uint i = 0; i < num_pre_unmask_sigmask_records; i++) {
+        if (pre_unmask_sigmask_records[i].tid == tid) {
+            *sigmask = pre_unmask_sigmask_records[i].sigmask;
+            return true;
+        }
+    }
+    return false;
+}
+
+void
+os_clear_pre_unmask_sigmasks(void)
+{
+    if (pre_unmask_sigmask_records != NULL) {
+        ASSERT(pre_unmask_sigmask_records_size > 0);
+        global_heap_free(pre_unmask_sigmask_records,
+                         pre_unmask_sigmask_records_size HEAPACCT(ACCT_THREAD_MGT));
+    }
+    pre_unmask_sigmask_records = NULL;
+    num_pre_unmask_sigmask_records = 0;
+    pre_unmask_sigmask_records_size = 0;
 }
 
 /* Determine whether a given thread is blocked inside one of the signal waiting
@@ -195,16 +239,37 @@ ptrace_unmask_all_threads(void *param)
 
     tids = os_list_threads_by_pid(dcontext, state->target_pid, &num_threads);
     if (tids != NULL) {
+        if (num_threads > 0) {
+            state->sigmask_records_size = num_threads * sizeof(*state->sigmask_records);
+            state->sigmask_records = (ptrace_sigmask_record_t *)global_heap_alloc(
+                state->sigmask_records_size HEAPACCT(ACCT_THREAD_MGT));
+            if (state->sigmask_records == NULL) {
+                state->sigmask_records_size = 0;
+                state->success = false;
+                HEAP_ARRAY_FREE(dcontext, tids, thread_id_t, num_threads, ACCT_THREAD_MGT,
+                                PROTECTED);
+                signal_event(state->events.done);
+                return;
+            }
+        }
         for (uint i = 0; i < num_threads; i++) {
             thread_id_t tid = tids[i];
+            kernel_sigset_t original_mask;
             if (tid == state->skip_tid)
                 continue;
             if (!ptrace_attach_and_stop(tid, NULL))
                 continue;
 
             any_tids_attempted = true;
-            if (!ptrace_unmask_signal(tid, state->suspend_sig))
+            if (!ptrace_unmask_signal(tid, state->suspend_sig, &original_mask)) {
                 any_tids_failed = true;
+            } else if (kernel_sigismember(&original_mask, state->suspend_sig)) {
+                ASSERT(state->num_sigmask_records < num_threads);
+                ptrace_sigmask_record_t *record =
+                    &state->sigmask_records[state->num_sigmask_records++];
+                record->tid = tid;
+                record->sigmask = original_mask;
+            }
 
             ptrace_detach(tid);
         }
@@ -572,13 +637,17 @@ os_ptrace_takeover_threads(dcontext_t *dcontext, thread_id_t *tids, uint count)
 /* This function creates a thread, ptrace_unmask_all_threads, which uses
  * /proc/<pid>/task to list threads by PID, attaching and stopping each thread
  * with ptrace. PTRACE_{GETSIGMASK,SETSIGMASK} are used to clear SUSPEND_SIGNAL
- * from each thread's blocked mask before detaching with ptrace.
+ * from each thread's blocked mask before detaching with ptrace. Each thread's
+ * original mask will be saved for restoration after attach.
  */
 bool
 os_unmask_suspend_signal_via_ptrace(thread_id_t skip_tid)
 {
     ptrace_unmask_state_t *state;
     bool ok = false;
+
+    /* Discard saved sigmask records left by any earlier attach. */
+    os_clear_pre_unmask_sigmasks();
 
     state = HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, ptrace_unmask_state_t, ACCT_THREAD_MGT,
                             PROTECTED);
@@ -615,6 +684,16 @@ os_unmask_suspend_signal_via_ptrace(thread_id_t skip_tid)
     signal_event(state->events.go);
     wait_for_event(state->events.done, 0);
     ok = state->success;
+
+    /* Initialise data structures to store original (pre-unmask) signal masks
+     * for each thread.
+     */
+    pre_unmask_sigmask_records = state->sigmask_records;
+    num_pre_unmask_sigmask_records = state->num_sigmask_records;
+    pre_unmask_sigmask_records_size = state->sigmask_records_size;
+    state->sigmask_records = NULL;
+    state->num_sigmask_records = 0;
+    state->sigmask_records_size = 0;
 
     destroy_events(&state->events);
     HEAP_TYPE_FREE(GLOBAL_DCONTEXT, state, ptrace_unmask_state_t, ACCT_THREAD_MGT,

--- a/core/unix/ptrace_attach.c
+++ b/core/unix/ptrace_attach.c
@@ -688,6 +688,7 @@ os_unmask_suspend_signal_via_ptrace(thread_id_t skip_tid)
     /* Initialise data structures to store original (pre-unmask) signal masks
      * for each thread.
      */
+    ASSERT(pre_unmask_sigmask_records == NULL);
     pre_unmask_sigmask_records = state->sigmask_records;
     num_pre_unmask_sigmask_records = state->num_sigmask_records;
     pre_unmask_sigmask_records_size = state->sigmask_records_size;

--- a/core/unix/ptrace_lib.c
+++ b/core/unix/ptrace_lib.c
@@ -202,8 +202,9 @@ ptrace_set_sigmask(thread_id_t tid, const kernel_sigset_t *mask)
     return dynamorio_syscall(SYS_ptrace, 4, PTRACE_SETSIGMASK, tid, (void *)sz, buf) == 0;
 }
 
+/* If original_mask is not NULL, return the mask from before sig was cleared. */
 bool
-ptrace_unmask_signal(thread_id_t tid, int sig)
+ptrace_unmask_signal(thread_id_t tid, int sig, kernel_sigset_t *original_mask)
 {
     kernel_sigset_t mask;
 
@@ -211,6 +212,8 @@ ptrace_unmask_signal(thread_id_t tid, int sig)
         return false;
     if (!ptrace_get_sigmask(tid, &mask))
         return false;
+    if (original_mask != NULL)
+        *original_mask = mask;
     if (kernel_sigismember(&mask, sig)) {
         kernel_sigdelset(&mask, sig);
         if (!ptrace_set_sigmask(tid, &mask))

--- a/core/unix/ptrace_lib.h
+++ b/core/unix/ptrace_lib.h
@@ -58,7 +58,8 @@ bool
 ptrace_set_sigmask(thread_id_t tid, const kernel_sigset_t *mask);
 
 bool
-ptrace_unmask_signal(thread_id_t tid, int sig);
+ptrace_unmask_signal(thread_id_t tid, int sig,
+                     DR_PARAM_OUT kernel_sigset_t *original_mask);
 
 #    if defined(AARCH64) && defined(DR_HOST_AARCH64)
 #        include <sys/uio.h>

--- a/core/unix/ptrace_private.h
+++ b/core/unix/ptrace_private.h
@@ -78,6 +78,9 @@ thread_in_sigtimedwait(thread_id_t tid, int suspend_sig, bool *is_in_set);
 bool
 os_ptrace_takeover_threads(dcontext_t *dcontext, thread_id_t *tids, uint count);
 
+bool
+ptrace_get_pre_unmask_sigmask(thread_id_t tid, kernel_sigset_t *sigmask);
+
 void
 ptrace_takeover_cleanup(void *param);
 

--- a/suite/tests/api/sigill_blocked.c
+++ b/suite/tests/api/sigill_blocked.c
@@ -36,8 +36,11 @@
  *  sigwait syscalls. Two threads are created:
  * - sig_thread: all signals are masked and blocked and thread waits in
  *               sigwaitinfo().
- * - busy_thread: no signals are masked and the thread just runs without being
- *                 blocked in any sigwait syscall.
+ * - busy_thread: uses a distinctive signal mask which does not include SIGILL
+ *                and runs without being blocked in any sigwait syscall.
+ *
+ * The test also checks the threads' original signal masks are restored after
+ * attach.
  */
 
 #include "configure.h"
@@ -53,21 +56,67 @@
 #    include <unistd.h>
 #endif
 
+/* Synchronisation variables. */
 static void *signals_blocked;
 static void *busy_started;
-static volatile bool busy_stop;
+static void *sigusr1_received;
+static void *dr_stopped;
+static void *busy_mask_checked;
+
+/* The main() thread writes to busy_check_mask while busy_thread() reads it. We
+ * cannot use a condition variable to synchronize because it would make the
+ * busy_thread() block instead of remaining busy, so use atomic release/store
+ * and acquire/load.
+ */
+static bool busy_check_mask;
 static pid_t busy_tid;
+
+/* Test threads' signal mask flags to indicate if they have been restored
+ * correctly after attach. Although busy_thread() uses the normal signal based
+ * attach (rather than ptrace assisted attach), we should still check that
+ * enabling -attach_unmask_suspend_signal does not corrupt its mask.
+ */
+static bool sig_mask_attached_equal;
+static bool sig_mask_detached_equal;
+static bool busy_mask_attached_equal;
+static bool busy_mask_detached_equal;
+
+static bool
+are_signal_masks_equal(const sigset_t *orig, const sigset_t *curr, int line)
+{
+    bool equal = true;
+
+    for (int sig = 1; sig <= SIGRTMAX; ++sig) {
+        int orig_member = sigismember(orig, sig);
+        int curr_member = sigismember(curr, sig);
+        assert(orig_member != -1);
+        assert(curr_member != -1);
+        if (orig_member != curr_member) {
+            print("signal mask mismatch at line %d for signal %d: original=%s, "
+                  "current=%s\n",
+                  line, sig, orig_member ? "blocked" : "unblocked",
+                  curr_member ? "blocked" : "unblocked");
+            equal = false;
+        }
+    }
+    return equal;
+}
 
 static THREAD_FUNC_RETURN_TYPE
 sig_thread(void *arg)
 {
     sigset_t set;
+    sigset_t original_mask;
+    sigset_t current_mask;
     siginfo_t info;
     int res;
 
     sigfillset(&set);
     res = pthread_sigmask(SIG_BLOCK, &set, NULL);
     assert(res == 0);
+    res = pthread_sigmask(SIG_SETMASK, NULL, &original_mask);
+    assert(res == 0);
+    assert(sigismember(&original_mask, SIGILL) == 1);
 
     print("sig_thread blocked signals\n");
     signal_cond_var(signals_blocked);
@@ -81,15 +130,42 @@ sig_thread(void *arg)
         assert(res != -1);
         if (res == SIGUSR1) {
             print("sig_thread received SIGUSR1\n");
+            res = pthread_sigmask(SIG_SETMASK, NULL, &current_mask);
+            assert(res == 0);
+            sig_mask_attached_equal =
+                are_signal_masks_equal(&original_mask, &current_mask, __LINE__);
+            signal_cond_var(sigusr1_received);
             break;
         }
     }
+
+    /* Wait until detach is complete, then verify that attach and detach
+     * preserved the thread's original signal mask.
+     */
+    wait_cond_var(dr_stopped);
+    res = pthread_sigmask(SIG_SETMASK, NULL, &current_mask);
+    assert(res == 0);
+    sig_mask_detached_equal =
+        are_signal_masks_equal(&original_mask, &current_mask, __LINE__);
     return NULL;
 }
 
 static THREAD_FUNC_RETURN_TYPE
 busy_thread(void *arg)
 {
+    sigset_t set;
+    sigset_t original_mask;
+    sigset_t current_mask;
+    int res;
+
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR2);
+    res = pthread_sigmask(SIG_SETMASK, &set, NULL);
+    assert(res == 0);
+    res = pthread_sigmask(SIG_SETMASK, NULL, &original_mask);
+    assert(res == 0);
+    assert(sigismember(&original_mask, SIGUSR2) == 1);
+    assert(sigismember(&original_mask, SIGILL) == 0);
 #ifdef LINUX
     busy_tid = (pid_t)syscall(SYS_gettid);
     print("busy_thread starting (tid=%d)\n", busy_tid);
@@ -97,9 +173,20 @@ busy_thread(void *arg)
     print("busy_thread starting\n");
 #endif
     signal_cond_var(busy_started);
-    while (!busy_stop) {
+    while (!__atomic_load_n(&busy_check_mask, __ATOMIC_ACQUIRE)) {
         thread_yield();
     }
+    res = pthread_sigmask(SIG_SETMASK, NULL, &current_mask);
+    assert(res == 0);
+    busy_mask_attached_equal =
+        are_signal_masks_equal(&original_mask, &current_mask, __LINE__);
+    signal_cond_var(busy_mask_checked);
+
+    wait_cond_var(dr_stopped);
+    res = pthread_sigmask(SIG_SETMASK, NULL, &current_mask);
+    assert(res == 0);
+    busy_mask_detached_equal =
+        are_signal_masks_equal(&original_mask, &current_mask, __LINE__);
     print("busy_thread exiting\n");
     return NULL;
 }
@@ -115,6 +202,9 @@ main(int argc, const char *argv[])
 {
     signals_blocked = create_cond_var();
     busy_started = create_cond_var();
+    busy_mask_checked = create_cond_var();
+    sigusr1_received = create_cond_var();
+    dr_stopped = create_cond_var();
 
     print("starting busy_thread\n");
     thread_t busy = create_thread(busy_thread, NULL);
@@ -133,20 +223,31 @@ main(int argc, const char *argv[])
     dr_app_setup_and_start();
     assert(dr_app_running_under_dynamorio());
 
-    print("stopping busy_thread\n");
-    busy_stop = true;
-    join_thread(busy);
+    print("checking busy_thread signal mask\n");
+    __atomic_store_n(&busy_check_mask, true, __ATOMIC_RELEASE);
+    wait_cond_var(busy_mask_checked);
 
     print("sending SIGUSR1 to sig_thread\n");
     pthread_kill(thread, SIGUSR1);
-    join_thread(thread);
+    wait_cond_var(sigusr1_received);
 
     print("pre-DR stop\n");
     dr_app_stop_and_cleanup();
     assert(!dr_app_running_under_dynamorio());
+    signal_cond_var(dr_stopped);
+    join_thread(busy);
+    join_thread(thread);
+
+    assert(busy_mask_attached_equal);
+    assert(busy_mask_detached_equal);
+    assert(sig_mask_attached_equal);
+    assert(sig_mask_detached_equal);
 
     destroy_cond_var(signals_blocked);
     destroy_cond_var(busy_started);
+    destroy_cond_var(busy_mask_checked);
+    destroy_cond_var(sigusr1_received);
+    destroy_cond_var(dr_stopped);
 
     print("all done\n");
     return 0;

--- a/suite/tests/api/sigill_blocked.templatex
+++ b/suite/tests/api/sigill_blocked.templatex
@@ -3,9 +3,9 @@ busy_thread starting \(tid=[0-9]+\)
 starting sig_thread
 sig_thread blocked signals
 pre-DR start
-stopping busy_thread
-busy_thread exiting
+checking busy_thread signal mask
 sending SIGUSR1 to sig_thread
 sig_thread received SIGUSR1
 pre-DR stop
+busy_thread exiting
 all done


### PR DESCRIPTION
PR7843 (4d6e9ac84) added ptrace assisted attach for applications which blocked SUSPEND_SIGNAL. The implementation cleared SUSPEND_SIGNAL from each thread's kernel signal mask but did not save and restore the original mask.

This patch saves the original mask for each modified thread using the saved mask to initialise signal state during os_thread_take_over().

The api.sigill_blocked unit test has been updated to check each test thread's original mask during attach and after detach. If the original mask is not saved, the test will issue an error message with the numbers of all the signals which didn't match, e.g.
signal mask mismatch at line 131 for signal 4: original=blocked, current=unblocked

AI was used for some aspects of this patch. Code provided by AI was reviewed and revised by the author.

Issue: #8091