### PR TITLE
i#4914 repstr bounds: Add backward loop to allasm-repstr

### DIFF
--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -1,3 +1,4 @@
+Wally world!
 Adios world!
 Adios world!
 Adios world!
@@ -11,16 +12,16 @@ Adios world!
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-         110 total \(fetched\) instructions
-          38 total unique \(fetched\) instructions
-           4 total non-fetched instructions
+         122 total \(fetched\) instructions
+          50 total unique \(fetched\) instructions
+           8 total non-fetched instructions
            0 total prefetches
-           7 total data loads
-           5 total data stores
+          12 total data loads
+          10 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
-          56 total timestamp \+ cpuid markers
+          60 total timestamp \+ cpuid markers
            0 total idle markers
            0 total wait markers
            0 total kernel transfer markers
@@ -30,32 +31,11 @@ Total counts:
            0 total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-          14 total system call number markers
+          15 total system call number markers
            0 total blocking system call markers
            0 total skipped memref markers
            4 total other markers
-         114 total encodings
+         130 total encodings
 Thread [0-9]* counts:
-         110 \(fetched\) instructions
-          38 unique \(fetched\) instructions
-           4 non-fetched instructions
-           0 prefetches
-           7 data loads
-           5 data stores
-           0 icache flushes
-           0 dcache flushes
-          56 timestamp \+ cpuid markers
-           0 idle markers
-           0 wait markers
-           0 kernel transfer markers
-           0 function id markers
-           0 function return address markers
-           0 function argument markers
-           0 function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-          14 system call number markers
-           0 blocking system call markers
-           0 skipped memref markers
-           4 other markers
-         114 encodings
+         122 \(fetched\) instructions
+.*

--- a/clients/drcachesim/tests/allasm_repstr.asm
+++ b/clients/drcachesim/tests/allasm_repstr.asm
@@ -52,8 +52,9 @@ _start:
         add      esi, 4
         lea      edi, hello_str
         add      edi, 4
-        std
+        std // Setting DF makes rep go backward.
         rep      movsb
+        // Print the backward-copied string to ensure we did it right.
         mov      rdi, 2           // stderr
         lea      rsi, hello_str
         mov      rdx, 13          // sizeof(hello_str)

