### PR TITLE
i#8110: Clear last block in raw2trace on filter endpoint

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -4693,7 +4693,7 @@ test_filter_endpoint(void *drcontext)
     raw.push_back(make_tid());
     raw.push_back(make_pid());
     raw.push_back(make_line_size());
-    constexpr uint64_t TIME_VALUE = 0x0013000000000000;
+    constexpr uint64_t TIME_VALUE = IF_X64_ELSE(0x0013000000000000, 0x13000000);
     raw.push_back(make_timestamp(TIME_VALUE));
     raw.push_back(make_core());
     constexpr uint64_t LOAD_ADDR = 0x1200;

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -267,6 +267,17 @@ make_memref(uint64_t addr)
 }
 
 offline_entry_t
+make_meminfo(int type, int size)
+{
+    offline_entry_t entry;
+    entry.extended.type = OFFLINE_TYPE_EXTENDED;
+    entry.extended.ext = OFFLINE_EXT_TYPE_MEMINFO;
+    entry.extended.valueB = type;
+    entry.extended.valueA = size;
+    return entry;
+}
+
+offline_entry_t
 make_timestamp(uint64_t value = 0)
 {
     static int timecount;

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -4660,6 +4660,77 @@ test_skipped_memrefs(void *drcontext)
 #endif
 }
 
+bool
+test_filter_endpoint(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting a filter endpoint\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *load =
+        XINST_CREATE_load(drcontext, opnd_create_reg(REG1), OPND_CREATE_MEMPTR(REG1, 0));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, load);
+    size_t offs_nop = 0;
+    size_t offs_load = offs_nop + instr_length(drcontext, nop);
+
+    std::vector<offline_entry_t> raw;
+    // This is a filtered trace that transitions to unfiltered.
+    raw.push_back(make_header(OFFLINE_FILE_VERSION,
+                              OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP |
+                                  OFFLINE_FILE_TYPE_IFILTERED |
+                                  OFFLINE_FILE_TYPE_DFILTERED));
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    constexpr uint64_t TIME_VALUE = 0x0013000000000000;
+    raw.push_back(make_timestamp(TIME_VALUE));
+    raw.push_back(make_core());
+    constexpr uint64_t LOAD_ADDR = 0x1200;
+    raw.push_back(make_block(offs_load, 1));
+    raw.push_back(make_block(offs_load, 0));
+    raw.push_back(make_meminfo(TRACE_TYPE_READ, sizeof(void *)));
+    raw.push_back(make_memref(LOAD_ADDR));
+    // Filtering ends.
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_FILTER_ENDPOINT, 0));
+    // Now repeat the same PC to test i#8110.
+    raw.push_back(make_block(offs_load, 1));
+    raw.push_back(make_memref(LOAD_ADDR));
+    raw.push_back(make_timestamp(TIME_VALUE));
+    raw.push_back(make_core());
+    raw.push_back(make_exit());
+
+    std::vector<uint64_t> stats;
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries, &stats))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,
+                    TIME_VALUE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, 0, offs_load) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, sizeof(void *), LOAD_ADDR) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILTER_ENDPOINT) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_load) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, sizeof(void *), LOAD_ADDR) &&
+        // Tail of trace.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,
+                    TIME_VALUE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -4686,7 +4757,8 @@ test_main(int argc, const char *argv[])
         !test_is_maybe_blocking_syscall(drcontext) || !test_ifiltered(drcontext) ||
         !test_asynchronous_signal(drcontext) || !test_syscall_injection(drcontext) ||
         !test_negative_timestamps(drcontext) || !test_top_byte_ignore(drcontext) ||
-        !test_missing_memref(drcontext) || !test_skipped_memrefs(drcontext))
+        !test_missing_memref(drcontext) || !test_skipped_memrefs(drcontext) ||
+        !test_filter_endpoint(drcontext))
         return 1;
     return 0;
 }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1072,10 +1072,8 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
                                 &flush_decode_cache)) {
                 return false;
             }
-            if (flush_decode_cache) {
-                decode_cache_[tdata->worker].clear();
-                clear_last_block_info(tdata);
-            }
+            if (flush_decode_cache)
+                clear_decode_and_last_block_info(tdata);
             if ((uint)(buf - buf_base) >= WRITE_BUFFER_SIZE) {
                 tdata->error = "Too many entries";
                 return false;
@@ -1127,10 +1125,8 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
         bool flush_decode_cache = false;
         bool success = process_offline_entry(tdata, &entry, tdata->tid, end_of_record,
                                              &last_bb_handled, &flush_decode_cache);
-        if (flush_decode_cache) {
-            decode_cache_[tdata->worker].clear();
-            clear_last_block_info(tdata);
-        }
+        if (flush_decode_cache)
+            clear_decode_and_last_block_info(tdata);
         if (!success)
             return false;
     }