--- a/clients/drcachesim/tests/allasm_repstr.asm
+++ b/clients/drcachesim/tests/allasm_repstr.asm
@@ -1,5 +1,5 @@
  /* **********************************************************
- * Copyright (c) 2021-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -45,6 +45,20 @@ _start:
         lea      edi, hello_str
         cld
         rep      movsd
+
+        // Test a backward rep string loop.
+        mov      ecx, 5
+        lea      esi, wally_str
+        add      esi, 4
+        lea      edi, hello_str
+        add      edi, 4
+        std
+        rep      movsb
+        mov      rdi, 2           // stderr
+        lea      rsi, hello_str
+        mov      rdx, 13          // sizeof(hello_str)
+        mov      eax, 1           // SYS_write
+        syscall
 
         // Test a rep string loop.
         mov      ecx, 5
@@ -101,6 +115,8 @@ hello_str:
         .string  "Hello world!\n"
 bye_str:
         .string  "Adios\n"
+wally_str:
+        .string  "Wally\n"
         // Push .data onto a 2nd page to test page-spanning accesses.
         // We assume 4K pages here.
         .align   4096

--- a/clients/drcachesim/tests/offline-allasm-dyn-inject-invariants.templatex
+++ b/clients/drcachesim/tests/offline-allasm-dyn-inject-invariants.templatex
@@ -1,3 +1,4 @@
+Wally world!
 Adios world!
 Adios world!
 Adios world!

--- a/clients/drcachesim/tests/offline-allasm-dyn-inject-view.templatex
+++ b/clients/drcachesim/tests/offline-allasm-dyn-inject-view.templatex
@@ -1,3 +1,4 @@
+Wally world!
 Adios world!
 Adios world!
 Adios world!
@@ -9,59 +10,76 @@ Adios world!
 Adios world!
 Adios world!
 .*
-          34          13: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
-          35          13: .* <marker: timestamp .*>
-          36          13: .* <marker: .* on core .*>
-          37          13: .* <marker: system call 39>
-          37          13: .* <marker: trace start for system call number 39>
-          37          13: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
-          37          13: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
-          37          13: .* <marker: trace end for system call number 39>
-          38          13: .* <marker: timestamp .*>
+          39          18: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+          40          18: .* <marker: timestamp .*>
+          41          18: .* <marker: .* on core .*>
+          42          18: .* <marker: system call 1>
+          43          18: .* <marker: maybe-blocking system call>
+          44          18: .* <marker: function==syscall #1>
+          45          18: .* <marker: function argument 0x2>
+          46          18: .* <marker: function argument 0x.*>
+          47          18: .* <marker: function argument 0xd>
+          47          18: .* <marker: trace start for system call number 1>
+          47          18: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
+          47          18: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
+          47          18: .* <marker: trace end for system call number 1>
+          48          18: .* <marker: function==syscall #1>
+          49          18: .* <marker: function return value 0xd>
+          50          18: .* <marker: timestamp .*>
 .*
-          44          18: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
-          45          18: .* <marker: timestamp .*>
-          46          18: .* <marker: .* on core .*>
-          47          18: .* <marker: system call 324>
-          48          18: .* <marker: maybe-blocking system call>
-          48          18: .* <marker: trace start for system call number 324>
-          48          18: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
-          48          18: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
-          48          18: .* <marker: trace end for system call number 324>
-          49          18: .* <marker: timestamp .*>
+          72          25: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+          73          25: .* <marker: timestamp .*>
+          74          25: .* <marker: .* on core .*>
+          75          25: .* <marker: system call 39>
+          75          25: .* <marker: trace start for system call number 39>
+          75          25: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
+          75          25: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
+          75          25: .* <marker: trace end for system call number 39>
+          76          25: .* <marker: timestamp .*>
 .*
-          61          27: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
-          62          27: .* <marker: timestamp .*>
-          63          27: .* <marker: .* on core .*>
-          64          27: .* <marker: system call 1>
-          65          27: .* <marker: maybe-blocking system call>
-          66          27: .* <marker: function==syscall #1>
-          67          27: .* <marker: function argument 0x2>
-          68          27: .* <marker: function argument 0x.*>
-          69          27: .* <marker: function argument 0xd>
-          69          27: .* <marker: trace start for system call number 1>
-          69          27: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
-          69          27: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
-          69          27: .* <marker: trace end for system call number 1>
-          70          27: .* <marker: function==syscall #1>
-          71          27: .* <marker: function return value 0xd>
-          72          27: .* <marker: timestamp .*>
+          82          30: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+          83          30: .* <marker: timestamp .*>
+          84          30: .* <marker: .* on core .*>
+          85          30: .* <marker: system call 324>
+          86          30: .* <marker: maybe-blocking system call>
+          86          30: .* <marker: trace start for system call number 324>
+          86          30: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
+          86          30: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
+          86          30: .* <marker: trace end for system call number 324>
+          87          30: .* <marker: timestamp .*>
 .*
-         261         107: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
-         262         107: .* <marker: timestamp .*>
-         263         107: .* <marker: .* on core .*>
-         264         107: .* <marker: system call 1>
-         265         107: .* <marker: maybe-blocking system call>
-         266         107: .* <marker: function==syscall #1>
-         267         107: .* <marker: function argument 0x2a>
-         268         107: .* <marker: function argument 0x.*>
-         269         107: .* <marker: function argument 0xd>
-         269         107: .* <marker: trace start for system call number 1>
-         269         107: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
-         269         107: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
-         269         107: .* <marker: trace end for system call number 1>
-         270         107: .* <marker: function==syscall #1>
-         271         107: .* <marker: function return value 0xfffffffffffffff7>
-         272         107: .* <marker: system call failed: 9>
-         273         107: .* <marker: timestamp .*>
+          99          39: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+         100          39: .* <marker: timestamp .*>
+         101          39: .* <marker: .* on core .*>
+         102          39: .* <marker: system call 1>
+         103          39: .* <marker: maybe-blocking system call>
+         104          39: .* <marker: function==syscall #1>
+         105          39: .* <marker: function argument 0x2>
+         106          39: .* <marker: function argument 0x.*>
+         107          39: .* <marker: function argument 0xd>
+         107          39: .* <marker: trace start for system call number 1>
+         107          39: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
+         107          39: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
+         107          39: .* <marker: trace end for system call number 1>
+         108          39: .* <marker: function==syscall #1>
+         109          39: .* <marker: function return value 0xd>
+         110          39: .* <marker: timestamp .*>
+.*
+         299         119: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+         300         119: .* <marker: timestamp .*>
+         301         119: .* <marker: .* on core .*>
+         302         119: .* <marker: system call 1>
+         303         119: .* <marker: maybe-blocking system call>
+         304         119: .* <marker: function==syscall #1>
+         305         119: .* <marker: function argument 0x2a>
+         306         119: .* <marker: function argument 0x.*>
+         307         119: .* <marker: function argument 0xd>
+         307         119: .* <marker: trace start for system call number 1>
+         307         119: .* ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
+         307         119: .* ifetch       2 byte\(s\) @ 0x00000000deadbe01 0f 07                sysret \(target .*\)
+         307         119: .* <marker: trace end for system call number 1>
+         308         119: .* <marker: function==syscall #1>
+         309         119: .* <marker: function return value 0xfffffffffffffff7>
+         310         119: .* <marker: system call failed: 9>
+         311         119: .* <marker: timestamp .*>
 .*

--- a/clients/drcachesim/tests/offline-allasm-record-syscall.templatex
+++ b/clients/drcachesim/tests/offline-allasm-record-syscall.templatex
@@ -1,3 +1,4 @@
+Wally world!
 Adios world!
 Adios world!
 Adios world!
@@ -9,43 +10,49 @@ Adios world!
 Adios world!
 Adios world!
 .*
-          34          13: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
-          35          13: .* <marker: timestamp .*>
-          36          13: .* <marker: .* on core .*>
-          37          13: .* <marker: system call 39>
-          38          13: .* <marker: timestamp .*>
+          39          18: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+          40          18: .* <marker: timestamp .*>
+          41          18: .* <marker: .* on core .*>
+          42          18: .* <marker: system call 1>
+          43          18: .* <marker: maybe-blocking system call>
+          44          18: .* <marker: function==syscall #1>
+          45          18: .* <marker: function argument 0x2>
+          46          18: .* <marker: function argument 0x.*>
+          47          18: .* <marker: function argument 0xd>
+          48          18: .* <marker: function==syscall #1>
+          49          18: .* <marker: function return value 0xd>
+          50          18: .* <marker: timestamp .*>
 .*
-          44          18: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
-          45          18: .* <marker: timestamp .*>
-          46          18: .* <marker: .* on core .*>
-          47          18: .* <marker: system call 324>
-          48          18: .* <marker: maybe-blocking system call>
-          49          18: .* <marker: timestamp .*>
+          72          25: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+          73          25: .* <marker: timestamp .*>
+          74          25: .* <marker: .* on core .*>
+          75          25: .* <marker: system call 39>
+          76          25: .* <marker: timestamp .*>
 .*
-          61          27: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
-          62          27: .* <marker: timestamp .*>
-          63          27: .* <marker: .* on core .*>
-          64          27: .* <marker: system call 1>
-          65          27: .* <marker: maybe-blocking system call>
-          66          27: .* <marker: function==syscall #1>
-          67          27: .* <marker: function argument 0x2>
-          68          27: .* <marker: function argument 0x.*>
-          69          27: .* <marker: function argument 0xd>
-          70          27: .* <marker: function==syscall #1>
-          71          27: .* <marker: function return value 0xd>
-          72          27: .* <marker: timestamp .*>
+          99          39: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+         100          39: .* <marker: timestamp .*>
+         101          39: .* <marker: .* on core .*>
+         102          39: .* <marker: system call 1>
+         103          39: .* <marker: maybe-blocking system call>
+         104          39: .* <marker: function==syscall #1>
+         105          39: .* <marker: function argument 0x2>
+         106          39: .* <marker: function argument 0x.*>
+         107          39: .* <marker: function argument 0xd>
+         108          39: .* <marker: function==syscall #1>
+         109          39: .* <marker: function return value 0xd>
+         110          39: .* <marker: timestamp .*>
 .*
-         261         107: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
-         262         107: .* <marker: timestamp .*>
-         263         107: .* <marker: .* on core .*>
-         264         107: .* <marker: system call 1>
-         265         107: .* <marker: maybe-blocking system call>
-         266         107: .* <marker: function==syscall #1>
-         267         107: .* <marker: function argument 0x2a>
-         268         107: .* <marker: function argument 0x.*>
-         269         107: .* <marker: function argument 0xd>
-         270         107: .* <marker: function==syscall #1>
-         271         107: .* <marker: function return value 0xfffffffffffffff7>
-         272         107: .* <marker: system call failed: 9>
-         273         107: .* <marker: timestamp .*>
+         299         119: .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+         300         119: .* <marker: timestamp .*>
+         301         119: .* <marker: .* on core .*>
+         302         119: .* <marker: system call 1>
+         303         119: .* <marker: maybe-blocking system call>
+         304         119: .* <marker: function==syscall #1>
+         305         119: .* <marker: function argument 0x2a>
+         306         119: .* <marker: function argument 0x.*>
+         307         119: .* <marker: function argument 0xd>
+         308         119: .* <marker: function==syscall #1>
+         309         119: .* <marker: function return value 0xfffffffffffffff7>
+         310         119: .* <marker: system call failed: 9>
+         311         119: .* <marker: timestamp .*>
 .*

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -1,3 +1,4 @@
+Wally world!
 Adios world!
 Adios world!
 Adios world!
@@ -10,16 +11,16 @@ Adios world!
 Adios world!
 Basic counts tool results:
 Total counts:
-         110 total \(fetched\) instructions
-          38 total unique \(fetched\) instructions
-           4 total non-fetched instructions
+         122 total \(fetched\) instructions
+          50 total unique \(fetched\) instructions
+           8 total non-fetched instructions
            0 total prefetches
-           7 total data loads
-           5 total data stores
+          12 total data loads
+          10 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
-          56 total timestamp \+ cpuid markers
+          60 total timestamp \+ cpuid markers
            0 total idle markers
            0 total wait markers
            0 total kernel transfer markers
@@ -29,32 +30,11 @@ Total counts:
            0 total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-          14 total system call number markers
-          12 total blocking system call markers
+          15 total system call number markers
+          13 total blocking system call markers
            0 total skipped memref markers
            5 total other markers
-          38 total encodings
+          50 total encodings
 Thread [0-9]* counts:
-         110 \(fetched\) instructions
-          38 unique \(fetched\) instructions
-           4 non-fetched instructions
-           0 prefetches
-           7 data loads
-           5 data stores
-           0 icache flushes
-           0 dcache flushes
-          56 timestamp \+ cpuid markers
-           0 idle markers
-           0 wait markers
-           0 kernel transfer markers
-           0 function id markers
-           0 function return address markers
-           0 function argument markers
-           0 function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-          14 system call number markers
-          12 blocking system call markers
-           0 skipped memref markers
-           5 other markers
-          38 encodings
+         122 \(fetched\) instructions
+.*

--- a/clients/drcachesim/tests/offline-phys.templatex
+++ b/clients/drcachesim/tests/offline-phys.templatex
@@ -1,3 +1,4 @@
+Wally world!
 Adios world!
 Adios world!
 Adios world!

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -1,10 +1,9 @@
 Hit delay threshold: enabling tracing.
 Hit tracing window #0 limit: disabling tracing.
+Wally world!
 Hit retrace threshold: enabling tracing for window #1.
 Hit tracing window #1 limit: disabling tracing.
-Adios world!
 Hit retrace threshold: enabling tracing for window #2.
-Adios world!
 Hit tracing window #2 limit: disabling tracing.
 Adios world!
 Hit retrace threshold: enabling tracing for window #3.
@@ -22,18 +21,22 @@ Adios world!
 Hit retrace threshold: enabling tracing for window #6.
 Adios world!
 Hit tracing window #6 limit: disabling tracing.
+Adios world!
+Hit retrace threshold: enabling tracing for window #7.
+Adios world!
+Hit tracing window #7 limit: disabling tracing.
 Basic counts tool results:
 Total counts:
-          57 total \(fetched\) instructions
-          25 total unique \(fetched\) instructions
-           4 total non-fetched instructions
+          65 total \(fetched\) instructions
+          33 total unique \(fetched\) instructions
+           8 total non-fetched instructions
            0 total prefetches
-           7 total data loads
-           5 total data stores
+          12 total data loads
+          10 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
-          42 total timestamp \+ cpuid markers
+          46 total timestamp \+ cpuid markers
            0 total idle markers
            0 total wait markers
            0 total kernel transfer markers
@@ -43,15 +46,15 @@ Total counts:
            0 total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-           7 total system call number markers
-           6 total blocking system call markers
+           8 total system call number markers
+           7 total blocking system call markers
            0 total skipped memref markers
-          13 total other markers
-          25 total encodings
-Total windows: 8
+          14 total other markers
+          33 total encodings
+Total windows: 9
 Window #0:
-           8 window \(fetched\) instructions
-           8 window unique \(fetched\) instructions
+          13 window \(fetched\) instructions
+          13 window unique \(fetched\) instructions
            4 window non-fetched instructions
            0 window prefetches
            5 window data loads
@@ -69,11 +72,35 @@ Window #0:
            0 window physical address \+ virtual address marker pairs
            0 window physical address unavailable markers
            1 window system call number markers
-           0 window blocking system call markers
+           1 window blocking system call markers
            0 window skipped memref markers
            6 window other markers
-           8 window encodings
+          13 window encodings
 Window #1:
+           3 window \(fetched\) instructions
+           3 window unique \(fetched\) instructions
+           4 window non-fetched instructions
+           0 window prefetches
+           5 window data loads
+           5 window data stores
+           0 window icache flushes
+           0 window dcache flushes
+           4 window timestamp \+ cpuid markers
+           0 window idle markers
+           0 window wait markers
+           0 window kernel transfer markers
+           0 window function id markers
+           0 window function return address markers
+           0 window function argument markers
+           0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
+           1 window system call number markers
+           0 window blocking system call markers
+           0 window skipped memref markers
+           1 window other markers
+           3 window encodings
+Window #2:
            9 window \(fetched\) instructions
            9 window unique \(fetched\) instructions
            0 window non-fetched instructions
@@ -97,30 +124,6 @@ Window #1:
            0 window skipped memref markers
            1 window other markers
            9 window encodings
-Window #2:
-           8 window \(fetched\) instructions
-           8 window unique \(fetched\) instructions
-           0 window non-fetched instructions
-           0 window prefetches
-           0 window data loads
-           0 window data stores
-           0 window icache flushes
-           0 window dcache flushes
-           6 window timestamp \+ cpuid markers
-           0 window idle markers
-           0 window wait markers
-           0 window kernel transfer markers
-           0 window function id markers
-           0 window function return address markers
-           0 window function argument markers
-           0 window function return value markers
-           0 window physical address \+ virtual address marker pairs
-           0 window physical address unavailable markers
-           1 window system call number markers
-           1 window blocking system call markers
-           0 window skipped memref markers
-           1 window other markers
-           3 window encodings
 Window #3:
            8 window \(fetched\) instructions
            8 window unique \(fetched\) instructions
@@ -144,7 +147,7 @@ Window #3:
            1 window blocking system call markers
            0 window skipped memref markers
            1 window other markers
-           0 window encodings
+           3 window encodings
 Window #4:
            8 window \(fetched\) instructions
            8 window unique \(fetched\) instructions
@@ -216,8 +219,32 @@ Window #6:
            1 window blocking system call markers
            0 window skipped memref markers
            1 window other markers
-           5 window encodings
+           0 window encodings
 Window #7:
+           8 window \(fetched\) instructions
+           8 window unique \(fetched\) instructions
+           0 window non-fetched instructions
+           0 window prefetches
+           0 window data loads
+           0 window data stores
+           0 window icache flushes
+           0 window dcache flushes
+           6 window timestamp \+ cpuid markers
+           0 window idle markers
+           0 window wait markers
+           0 window kernel transfer markers
+           0 window function id markers
+           0 window function return address markers
+           0 window function argument markers
+           0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
+           1 window system call number markers
+           1 window blocking system call markers
+           0 window skipped memref markers
+           1 window other markers
+           5 window encodings
+Window #8:
            0 window \(fetched\) instructions
            0 window unique \(fetched\) instructions
            0 window non-fetched instructions
@@ -242,8 +269,8 @@ Window #7:
            1 window other markers
            0 window encodings
 Thread [0-9]* counts:
-           8 \(fetched\) instructions
-           8 unique \(fetched\) instructions
+          13 \(fetched\) instructions
+          13 unique \(fetched\) instructions
            4 non-fetched instructions
            0 prefetches
            5 data loads
@@ -261,7 +288,7 @@ Thread [0-9]* counts:
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
            1 system call number markers
-           0 blocking system call markers
+           1 blocking system call markers
            0 skipped memref markers
            6 other markers
-           8 encodings
+          13 encodings

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4664,6 +4664,9 @@ if (BUILD_CLIENTS)
       "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
       "@-tool@invariant_checker" "")
     if (X86 AND X64 AND UNIX)
+      # XXX i#4914: It is a pain to updating other tests using allasm_repstr when we
+      # add repstr coverage for testing new repstr features. Maybe this window test
+      # should have its own app.
       torunonly_drcacheoff(windows-asm allasm_repstr
         "-no_split_windows -trace_after_instrs 3 -trace_for_instrs 4 -retrace_every_instrs 4"
         "@-tool@basic_counts" "")

--- a/suite/tests/samples/memtrace_simple_repstr.templatex
+++ b/suite/tests/samples/memtrace_simple_repstr.templatex
@@ -16,6 +16,22 @@ Format: <data address>: <data size>, <\(r\)ead/\(w\)rite/opcode>
 0x[0-9a-f]*:  2, rep movs
 0x[0-9a-f]*:  1, r
 0x[0-9a-f]*:  1, w
+Wally world!
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
 0x[0-9a-f]*:  3, mov
 0x[0-9a-f]*:  4, r
 0x[0-9a-f]*:  3, mov


### PR DESCRIPTION
Adds a backward loop to allasm-repstr.asm to help test that case. Split from the rest of #4914 to keep review sizes down.

Issue: #4914