@@ -1157,10 +1153,8 @@ raw2trace_t::process_thread_file(raw2trace_thread_data_t *tdata)
                 bool success =
                     process_offline_entry(tdata, &entry, tdata->tid, &end_of_file,
                                           &last_bb_handled, &flush_decode_cache);
-                if (flush_decode_cache) {
-                    decode_cache_[tdata->worker].clear();
-                    clear_last_block_info(tdata);
-                }
+                if (flush_decode_cache)
+                    clear_decode_and_last_block_info(tdata);
                 if (!end_of_file) {
                     tdata->error = "Synthetic footer failed";
                     return false;
@@ -3858,9 +3852,10 @@ raw2trace_t::set_file_type(raw2trace_thread_data_t *tdata, offline_file_type_t f
 }
 
 void
-raw2trace_t::clear_last_block_info(raw2trace_thread_data_t *tdata)
+raw2trace_t::clear_decode_and_last_block_info(raw2trace_thread_data_t *tdata)
 {
-    tdata->last_decode_block_start = 0;
+    decode_cache_[tdata->worker].clear();
+    tdata->last_decode_block_start = nullptr;
     tdata->last_decode_modidx = 0;
     tdata->last_decode_modoffs = 0;
     tdata->last_block_summary = nullptr;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1072,8 +1072,10 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
                                 &flush_decode_cache)) {
                 return false;
             }
-            if (flush_decode_cache)
+            if (flush_decode_cache) {
                 decode_cache_[tdata->worker].clear();
+                clear_last_block_info(tdata);
+            }
             if ((uint)(buf - buf_base) >= WRITE_BUFFER_SIZE) {
                 tdata->error = "Too many entries";
                 return false;
@@ -1125,8 +1127,10 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
         bool flush_decode_cache = false;
         bool success = process_offline_entry(tdata, &entry, tdata->tid, end_of_record,
                                              &last_bb_handled, &flush_decode_cache);
-        if (flush_decode_cache)
+        if (flush_decode_cache) {
             decode_cache_[tdata->worker].clear();
+            clear_last_block_info(tdata);
+        }
         if (!success)
             return false;
     }
@@ -1153,8 +1157,10 @@ raw2trace_t::process_thread_file(raw2trace_thread_data_t *tdata)
                 bool success =
                     process_offline_entry(tdata, &entry, tdata->tid, &end_of_file,
                                           &last_bb_handled, &flush_decode_cache);
-                if (flush_decode_cache)
+                if (flush_decode_cache) {
                     decode_cache_[tdata->worker].clear();
+                    clear_last_block_info(tdata);
+                }
                 if (!end_of_file) {
                     tdata->error = "Synthetic footer failed";
                     return false;
@@ -3813,6 +3819,15 @@ raw2trace_t::set_file_type(raw2trace_thread_data_t *tdata, offline_file_type_t f
     tdata->file_type = file_type;
     tdata->instru_offline.set_disable_optimizations(
         TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS, file_type));
+}
+
+void
+raw2trace_t::clear_last_block_info(raw2trace_thread_data_t *tdata)
+{
+    tdata->last_decode_block_start = 0;
+    tdata->last_decode_modidx = 0;
+    tdata->last_decode_modoffs = 0;
+    tdata->last_block_summary = nullptr;
 }
 
 raw2trace_t::raw2trace_t(

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1020,6 +1020,9 @@ protected:
     virtual bool
     is_maybe_blocking_syscall(uintptr_t number);
 
+    void
+    clear_last_block_info(raw2trace_thread_data_t *tdata);
+
     const module_mapper_t *modmap_ptr_ = nullptr;
 
     uint64 count_elided_ = 0;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1032,7 +1032,7 @@ protected:
     is_maybe_blocking_syscall(uintptr_t number);
 
     void
-    clear_last_block_info(raw2trace_thread_data_t *tdata);
+    clear_decode_and_last_block_info(raw2trace_thread_data_t *tdata);
 
     const module_mapper_t *modmap_ptr_ = nullptr;
 


### PR DESCRIPTION
When the decode cache is cleared on a filter endpoint, raw2trace needs to also clear its last block fields.

Adds a unit test that fails without this fix.

Fixes #8110